### PR TITLE
Hotfix/inscription phptour

### DIFF
--- a/htdocs/pages/phptourlyon2014/inscription.php
+++ b/htdocs/pages/phptourlyon2014/inscription.php
@@ -103,22 +103,22 @@ $formulaire->addElement('select'  , 'id_pays_facturation'    , 'Pays'           
 $formulaire->addElement('text'    , 'email_facturation'      , 'Email (facture)', array('size' => 30, 'maxlength' => 100));
 $formulaire->addElement('text'    , 'coupon'                 , 'Coupon'         , array('size' => 30, 'maxlength' => 200));
 
-$formulaire->addElement('header', null, 'Divers');
-$formulaire->addElement('static', null, null, "J'accepte que ma compagnie soit citée comme participant à la conférence");
-$groupe = array();
-$groupe[] = &HTML_QuickForm::createElement('radio', 'citer_societe', null, 'oui', 1);
-$groupe[] = &HTML_QuickForm::createElement('radio', 'citer_societe', null, 'non', 0);
-$formulaire->addGroup($groupe, 'groupe_citer_societe', null, '&nbsp;', false);
-$formulaire->addElement('static', null, null, "Je souhaite être tenu au courant des rencontres de l'AFUP sur des sujets afférents à PHP");
-$groupe = array();
-$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_afup', null, 'oui', 1);
-$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_afup', null, 'non', 0);
-$formulaire->addGroup($groupe, 'groupe_newsletter_afup', null, '&nbsp;', false);
-$formulaire->addElement('static', null, null, "Je souhaite être tenu au courant de l'actualité PHP via la newsletter de notre sponsor");
-$groupe = array();
-$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_nexen', null, 'oui', 1);
-$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_nexen', null, 'non', 0);
-$formulaire->addGroup($groupe, 'groupe_newsletter_nexen', null, '&nbsp;', false);
+//$formulaire->addElement('header', null, 'Divers');
+//$formulaire->addElement('static', null, null, "J'accepte que ma compagnie soit citée comme participant à la conférence");
+//$groupe = array();
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'citer_societe', null, 'oui', 1);
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'citer_societe', null, 'non', 0);
+//$formulaire->addGroup($groupe, 'groupe_citer_societe', null, '&nbsp;', false);
+//$formulaire->addElement('static', null, null, "Je souhaite être tenu au courant des rencontres de l'AFUP sur des sujets afférents à PHP");
+//$groupe = array();
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_afup', null, 'oui', 1);
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_afup', null, 'non', 0);
+//$formulaire->addGroup($groupe, 'groupe_newsletter_afup', null, '&nbsp;', false);
+//$formulaire->addElement('static', null, null, "Je souhaite être tenu au courant de l'actualité PHP via la newsletter de notre sponsor");
+//$groupe = array();
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_nexen', null, 'oui', 1);
+//$groupe[] = &HTML_QuickForm::createElement('radio', 'newsletter_nexen', null, 'non', 0);
+//$formulaire->addGroup($groupe, 'groupe_newsletter_nexen', null, '&nbsp;', false);
 
 $formulaire->addElement('header', 'boutons'  , '');
 $formulaire->addElement('submit', 'soumettre', 'Soumettre');

--- a/htdocs/templates/forumphp2014/inscription_paiement.html
+++ b/htdocs/templates/forumphp2014/inscription_paiement.html
@@ -14,8 +14,8 @@
     	et de remplir le formulaire suivant : <a href="{$chemin_template}pdf/inscription-forum.pdf" class="btn">Inscription Forum PHP 2014</a>
     </p>
     <p>
-  		Une fois votre incription remplie, veuillez l'envoyer sous pli affranchi
-  		accompagn&eacute; de votre ch&egrave;que et d'un justificatif pour les
+  		Une fois votre inscription remplie, veuillez l'envoyer sous pli affranchi
+  		accompagn&eacute;e de votre ch&egrave;que et d'un justificatif pour les
   		étudiants et demandeurs d'emploi, &agrave; l'adresse :
     </p>
   	<p>

--- a/htdocs/templates/forumphp2014/mailing.html
+++ b/htdocs/templates/forumphp2014/mailing.html
@@ -7,7 +7,7 @@
   {/if}
     <form id="form_unsuscribe" name="form_unsuscribe" method="get" action="mailing.php">
     <fieldset>
-    <legend>&nbsp;Désincription &nbsp;</legend>
+    <legend>&nbsp;Désinscription &nbsp;</legend>
     Adresse email : <input type="text" name="unsuscribe" value="{$email}" />
     <input type="submit" name="envoyer" value="envoyer" />
     <input type="hidden" name="action" value="unsuscribe" />

--- a/htdocs/templates/phptourlyon2014/inscription.html
+++ b/htdocs/templates/phptourlyon2014/inscription.html
@@ -18,11 +18,7 @@
 	<p>
        <a name="renvoi">[1]</a> Un justificatif vous sera demandé le jour du forum.
 	</p>
-	<p>
-        Si vous souhaitez &ecirc;tre pr&eacute;venu quand la cl&ocirc;ture des inscriptions sera proche,
-        merci de laisser votre email.
-    </p>
-	{include file="rappel.html"}
+
     <div id="divPersonne" style="display:none;">
         <p>Je souhaite inscrire
         <select id="nbPersonnes">

--- a/htdocs/templates/phptourlyon2014/inscription_paiement.html
+++ b/htdocs/templates/phptourlyon2014/inscription_paiement.html
@@ -12,7 +12,7 @@
     </p>
 	<h3><a href="{$chemin_template}pdf/inscription-forum.pdf">Inscription PHP Tour Lyon 2014</a></h3>
 	<p>
-		Une fois votre incription remplie, veuillez l'envoyer sous pli affranchi accompagn&eacute;
+		Une fois votre inscription remplie, veuillez l'envoyer sous pli affranchi accompagn&eacute;e
 		de votre ch&egrave;que et d'un justificatif pour les étudiants et demandeurs d'emploi, &agrave; l'adresse :</p>
         <address>
             AFUP<br />

--- a/htdocs/templates/phptourlyon2014/mailing.html
+++ b/htdocs/templates/phptourlyon2014/mailing.html
@@ -7,7 +7,7 @@
   {/if}
     <form id="form_unsuscribe" name="form_unsuscribe" method="get" action="mailing.php">
     <fieldset>
-    <legend>&nbsp;Désincription &nbsp;</legend>
+    <legend>&nbsp;Désinscription &nbsp;</legend>
     Adresse email : <input type="text" name="unsuscribe" value="{$email}" />
     <input type="submit" name="envoyer" value="envoyer" />
     <input type="hidden" name="action" value="unsuscribe" />


### PR DESCRIPTION
suppression de 
![php_tour_lyon_2014_organis_par_l_afup_avec_les_meilleurs_experts_php_franais_et_internationaux](https://cloud.githubusercontent.com/assets/1131098/3152478/03be5f2a-ea8f-11e3-91a2-89a8658b2359.jpg)


ping @mikaelkael 
