### PR TITLE
Modification des urls cibles des signaux sociaux

### DIFF
--- a/htdocs/templates/phptourluxembourg2015/buzz.html
+++ b/htdocs/templates/phptourluxembourg2015/buzz.html
@@ -15,14 +15,14 @@
 
     <p>Suivez l'afup sur twitter <a href="http://twitter.com/#!/@afup">@afup</a> et twittez votre venue au PHP Tour Luxembourg 2015 :</p>
     <div class="block-leftbar">
-        <a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="afup" data-lang="fr">Tweet</a>
+        <a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="afup" data-lang="fr" data-url="http://afup.org/pages/phptourluxembourg2015/">Tweet</a>
         <script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
     </div>
 
     <h2>Sur Facebook</h2>
     <p>Devenez Fan de l'AFUP en cliquant sur :</p>
     <div class="block-leftbar">
-    	<iframe src="http://www.facebook.com/plugins/like.php?href=http://afup.org/pages/phptourluxembourg2015/&amp;layout=standard&amp;show_faces=true&amp;width=178&amp;action=like&amp;colorscheme=light" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:500px; height:30px;" allowTransparency="true"></iframe></p>
+    	<iframe src="http://www.facebook.com/plugins/like.php?href=http://www.facebook.com/pages/AFUP/148661101838283&amp;layout=standard&amp;show_faces=false&amp;width=178&amp;action=like&amp;colorscheme=light" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:500px; height:30px;" allowTransparency="true"></iframe></p>
     </div>
     <p>Annoncez votre venue au PHP Tour Luxembourg 2015 :<a href="http://www.facebook.com/share.php?u=http%3A%2F%2Fwww.afup.org%2Fpages%2Fphptourluxembourg2015">cliquez-ici pour mettre à jour votre statut Facebook</a></p><br/>
 </div>


### PR DESCRIPTION
J'ai modifié le lien "Devenez fan de l'AFUP sur Facebook" sur la page buzz du phptour pour pointer vers notre page Facebook : ça donne plus de j'aime et ça correspond au texte :)

![afup_fb](https://cloud.githubusercontent.com/assets/1848817/5577963/6c9cbc42-901d-11e4-9f24-cf7d9ceb9230.jpg)

De même, j'ai changé l'URL cible de twitter pour pointer vers la home du phptour plutôt que sur la page buzz, et en plus ça fait passer la longueur du tweet sous les 140 caractères car le lien est raccourci.

![afup_tw](https://cloud.githubusercontent.com/assets/1848817/5577979/a2652f58-901d-11e4-9dfb-7f935fbe3c6b.jpg)
