### PR TITLE
Site: redir pages/forumphp/ vers forumphp.org

### DIFF
--- a/htdocs/pages/forumphp/index.php
+++ b/htdocs/pages/forumphp/index.php
@@ -1,3 +1,3 @@
 <?php
-header('Location: http://afup.org/pages/forumphp2012/', true, 302);
+header('Location: http://www.forumphp.org/', true, 302);
 exit;


### PR DESCRIPTION
Ajoute la redirection de http://www.afup.org/pages/forumphp/ vers http://www.forumphp.org/
On ne redirige pas directement vers /pages/forumphp2014/ pour éviter d'avoir le même oubli l'année prochaine (comme on l'a eu l'année passée).
