### PR TITLE
Mandrill

### DIFF
--- a/configs/application/config.php.dist
+++ b/configs/application/config.php.dist
@@ -53,3 +53,7 @@ $configuration['sympa']['hote']='localhost';
 $configuration['sympa']['base']='sympa';
 $configuration['sympa']['utilisateur']='sympa';
 $configuration['sympa']['mot_de_passe']='sympa';
+
+$configuration['mandrill']['key'] = '';
+$configuration['mandrill']['bcc'] = 'tresorier@afup.org';
+

--- a/dependencies/mandrill/Mandrill.php
+++ b/dependencies/mandrill/Mandrill.php
@@ -1,0 +1,161 @@
+<?php
+
+require_once 'Mandrill/Templates.php';
+require_once 'Mandrill/Exports.php';
+require_once 'Mandrill/Users.php';
+require_once 'Mandrill/Rejects.php';
+require_once 'Mandrill/Inbound.php';
+require_once 'Mandrill/Tags.php';
+require_once 'Mandrill/Messages.php';
+require_once 'Mandrill/Whitelists.php';
+require_once 'Mandrill/Ips.php';
+require_once 'Mandrill/Internal.php';
+require_once 'Mandrill/Subaccounts.php';
+require_once 'Mandrill/Urls.php';
+require_once 'Mandrill/Webhooks.php';
+require_once 'Mandrill/Senders.php';
+require_once 'Mandrill/Metadata.php';
+require_once 'Mandrill/Exceptions.php';
+
+class Mandrill {
+    
+    public $apikey;
+    public $ch;
+    public $root = 'https://mandrillapp.com/api/1.0';
+    public $debug = false;
+
+    public static $error_map = array(
+        "ValidationError" => "Mandrill_ValidationError",
+        "Invalid_Key" => "Mandrill_Invalid_Key",
+        "PaymentRequired" => "Mandrill_PaymentRequired",
+        "Unknown_Subaccount" => "Mandrill_Unknown_Subaccount",
+        "Unknown_Template" => "Mandrill_Unknown_Template",
+        "ServiceUnavailable" => "Mandrill_ServiceUnavailable",
+        "Unknown_Message" => "Mandrill_Unknown_Message",
+        "Invalid_Tag_Name" => "Mandrill_Invalid_Tag_Name",
+        "Invalid_Reject" => "Mandrill_Invalid_Reject",
+        "Unknown_Sender" => "Mandrill_Unknown_Sender",
+        "Unknown_Url" => "Mandrill_Unknown_Url",
+        "Unknown_TrackingDomain" => "Mandrill_Unknown_TrackingDomain",
+        "Invalid_Template" => "Mandrill_Invalid_Template",
+        "Unknown_Webhook" => "Mandrill_Unknown_Webhook",
+        "Unknown_InboundDomain" => "Mandrill_Unknown_InboundDomain",
+        "Unknown_InboundRoute" => "Mandrill_Unknown_InboundRoute",
+        "Unknown_Export" => "Mandrill_Unknown_Export",
+        "IP_ProvisionLimit" => "Mandrill_IP_ProvisionLimit",
+        "Unknown_Pool" => "Mandrill_Unknown_Pool",
+        "NoSendingHistory" => "Mandrill_NoSendingHistory",
+        "PoorReputation" => "Mandrill_PoorReputation",
+        "Unknown_IP" => "Mandrill_Unknown_IP",
+        "Invalid_EmptyDefaultPool" => "Mandrill_Invalid_EmptyDefaultPool",
+        "Invalid_DeleteDefaultPool" => "Mandrill_Invalid_DeleteDefaultPool",
+        "Invalid_DeleteNonEmptyPool" => "Mandrill_Invalid_DeleteNonEmptyPool",
+        "Invalid_CustomDNS" => "Mandrill_Invalid_CustomDNS",
+        "Invalid_CustomDNSPending" => "Mandrill_Invalid_CustomDNSPending",
+        "Metadata_FieldLimit" => "Mandrill_Metadata_FieldLimit",
+        "Unknown_MetadataField" => "Mandrill_Unknown_MetadataField"
+    );
+
+    public function __construct($apikey=null) {
+        if(!$apikey) $apikey = getenv('MANDRILL_APIKEY');
+        if(!$apikey) $apikey = $this->readConfigs();
+        if(!$apikey) throw new Mandrill_Error('You must provide a Mandrill API key');
+        $this->apikey = $apikey;
+
+        $this->ch = curl_init();
+        curl_setopt($this->ch, CURLOPT_USERAGENT, 'Mandrill-PHP/1.0.54');
+        curl_setopt($this->ch, CURLOPT_POST, true);
+        curl_setopt($this->ch, CURLOPT_FOLLOWLOCATION, true);
+        curl_setopt($this->ch, CURLOPT_HEADER, false);
+        curl_setopt($this->ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($this->ch, CURLOPT_CONNECTTIMEOUT, 30);
+        curl_setopt($this->ch, CURLOPT_TIMEOUT, 600);
+
+        $this->root = rtrim($this->root, '/') . '/';
+
+        $this->templates = new Mandrill_Templates($this);
+        $this->exports = new Mandrill_Exports($this);
+        $this->users = new Mandrill_Users($this);
+        $this->rejects = new Mandrill_Rejects($this);
+        $this->inbound = new Mandrill_Inbound($this);
+        $this->tags = new Mandrill_Tags($this);
+        $this->messages = new Mandrill_Messages($this);
+        $this->whitelists = new Mandrill_Whitelists($this);
+        $this->ips = new Mandrill_Ips($this);
+        $this->internal = new Mandrill_Internal($this);
+        $this->subaccounts = new Mandrill_Subaccounts($this);
+        $this->urls = new Mandrill_Urls($this);
+        $this->webhooks = new Mandrill_Webhooks($this);
+        $this->senders = new Mandrill_Senders($this);
+        $this->metadata = new Mandrill_Metadata($this);
+    }
+
+    public function __destruct() {
+        curl_close($this->ch);
+    }
+
+    public function call($url, $params) {
+        $params['key'] = $this->apikey;
+        $params = json_encode($params);
+        $ch = $this->ch;
+
+        curl_setopt($ch, CURLOPT_URL, $this->root . $url . '.json');
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+        curl_setopt($ch, CURLOPT_VERBOSE, $this->debug);
+
+        $start = microtime(true);
+        $this->log('Call to ' . $this->root . $url . '.json: ' . $params);
+        if($this->debug) {
+            $curl_buffer = fopen('php://memory', 'w+');
+            curl_setopt($ch, CURLOPT_STDERR, $curl_buffer);
+        }
+
+        $response_body = curl_exec($ch);
+        $info = curl_getinfo($ch);
+        $time = microtime(true) - $start;
+        if($this->debug) {
+            rewind($curl_buffer);
+            $this->log(stream_get_contents($curl_buffer));
+            fclose($curl_buffer);
+        }
+        $this->log('Completed in ' . number_format($time * 1000, 2) . 'ms');
+        $this->log('Got response: ' . $response_body);
+
+        if(curl_error($ch)) {
+            throw new Mandrill_HttpError("API call to $url failed: " . curl_error($ch));
+        }
+        $result = json_decode($response_body, true);
+        if($result === null) throw new Mandrill_Error('We were unable to decode the JSON response from the Mandrill API: ' . $response_body);
+        
+        if(floor($info['http_code'] / 100) >= 4) {
+            throw $this->castError($result);
+        }
+
+        return $result;
+    }
+
+    public function readConfigs() {
+        $paths = array('~/.mandrill.key', '/etc/mandrill.key');
+        foreach($paths as $path) {
+            if(file_exists($path)) {
+                $apikey = trim(file_get_contents($path));
+                if($apikey) return $apikey;
+            }
+        }
+        return false;
+    }
+
+    public function castError($result) {
+        if($result['status'] !== 'error' || !$result['name']) throw new Mandrill_Error('We received an unexpected error: ' . json_encode($result));
+
+        $class = (isset(self::$error_map[$result['name']])) ? self::$error_map[$result['name']] : 'Mandrill_Error';
+        return new $class($result['message'], $result['code']);
+    }
+
+    public function log($msg) {
+        if($this->debug) error_log($msg);
+    }
+}
+
+

--- a/dependencies/mandrill/Mandrill/Exceptions.php
+++ b/dependencies/mandrill/Mandrill/Exceptions.php
@@ -1,0 +1,151 @@
+<?php
+
+class Mandrill_Error extends Exception {}
+class Mandrill_HttpError extends Mandrill_Error {}
+
+/**
+ * The parameters passed to the API call are invalid or not provided when required
+ */
+class Mandrill_ValidationError extends Mandrill_Error {}
+
+/**
+ * The provided API key is not a valid Mandrill API key
+ */
+class Mandrill_Invalid_Key extends Mandrill_Error {}
+
+/**
+ * The requested feature requires payment.
+ */
+class Mandrill_PaymentRequired extends Mandrill_Error {}
+
+/**
+ * The provided subaccount id does not exist.
+ */
+class Mandrill_Unknown_Subaccount extends Mandrill_Error {}
+
+/**
+ * The requested template does not exist
+ */
+class Mandrill_Unknown_Template extends Mandrill_Error {}
+
+/**
+ * The subsystem providing this API call is down for maintenance
+ */
+class Mandrill_ServiceUnavailable extends Mandrill_Error {}
+
+/**
+ * The provided message id does not exist.
+ */
+class Mandrill_Unknown_Message extends Mandrill_Error {}
+
+/**
+ * The requested tag does not exist or contains invalid characters
+ */
+class Mandrill_Invalid_Tag_Name extends Mandrill_Error {}
+
+/**
+ * The requested email is not in the rejection list
+ */
+class Mandrill_Invalid_Reject extends Mandrill_Error {}
+
+/**
+ * The requested sender does not exist
+ */
+class Mandrill_Unknown_Sender extends Mandrill_Error {}
+
+/**
+ * The requested URL has not been seen in a tracked link
+ */
+class Mandrill_Unknown_Url extends Mandrill_Error {}
+
+/**
+ * The provided tracking domain does not exist.
+ */
+class Mandrill_Unknown_TrackingDomain extends Mandrill_Error {}
+
+/**
+ * The given template name already exists or contains invalid characters
+ */
+class Mandrill_Invalid_Template extends Mandrill_Error {}
+
+/**
+ * The requested webhook does not exist
+ */
+class Mandrill_Unknown_Webhook extends Mandrill_Error {}
+
+/**
+ * The requested inbound domain does not exist
+ */
+class Mandrill_Unknown_InboundDomain extends Mandrill_Error {}
+
+/**
+ * The provided inbound route does not exist.
+ */
+class Mandrill_Unknown_InboundRoute extends Mandrill_Error {}
+
+/**
+ * The requested export job does not exist
+ */
+class Mandrill_Unknown_Export extends Mandrill_Error {}
+
+/**
+ * A dedicated IP cannot be provisioned while another request is pending.
+ */
+class Mandrill_IP_ProvisionLimit extends Mandrill_Error {}
+
+/**
+ * The provided dedicated IP pool does not exist.
+ */
+class Mandrill_Unknown_Pool extends Mandrill_Error {}
+
+/**
+ * The user hasn't started sending yet.
+ */
+class Mandrill_NoSendingHistory extends Mandrill_Error {}
+
+/**
+ * The user's reputation is too low to continue.
+ */
+class Mandrill_PoorReputation extends Mandrill_Error {}
+
+/**
+ * The provided dedicated IP does not exist.
+ */
+class Mandrill_Unknown_IP extends Mandrill_Error {}
+
+/**
+ * You cannot remove the last IP from your default IP pool.
+ */
+class Mandrill_Invalid_EmptyDefaultPool extends Mandrill_Error {}
+
+/**
+ * The default pool cannot be deleted.
+ */
+class Mandrill_Invalid_DeleteDefaultPool extends Mandrill_Error {}
+
+/**
+ * Non-empty pools cannot be deleted.
+ */
+class Mandrill_Invalid_DeleteNonEmptyPool extends Mandrill_Error {}
+
+/**
+ * The domain name is not configured for use as the dedicated IP's custom reverse DNS.
+ */
+class Mandrill_Invalid_CustomDNS extends Mandrill_Error {}
+
+/**
+ * A custom DNS change for this dedicated IP is currently pending.
+ */
+class Mandrill_Invalid_CustomDNSPending extends Mandrill_Error {}
+
+/**
+ * Custom metadata field limit reached.
+ */
+class Mandrill_Metadata_FieldLimit extends Mandrill_Error {}
+
+/**
+ * The provided metadata field name does not exist.
+ */
+class Mandrill_Unknown_MetadataField extends Mandrill_Error {}
+
+

--- a/dependencies/mandrill/Mandrill/Exports.php
+++ b/dependencies/mandrill/Mandrill/Exports.php
@@ -1,0 +1,112 @@
+<?php
+
+class Mandrill_Exports {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Returns information about an export job. If the export job's state is 'complete',
+the returned data will include a URL you can use to fetch the results. Every export
+job produces a zip archive, but the format of the archive is distinct for each job
+type. The api calls that initiate exports include more details about the output format
+for that job type.
+     * @param string $id an export job identifier
+     * @return struct the information about the export
+     *     - id string the unique identifier for this Export. Use this identifier when checking the export job's status
+     *     - created_at string the date and time that the export job was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - type string the type of the export job - activity, reject, or whitelist
+     *     - finished_at string the date and time that the export job was finished as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - state string the export job's state - waiting, working, complete, error, or expired.
+     *     - result_url string the url for the export job's results, if the job is completed.
+     */
+    public function info($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('exports/info', $_params);
+    }
+
+    /**
+     * Returns a list of your exports.
+     * @return array the account's exports
+     *     - return[] struct the individual export info
+     *         - id string the unique identifier for this Export. Use this identifier when checking the export job's status
+     *         - created_at string the date and time that the export job was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - type string the type of the export job - activity, reject, or whitelist
+     *         - finished_at string the date and time that the export job was finished as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - state string the export job's state - waiting, working, complete, error, or expired.
+     *         - result_url string the url for the export job's results, if the job is completed.
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('exports/list', $_params);
+    }
+
+    /**
+     * Begins an export of your rejection blacklist. The blacklist will be exported to a zip archive
+containing a single file named rejects.csv that includes the following fields: email,
+reason, detail, created_at, expires_at, last_event_at, expires_at.
+     * @param string $notify_email an optional email address to notify when the export job has finished.
+     * @return struct information about the rejects export job that was started
+     *     - id string the unique identifier for this Export. Use this identifier when checking the export job's status
+     *     - created_at string the date and time that the export job was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - type string the type of the export job
+     *     - finished_at string the date and time that the export job was finished as a UTC string in YYYY-MM-DD HH:MM:SS format, or null for jobs that have not run
+     *     - state string the export job's state
+     *     - result_url string the url for the export job's results, if the job is complete
+     */
+    public function rejects($notify_email=null) {
+        $_params = array("notify_email" => $notify_email);
+        return $this->master->call('exports/rejects', $_params);
+    }
+
+    /**
+     * Begins an export of your rejection whitelist. The whitelist will be exported to a zip archive
+containing a single file named whitelist.csv that includes the following fields:
+email, detail, created_at.
+     * @param string $notify_email an optional email address to notify when the export job has finished.
+     * @return struct information about the whitelist export job that was started
+     *     - id string the unique identifier for this Export. Use this identifier when checking the export job's status
+     *     - created_at string the date and time that the export job was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - type string the type of the export job
+     *     - finished_at string the date and time that the export job was finished as a UTC string in YYYY-MM-DD HH:MM:SS format, or null for jobs that have not run
+     *     - state string the export job's state
+     *     - result_url string the url for the export job's results, if the job is complete
+     */
+    public function whitelist($notify_email=null) {
+        $_params = array("notify_email" => $notify_email);
+        return $this->master->call('exports/whitelist', $_params);
+    }
+
+    /**
+     * Begins an export of your activity history. The activity will be exported to a zip archive
+containing a single file named activity.csv in the same format as you would be able to export
+from your account's activity view. It includes the following fields: Date, Email Address,
+Sender, Subject, Status, Tags, Opens, Clicks, Bounce Detail. If you have configured any custom
+metadata fields, they will be included in the exported data.
+     * @param string $notify_email an optional email address to notify when the export job has finished
+     * @param string $date_from start date as a UTC string in YYYY-MM-DD HH:MM:SS format
+     * @param string $date_to end date as a UTC string in YYYY-MM-DD HH:MM:SS format
+     * @param array $tags an array of tag names to narrow the export to; will match messages that contain ANY of the tags
+     *     - tags[] string a tag name
+     * @param array $senders an array of senders to narrow the export to
+     *     - senders[] string a sender address
+     * @param array $states an array of states to narrow the export to; messages with ANY of the states will be included
+     *     - states[] string a message state
+     * @param array $api_keys an array of api keys to narrow the export to; messsagse sent with ANY of the keys will be included
+     *     - api_keys[] string an API key associated with your account
+     * @return struct information about the activity export job that was started
+     *     - id string the unique identifier for this Export. Use this identifier when checking the export job's status
+     *     - created_at string the date and time that the export job was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - type string the type of the export job
+     *     - finished_at string the date and time that the export job was finished as a UTC string in YYYY-MM-DD HH:MM:SS format, or null for jobs that have not run
+     *     - state string the export job's state
+     *     - result_url string the url for the export job's results, if the job is complete
+     */
+    public function activity($notify_email=null, $date_from=null, $date_to=null, $tags=null, $senders=null, $states=null, $api_keys=null) {
+        $_params = array("notify_email" => $notify_email, "date_from" => $date_from, "date_to" => $date_to, "tags" => $tags, "senders" => $senders, "states" => $states, "api_keys" => $api_keys);
+        return $this->master->call('exports/activity', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Inbound.php
+++ b/dependencies/mandrill/Mandrill/Inbound.php
@@ -1,0 +1,138 @@
+<?php
+
+class Mandrill_Inbound {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * List the domains that have been configured for inbound delivery
+     * @return array the inbound domains associated with the account
+     *     - return[] struct the individual domain info
+     *         - domain string the domain name that is accepting mail
+     *         - created_at string the date and time that the inbound domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - valid_mx boolean true if this inbound domain has successfully set up an MX record to deliver mail to the Mandrill servers
+     */
+    public function domains() {
+        $_params = array();
+        return $this->master->call('inbound/domains', $_params);
+    }
+
+    /**
+     * Add an inbound domain to your account
+     * @param string $domain a domain name
+     * @return struct information about the domain
+     *     - domain string the domain name that is accepting mail
+     *     - created_at string the date and time that the inbound domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - valid_mx boolean true if this inbound domain has successfully set up an MX record to deliver mail to the Mandrill servers
+     */
+    public function addDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('inbound/add-domain', $_params);
+    }
+
+    /**
+     * Check the MX settings for an inbound domain. The domain must have already been added with the add-domain call
+     * @param string $domain an existing inbound domain
+     * @return struct information about the inbound domain
+     *     - domain string the domain name that is accepting mail
+     *     - created_at string the date and time that the inbound domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - valid_mx boolean true if this inbound domain has successfully set up an MX record to deliver mail to the Mandrill servers
+     */
+    public function checkDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('inbound/check-domain', $_params);
+    }
+
+    /**
+     * Delete an inbound domain from the account. All mail will stop routing for this domain immediately.
+     * @param string $domain an existing inbound domain
+     * @return struct information about the deleted domain
+     *     - domain string the domain name that is accepting mail
+     *     - created_at string the date and time that the inbound domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - valid_mx boolean true if this inbound domain has successfully set up an MX record to deliver mail to the Mandrill servers
+     */
+    public function deleteDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('inbound/delete-domain', $_params);
+    }
+
+    /**
+     * List the mailbox routes defined for an inbound domain
+     * @param string $domain the domain to check
+     * @return array the routes associated with the domain
+     *     - return[] struct the individual mailbox route
+     *         - id string the unique identifier of the route
+     *         - pattern string the search pattern that the mailbox name should match
+     *         - url string the webhook URL where inbound messages will be published
+     */
+    public function routes($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('inbound/routes', $_params);
+    }
+
+    /**
+     * Add a new mailbox route to an inbound domain
+     * @param string $domain an existing inbound domain
+     * @param string $pattern the search pattern that the mailbox name should match
+     * @param string $url the webhook URL where the inbound messages will be published
+     * @return struct the added mailbox route information
+     *     - id string the unique identifier of the route
+     *     - pattern string the search pattern that the mailbox name should match
+     *     - url string the webhook URL where inbound messages will be published
+     */
+    public function addRoute($domain, $pattern, $url) {
+        $_params = array("domain" => $domain, "pattern" => $pattern, "url" => $url);
+        return $this->master->call('inbound/add-route', $_params);
+    }
+
+    /**
+     * Update the pattern or webhook of an existing inbound mailbox route. If null is provided for any fields, the values will remain unchanged.
+     * @param string $id the unique identifier of an existing mailbox route
+     * @param string $pattern the search pattern that the mailbox name should match
+     * @param string $url the webhook URL where the inbound messages will be published
+     * @return struct the updated mailbox route information
+     *     - id string the unique identifier of the route
+     *     - pattern string the search pattern that the mailbox name should match
+     *     - url string the webhook URL where inbound messages will be published
+     */
+    public function updateRoute($id, $pattern=null, $url=null) {
+        $_params = array("id" => $id, "pattern" => $pattern, "url" => $url);
+        return $this->master->call('inbound/update-route', $_params);
+    }
+
+    /**
+     * Delete an existing inbound mailbox route
+     * @param string $id the unique identifier of an existing route
+     * @return struct the deleted mailbox route information
+     *     - id string the unique identifier of the route
+     *     - pattern string the search pattern that the mailbox name should match
+     *     - url string the webhook URL where inbound messages will be published
+     */
+    public function deleteRoute($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('inbound/delete-route', $_params);
+    }
+
+    /**
+     * Take a raw MIME document destined for a domain with inbound domains set up, and send it to the inbound hook exactly as if it had been sent over SMTP
+     * @param string $raw_message the full MIME document of an email message
+     * @param array|null $to optionally define the recipients to receive the message - otherwise we'll use the To, Cc, and Bcc headers provided in the document
+     *     - to[] string the email address of the recipient
+     * @param string $mail_from the address specified in the MAIL FROM stage of the SMTP conversation. Required for the SPF check.
+     * @param string $helo the identification provided by the client mta in the MTA state of the SMTP conversation. Required for the SPF check.
+     * @param string $client_address the remote MTA's ip address. Optional; required for the SPF check.
+     * @return array an array of the information for each recipient in the message (usually one) that matched an inbound route
+     *     - return[] struct the individual recipient information
+     *         - email string the email address of the matching recipient
+     *         - pattern string the mailbox route pattern that the recipient matched
+     *         - url string the webhook URL that the message was posted to
+     */
+    public function sendRaw($raw_message, $to=null, $mail_from=null, $helo=null, $client_address=null) {
+        $_params = array("raw_message" => $raw_message, "to" => $to, "mail_from" => $mail_from, "helo" => $helo, "client_address" => $client_address);
+        return $this->master->call('inbound/send-raw', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Internal.php
+++ b/dependencies/mandrill/Mandrill/Internal.php
@@ -1,0 +1,10 @@
+<?php
+
+class Mandrill_Internal {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Ips.php
+++ b/dependencies/mandrill/Mandrill/Ips.php
@@ -1,0 +1,279 @@
+<?php
+
+class Mandrill_Ips {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Lists your dedicated IPs.
+     * @return array an array of structs for each dedicated IP
+     *     - return[] struct information about a single dedicated IP
+     *         - ip string the ip address
+     *         - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - pool string the name of the pool that this dedicated IP belongs to
+     *         - domain string the domain name (reverse dns) of this dedicated IP
+     *         - custom_dns struct information about the ip's custom dns, if it has been configured
+     *             - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *             - valid boolean whether the ip's custom dns is currently valid
+     *             - error string if the ip's custom dns is invalid, this will include details about the error
+     *         - warmup struct information about the ip's warmup status
+     *             - warming_up boolean whether the ip is currently in warmup mode
+     *             - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *             - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('ips/list', $_params);
+    }
+
+    /**
+     * Retrieves information about a single dedicated ip.
+     * @param string $ip a dedicated IP address
+     * @return struct Information about the dedicated ip
+     *     - ip string the ip address
+     *     - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - pool string the name of the pool that this dedicated IP belongs to
+     *     - domain string the domain name (reverse dns) of this dedicated IP
+     *     - custom_dns struct information about the ip's custom dns, if it has been configured
+     *         - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *         - valid boolean whether the ip's custom dns is currently valid
+     *         - error string if the ip's custom dns is invalid, this will include details about the error
+     *     - warmup struct information about the ip's warmup status
+     *         - warming_up boolean whether the ip is currently in warmup mode
+     *         - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function info($ip) {
+        $_params = array("ip" => $ip);
+        return $this->master->call('ips/info', $_params);
+    }
+
+    /**
+     * Requests an additional dedicated IP for your account. Accounts may
+have one outstanding request at any time, and provisioning requests
+are processed within 24 hours.
+     * @param boolean $warmup whether to enable warmup mode for the ip
+     * @param string $pool the id of the pool to add the dedicated ip to, or null to use your account's default pool
+     * @return struct a description of the provisioning request that was created
+     *     - requested_at string the date and time that the request was created as a UTC timestamp in YYYY-MM-DD HH:MM:SS format
+     */
+    public function provision($warmup=false, $pool=null) {
+        $_params = array("warmup" => $warmup, "pool" => $pool);
+        return $this->master->call('ips/provision', $_params);
+    }
+
+    /**
+     * Begins the warmup process for a dedicated IP. During the warmup process,
+Mandrill will gradually increase the percentage of your mail that is sent over
+the warming-up IP, over a period of roughly 30 days. The rest of your mail
+will be sent over shared IPs or other dedicated IPs in the same pool.
+     * @param string $ip a dedicated ip address
+     * @return struct Information about the dedicated IP
+     *     - ip string the ip address
+     *     - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - pool string the name of the pool that this dedicated IP belongs to
+     *     - domain string the domain name (reverse dns) of this dedicated IP
+     *     - custom_dns struct information about the ip's custom dns, if it has been configured
+     *         - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *         - valid boolean whether the ip's custom dns is currently valid
+     *         - error string if the ip's custom dns is invalid, this will include details about the error
+     *     - warmup struct information about the ip's warmup status
+     *         - warming_up boolean whether the ip is currently in warmup mode
+     *         - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function startWarmup($ip) {
+        $_params = array("ip" => $ip);
+        return $this->master->call('ips/start-warmup', $_params);
+    }
+
+    /**
+     * Cancels the warmup process for a dedicated IP.
+     * @param string $ip a dedicated ip address
+     * @return struct Information about the dedicated IP
+     *     - ip string the ip address
+     *     - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - pool string the name of the pool that this dedicated IP belongs to
+     *     - domain string the domain name (reverse dns) of this dedicated IP
+     *     - custom_dns struct information about the ip's custom dns, if it has been configured
+     *         - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *         - valid boolean whether the ip's custom dns is currently valid
+     *         - error string if the ip's custom dns is invalid, this will include details about the error
+     *     - warmup struct information about the ip's warmup status
+     *         - warming_up boolean whether the ip is currently in warmup mode
+     *         - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function cancelWarmup($ip) {
+        $_params = array("ip" => $ip);
+        return $this->master->call('ips/cancel-warmup', $_params);
+    }
+
+    /**
+     * Moves a dedicated IP to a different pool.
+     * @param string $ip a dedicated ip address
+     * @param string $pool the name of the new pool to add the dedicated ip to
+     * @param boolean $create_pool whether to create the pool if it does not exist; if false and the pool does not exist, an Unknown_Pool will be thrown.
+     * @return struct Information about the updated state of the dedicated IP
+     *     - ip string the ip address
+     *     - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - pool string the name of the pool that this dedicated IP belongs to
+     *     - domain string the domain name (reverse dns) of this dedicated IP
+     *     - custom_dns struct information about the ip's custom dns, if it has been configured
+     *         - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *         - valid boolean whether the ip's custom dns is currently valid
+     *         - error string if the ip's custom dns is invalid, this will include details about the error
+     *     - warmup struct information about the ip's warmup status
+     *         - warming_up boolean whether the ip is currently in warmup mode
+     *         - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function setPool($ip, $pool, $create_pool=false) {
+        $_params = array("ip" => $ip, "pool" => $pool, "create_pool" => $create_pool);
+        return $this->master->call('ips/set-pool', $_params);
+    }
+
+    /**
+     * Deletes a dedicated IP. This is permanent and cannot be undone.
+     * @param string $ip the dedicated ip to remove from your account
+     * @return struct a description of the ip that was removed from your account.
+     *     - ip string the ip address
+     *     - deleted string a boolean indicating whether the ip was successfully deleted
+     */
+    public function delete($ip) {
+        $_params = array("ip" => $ip);
+        return $this->master->call('ips/delete', $_params);
+    }
+
+    /**
+     * Lists your dedicated IP pools.
+     * @return array the dedicated IP pools for your account, up to a maximum of 1,000
+     *     - return[] struct information about each dedicated IP pool
+     *         - name string this pool's name
+     *         - created_at string the date and time that this pool was created as a UTC timestamp in YYYY-MM-DD HH:MM:SS format
+     *         - ips array the dedicated IPs in this pool
+     *             - ips[] struct information about each dedicated IP
+     *                 - ip string the ip address
+     *                 - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *                 - pool string the name of the pool that this dedicated IP belongs to
+     *                 - domain string the domain name (reverse dns) of this dedicated IP
+     *                 - custom_dns struct information about the ip's custom dns, if it has been configured
+     *                     - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *                     - valid boolean whether the ip's custom dns is currently valid
+     *                     - error string if the ip's custom dns is invalid, this will include details about the error
+     *                 - warmup struct information about the ip's warmup status
+     *                     - warming_up boolean whether the ip is currently in warmup mode
+     *                     - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *                     - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function listPools() {
+        $_params = array();
+        return $this->master->call('ips/list-pools', $_params);
+    }
+
+    /**
+     * Describes a single dedicated IP pool.
+     * @param string $pool a pool name
+     * @return struct Information about the dedicated ip pool
+     *     - name string this pool's name
+     *     - created_at string the date and time that this pool was created as a UTC timestamp in YYYY-MM-DD HH:MM:SS format
+     *     - ips array the dedicated IPs in this pool
+     *         - ips[] struct information about each dedicated IP
+     *             - ip string the ip address
+     *             - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *             - pool string the name of the pool that this dedicated IP belongs to
+     *             - domain string the domain name (reverse dns) of this dedicated IP
+     *             - custom_dns struct information about the ip's custom dns, if it has been configured
+     *                 - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *                 - valid boolean whether the ip's custom dns is currently valid
+     *                 - error string if the ip's custom dns is invalid, this will include details about the error
+     *             - warmup struct information about the ip's warmup status
+     *                 - warming_up boolean whether the ip is currently in warmup mode
+     *                 - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *                 - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function poolInfo($pool) {
+        $_params = array("pool" => $pool);
+        return $this->master->call('ips/pool-info', $_params);
+    }
+
+    /**
+     * Creates a pool and returns it. If a pool already exists with this
+name, no action will be performed.
+     * @param string $pool the name of a pool to create
+     * @return struct Information about the dedicated ip pool
+     *     - name string this pool's name
+     *     - created_at string the date and time that this pool was created as a UTC timestamp in YYYY-MM-DD HH:MM:SS format
+     *     - ips array the dedicated IPs in this pool
+     *         - ips[] struct information about each dedicated IP
+     *             - ip string the ip address
+     *             - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *             - pool string the name of the pool that this dedicated IP belongs to
+     *             - domain string the domain name (reverse dns) of this dedicated IP
+     *             - custom_dns struct information about the ip's custom dns, if it has been configured
+     *                 - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *                 - valid boolean whether the ip's custom dns is currently valid
+     *                 - error string if the ip's custom dns is invalid, this will include details about the error
+     *             - warmup struct information about the ip's warmup status
+     *                 - warming_up boolean whether the ip is currently in warmup mode
+     *                 - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *                 - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function createPool($pool) {
+        $_params = array("pool" => $pool);
+        return $this->master->call('ips/create-pool', $_params);
+    }
+
+    /**
+     * Deletes a pool. A pool must be empty before you can delete it, and you cannot delete your default pool.
+     * @param string $pool the name of the pool to delete
+     * @return struct information about the status of the pool that was deleted
+     *     - pool string the name of the pool
+     *     - deleted boolean whether the pool was deleted
+     */
+    public function deletePool($pool) {
+        $_params = array("pool" => $pool);
+        return $this->master->call('ips/delete-pool', $_params);
+    }
+
+    /**
+     * Tests whether a domain name is valid for use as the custom reverse
+DNS for a dedicated IP.
+     * @param string $ip a dedicated ip address
+     * @param string $domain the domain name to test
+     * @return struct validation results for the domain
+     *     - valid string whether the domain name has a correctly-configured A record pointing to the ip address
+     *     - error string if valid is false, this will contain details about why the domain's A record is incorrect
+     */
+    public function checkCustomDns($ip, $domain) {
+        $_params = array("ip" => $ip, "domain" => $domain);
+        return $this->master->call('ips/check-custom-dns', $_params);
+    }
+
+    /**
+     * Configures the custom DNS name for a dedicated IP.
+     * @param string $ip a dedicated ip address
+     * @param string $domain a domain name to set as the dedicated IP's custom dns name.
+     * @return struct information about the dedicated IP's new configuration
+     *     - ip string the ip address
+     *     - created_at string the date and time that the dedicated IP was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - pool string the name of the pool that this dedicated IP belongs to
+     *     - domain string the domain name (reverse dns) of this dedicated IP
+     *     - custom_dns struct information about the ip's custom dns, if it has been configured
+     *         - enabled boolean a boolean indicating whether custom dns has been configured for this ip
+     *         - valid boolean whether the ip's custom dns is currently valid
+     *         - error string if the ip's custom dns is invalid, this will include details about the error
+     *     - warmup struct information about the ip's warmup status
+     *         - warming_up boolean whether the ip is currently in warmup mode
+     *         - start_at string the start time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - end_at string the end date and time for the warmup process as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function setCustomDns($ip, $domain) {
+        $_params = array("ip" => $ip, "domain" => $domain);
+        return $this->master->call('ips/set-custom-dns', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Messages.php
+++ b/dependencies/mandrill/Mandrill/Messages.php
@@ -1,0 +1,410 @@
+<?php
+
+class Mandrill_Messages {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Send a new transactional message through Mandrill
+     * @param struct $message the information on the message to send
+     *     - html string the full HTML content to be sent
+     *     - text string optional full text content to be sent
+     *     - subject string the message subject
+     *     - from_email string the sender email address.
+     *     - from_name string optional from name to be used
+     *     - to array an array of recipient information.
+     *         - to[] struct a single recipient's information.
+     *             - email string the email address of the recipient
+     *             - name string the optional display name to use for the recipient
+     *             - type string the header type to use for the recipient, defaults to "to" if not provided
+     *     - headers struct optional extra headers to add to the message (most headers are allowed)
+     *     - important boolean whether or not this message is important, and should be delivered ahead of non-important messages
+     *     - track_opens boolean whether or not to turn on open tracking for the message
+     *     - track_clicks boolean whether or not to turn on click tracking for the message
+     *     - auto_text boolean whether or not to automatically generate a text part for messages that are not given text
+     *     - auto_html boolean whether or not to automatically generate an HTML part for messages that are not given HTML
+     *     - inline_css boolean whether or not to automatically inline all CSS styles provided in the message HTML - only for HTML documents less than 256KB in size
+     *     - url_strip_qs boolean whether or not to strip the query string from URLs when aggregating tracked URL data
+     *     - preserve_recipients boolean whether or not to expose all recipients in to "To" header for each email
+     *     - view_content_link boolean set to false to remove content logging for sensitive emails
+     *     - bcc_address string an optional address to receive an exact copy of each recipient's email
+     *     - tracking_domain string a custom domain to use for tracking opens and clicks instead of mandrillapp.com
+     *     - signing_domain string a custom domain to use for SPF/DKIM signing instead of mandrill (for "via" or "on behalf of" in email clients)
+     *     - return_path_domain string a custom domain to use for the messages's return-path
+     *     - merge boolean whether to evaluate merge tags in the message. Will automatically be set to true if either merge_vars or global_merge_vars are provided.
+     *     - merge_language string the merge tag language to use when evaluating merge tags, either mailchimp or handlebars
+     *     - global_merge_vars array global merge variables to use for all recipients. You can override these per recipient.
+     *         - global_merge_vars[] struct a single global merge variable
+     *             - name string the global merge variable's name. Merge variable names are case-insensitive and may not start with _
+     *             - content mixed the global merge variable's content
+     *     - merge_vars array per-recipient merge variables, which override global merge variables with the same name.
+     *         - merge_vars[] struct per-recipient merge variables
+     *             - rcpt string the email address of the recipient that the merge variables should apply to
+     *             - vars array the recipient's merge variables
+     *                 - vars[] struct a single merge variable
+     *                     - name string the merge variable's name. Merge variable names are case-insensitive and may not start with _
+     *                     - content mixed the merge variable's content
+     *     - tags array an array of string to tag the message with.  Stats are accumulated using tags, though we only store the first 100 we see, so this should not be unique or change frequently.  Tags should be 50 characters or less.  Any tags starting with an underscore are reserved for internal use and will cause errors.
+     *         - tags[] string a single tag - must not start with an underscore
+     *     - subaccount string the unique id of a subaccount for this message - must already exist or will fail with an error
+     *     - google_analytics_domains array an array of strings indicating for which any matching URLs will automatically have Google Analytics parameters appended to their query string automatically.
+     *     - google_analytics_campaign array|string optional string indicating the value to set for the utm_campaign tracking parameter. If this isn't provided the email's from address will be used instead.
+     *     - metadata array metadata an associative array of user metadata. Mandrill will store this metadata and make it available for retrieval. In addition, you can select up to 10 metadata fields to index and make searchable using the Mandrill search api.
+     *     - recipient_metadata array Per-recipient metadata that will override the global values specified in the metadata parameter.
+     *         - recipient_metadata[] struct metadata for a single recipient
+     *             - rcpt string the email address of the recipient that the metadata is associated with
+     *             - values array an associated array containing the recipient's unique metadata. If a key exists in both the per-recipient metadata and the global metadata, the per-recipient metadata will be used.
+     *     - attachments array an array of supported attachments to add to the message
+     *         - attachments[] struct a single supported attachment
+     *             - type string the MIME type of the attachment
+     *             - name string the file name of the attachment
+     *             - content string the content of the attachment as a base64-encoded string
+     *     - images array an array of embedded images to add to the message
+     *         - images[] struct a single embedded image
+     *             - type string the MIME type of the image - must start with "image/"
+     *             - name string the Content ID of the image - use <img src="cid:THIS_VALUE"> to reference the image in your HTML content
+     *             - content string the content of the image as a base64-encoded string
+     * @param boolean $async enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+     * @param string $ip_pool the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
+     * @param string $send_at when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately. An additional fee applies for scheduled email, and this feature is only available to accounts with a positive balance.
+     * @return array of structs for each recipient containing the key "email" with the email address, and details of the message status for that recipient
+     *     - return[] struct the sending results for a single recipient
+     *         - email string the email address of the recipient
+     *         - status string the sending status of the recipient - either "sent", "queued", "scheduled", "rejected", or "invalid"
+     *         - reject_reason string the reason for the rejection if the recipient status is "rejected" - one of "hard-bounce", "soft-bounce", "spam", "unsub", "custom", "invalid-sender", "invalid", "test-mode-limit", or "rule"
+     *         - _id string the message's unique id
+     */
+    public function send($message, $async=false, $ip_pool=null, $send_at=null) {
+        $_params = array("message" => $message, "async" => $async, "ip_pool" => $ip_pool, "send_at" => $send_at);
+        return $this->master->call('messages/send', $_params);
+    }
+
+    /**
+     * Send a new transactional message through Mandrill using a template
+     * @param string $template_name the immutable name or slug of a template that exists in the user's account. For backwards-compatibility, the template name may also be used but the immutable slug is preferred.
+     * @param array $template_content an array of template content to send.  Each item in the array should be a struct with two keys - name: the name of the content block to set the content for, and content: the actual content to put into the block
+     *     - template_content[] struct the injection of a single piece of content into a single editable region
+     *         - name string the name of the mc:edit editable region to inject into
+     *         - content string the content to inject
+     * @param struct $message the other information on the message to send - same as /messages/send, but without the html content
+     *     - html string optional full HTML content to be sent if not in template
+     *     - text string optional full text content to be sent
+     *     - subject string the message subject
+     *     - from_email string the sender email address.
+     *     - from_name string optional from name to be used
+     *     - to array an array of recipient information.
+     *         - to[] struct a single recipient's information.
+     *             - email string the email address of the recipient
+     *             - name string the optional display name to use for the recipient
+     *             - type string the header type to use for the recipient, defaults to "to" if not provided
+     *     - headers struct optional extra headers to add to the message (most headers are allowed)
+     *     - important boolean whether or not this message is important, and should be delivered ahead of non-important messages
+     *     - track_opens boolean whether or not to turn on open tracking for the message
+     *     - track_clicks boolean whether or not to turn on click tracking for the message
+     *     - auto_text boolean whether or not to automatically generate a text part for messages that are not given text
+     *     - auto_html boolean whether or not to automatically generate an HTML part for messages that are not given HTML
+     *     - inline_css boolean whether or not to automatically inline all CSS styles provided in the message HTML - only for HTML documents less than 256KB in size
+     *     - url_strip_qs boolean whether or not to strip the query string from URLs when aggregating tracked URL data
+     *     - preserve_recipients boolean whether or not to expose all recipients in to "To" header for each email
+     *     - view_content_link boolean set to false to remove content logging for sensitive emails
+     *     - bcc_address string an optional address to receive an exact copy of each recipient's email
+     *     - tracking_domain string a custom domain to use for tracking opens and clicks instead of mandrillapp.com
+     *     - signing_domain string a custom domain to use for SPF/DKIM signing instead of mandrill (for "via" or "on behalf of" in email clients)
+     *     - return_path_domain string a custom domain to use for the messages's return-path
+     *     - merge boolean whether to evaluate merge tags in the message. Will automatically be set to true if either merge_vars or global_merge_vars are provided.
+     *     - merge_language string the merge tag language to use when evaluating merge tags, either mailchimp or handlebars
+     *     - global_merge_vars array global merge variables to use for all recipients. You can override these per recipient.
+     *         - global_merge_vars[] struct a single global merge variable
+     *             - name string the global merge variable's name. Merge variable names are case-insensitive and may not start with _
+     *             - content mixed the global merge variable's content
+     *     - merge_vars array per-recipient merge variables, which override global merge variables with the same name.
+     *         - merge_vars[] struct per-recipient merge variables
+     *             - rcpt string the email address of the recipient that the merge variables should apply to
+     *             - vars array the recipient's merge variables
+     *                 - vars[] struct a single merge variable
+     *                     - name string the merge variable's name. Merge variable names are case-insensitive and may not start with _
+     *                     - content mixed the merge variable's content
+     *     - tags array an array of string to tag the message with.  Stats are accumulated using tags, though we only store the first 100 we see, so this should not be unique or change frequently.  Tags should be 50 characters or less.  Any tags starting with an underscore are reserved for internal use and will cause errors.
+     *         - tags[] string a single tag - must not start with an underscore
+     *     - subaccount string the unique id of a subaccount for this message - must already exist or will fail with an error
+     *     - google_analytics_domains array an array of strings indicating for which any matching URLs will automatically have Google Analytics parameters appended to their query string automatically.
+     *     - google_analytics_campaign array|string optional string indicating the value to set for the utm_campaign tracking parameter. If this isn't provided the email's from address will be used instead.
+     *     - metadata array metadata an associative array of user metadata. Mandrill will store this metadata and make it available for retrieval. In addition, you can select up to 10 metadata fields to index and make searchable using the Mandrill search api.
+     *     - recipient_metadata array Per-recipient metadata that will override the global values specified in the metadata parameter.
+     *         - recipient_metadata[] struct metadata for a single recipient
+     *             - rcpt string the email address of the recipient that the metadata is associated with
+     *             - values array an associated array containing the recipient's unique metadata. If a key exists in both the per-recipient metadata and the global metadata, the per-recipient metadata will be used.
+     *     - attachments array an array of supported attachments to add to the message
+     *         - attachments[] struct a single supported attachment
+     *             - type string the MIME type of the attachment
+     *             - name string the file name of the attachment
+     *             - content string the content of the attachment as a base64-encoded string
+     *     - images array an array of embedded images to add to the message
+     *         - images[] struct a single embedded image
+     *             - type string the MIME type of the image - must start with "image/"
+     *             - name string the Content ID of the image - use <img src="cid:THIS_VALUE"> to reference the image in your HTML content
+     *             - content string the content of the image as a base64-encoded string
+     * @param boolean $async enable a background sending mode that is optimized for bulk sending. In async mode, messages/send will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+     * @param string $ip_pool the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
+     * @param string $send_at when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately. An additional fee applies for scheduled email, and this feature is only available to accounts with a positive balance.
+     * @return array of structs for each recipient containing the key "email" with the email address, and details of the message status for that recipient
+     *     - return[] struct the sending results for a single recipient
+     *         - email string the email address of the recipient
+     *         - status string the sending status of the recipient - either "sent", "queued", "rejected", or "invalid"
+     *         - reject_reason string the reason for the rejection if the recipient status is "rejected" - one of "hard-bounce", "soft-bounce", "spam", "unsub", "custom", "invalid-sender", "invalid", "test-mode-limit", or "rule"
+     *         - _id string the message's unique id
+     */
+    public function sendTemplate($template_name, $template_content, $message, $async=false, $ip_pool=null, $send_at=null) {
+        $_params = array("template_name" => $template_name, "template_content" => $template_content, "message" => $message, "async" => $async, "ip_pool" => $ip_pool, "send_at" => $send_at);
+        return $this->master->call('messages/send-template', $_params);
+    }
+
+    /**
+     * Search recently sent messages and optionally narrow by date range, tags, senders, and API keys. If no date range is specified, results within the last 7 days are returned. This method may be called up to 20 times per minute. If you need the data more often, you can use <a href="/api/docs/messages.html#method=info">/messages/info.json</a> to get the information for a single message, or <a href="http://help.mandrill.com/entries/21738186-Introduction-to-Webhooks">webhooks</a> to push activity to your own application for querying.
+     * @param string $query <a href="http://help.mandrill.com/entries/22211902">search terms</a> to find matching messages
+     * @param string $date_from start date
+     * @param string $date_to end date
+     * @param array $tags an array of tag names to narrow the search to, will return messages that contain ANY of the tags
+     * @param array $senders an array of sender addresses to narrow the search to, will return messages sent by ANY of the senders
+     * @param array $api_keys an array of API keys to narrow the search to, will return messages sent by ANY of the keys
+     * @param integer $limit the maximum number of results to return, defaults to 100, 1000 is the maximum
+     * @return array of structs for each matching message
+     *     - return[] struct the information for a single matching message
+     *         - ts integer the Unix timestamp from when this message was sent
+     *         - _id string the message's unique id
+     *         - sender string the email address of the sender
+     *         - template string the unique name of the template used, if any
+     *         - subject string the message's subject line
+     *         - email string the recipient email address
+     *         - tags array list of tags on this message
+     *             - tags[] string individual tag on this message
+     *         - opens integer how many times has this message been opened
+     *         - opens_detail array list of individual opens for the message
+     *             - opens_detail[] struct information on an individual open
+     *                 - ts integer the unix timestamp from when the message was opened
+     *                 - ip string the IP address that generated the open
+     *                 - location string the approximate region and country that the opening IP is located
+     *                 - ua string the email client or browser data of the open
+     *         - clicks integer how many times has a link been clicked in this message
+     *         - clicks_detail array list of individual clicks for the message
+     *             - clicks_detail[] struct information on an individual click
+     *                 - ts integer the unix timestamp from when the message was clicked
+     *                 - url string the URL that was clicked on
+     *                 - ip string the IP address that generated the click
+     *                 - location string the approximate region and country that the clicking IP is located
+     *                 - ua string the email client or browser data of the click
+     *         - state string sending status of this message: sent, bounced, rejected
+     *         - metadata struct any custom metadata provided when the message was sent
+     *     - smtp_events array a log of up to 3 smtp events for the message
+     *         - smtp_events[] struct information about a specific smtp event
+     *             - ts integer the Unix timestamp when the event occured
+     *             - type string the message's state as a result of this event
+     *             - diag string the SMTP response from the recipient's server
+     */
+    public function search($query='*', $date_from=null, $date_to=null, $tags=null, $senders=null, $api_keys=null, $limit=100) {
+        $_params = array("query" => $query, "date_from" => $date_from, "date_to" => $date_to, "tags" => $tags, "senders" => $senders, "api_keys" => $api_keys, "limit" => $limit);
+        return $this->master->call('messages/search', $_params);
+    }
+
+    /**
+     * Search the content of recently sent messages and return the aggregated hourly stats for matching messages
+     * @param string $query the search terms to find matching messages for
+     * @param string $date_from start date
+     * @param string $date_to end date
+     * @param array $tags an array of tag names to narrow the search to, will return messages that contain ANY of the tags
+     * @param array $senders an array of sender addresses to narrow the search to, will return messages sent by ANY of the senders
+     * @return array the array of history information
+     *     - return[] struct the stats for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent during the hour
+     *         - hard_bounces integer the number of emails that hard bounced during the hour
+     *         - soft_bounces integer the number of emails that soft bounced during the hour
+     *         - rejects integer the number of emails that were rejected during the hour
+     *         - complaints integer the number of spam complaints received during the hour
+     *         - unsubs integer the number of unsubscribes received during the hour
+     *         - opens integer the number of emails opened during the hour
+     *         - unique_opens integer the number of unique opens generated by messages sent during the hour
+     *         - clicks integer the number of tracked URLs clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated by messages sent during the hour
+     */
+    public function searchTimeSeries($query='*', $date_from=null, $date_to=null, $tags=null, $senders=null) {
+        $_params = array("query" => $query, "date_from" => $date_from, "date_to" => $date_to, "tags" => $tags, "senders" => $senders);
+        return $this->master->call('messages/search-time-series', $_params);
+    }
+
+    /**
+     * Get the information for a single recently sent message
+     * @param string $id the unique id of the message to get - passed as the "_id" field in webhooks, send calls, or search calls
+     * @return struct the information for the message
+     *     - ts integer the Unix timestamp from when this message was sent
+     *     - _id string the message's unique id
+     *     - sender string the email address of the sender
+     *     - template string the unique name of the template used, if any
+     *     - subject string the message's subject line
+     *     - email string the recipient email address
+     *     - tags array list of tags on this message
+     *         - tags[] string individual tag on this message
+     *     - opens integer how many times has this message been opened
+     *     - opens_detail array list of individual opens for the message
+     *         - opens_detail[] struct information on an individual open
+     *             - ts integer the unix timestamp from when the message was opened
+     *             - ip string the IP address that generated the open
+     *             - location string the approximate region and country that the opening IP is located
+     *             - ua string the email client or browser data of the open
+     *     - clicks integer how many times has a link been clicked in this message
+     *     - clicks_detail array list of individual clicks for the message
+     *         - clicks_detail[] struct information on an individual click
+     *             - ts integer the unix timestamp from when the message was clicked
+     *             - url string the URL that was clicked on
+     *             - ip string the IP address that generated the click
+     *             - location string the approximate region and country that the clicking IP is located
+     *             - ua string the email client or browser data of the click
+     *     - state string sending status of this message: sent, bounced, rejected
+     *     - metadata struct any custom metadata provided when the message was sent
+     *     - smtp_events array a log of up to 3 smtp events for the message
+     *         - smtp_events[] struct information about a specific smtp event
+     *             - ts integer the Unix timestamp when the event occured
+     *             - type string the message's state as a result of this event
+     *             - diag string the SMTP response from the recipient's server
+     */
+    public function info($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('messages/info', $_params);
+    }
+
+    /**
+     * Get the full content of a recently sent message
+     * @param string $id the unique id of the message to get - passed as the "_id" field in webhooks, send calls, or search calls
+     * @return struct the content of the message
+     *     - ts integer the Unix timestamp from when this message was sent
+     *     - _id string the message's unique id
+     *     - from_email string the email address of the sender
+     *     - from_name string the alias of the sender (if any)
+     *     - subject string the message's subject line
+     *     - to struct the message recipient's information
+     *         - email string the email address of the recipient
+     *         - name string the alias of the recipient (if any)
+     *     - tags array list of tags on this message
+     *         - tags[] string individual tag on this message
+     *     - headers struct the key-value pairs of the custom MIME headers for the message's main document
+     *     - text string the text part of the message, if any
+     *     - html string the HTML part of the message, if any
+     *     - attachments array an array of any attachments that can be found in the message
+     *         - attachments[] struct information about an individual attachment
+     *             - name string the file name of the attachment
+     *             - type string the MIME type of the attachment
+     *             - content string the content of the attachment as a base64 encoded string
+     */
+    public function content($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('messages/content', $_params);
+    }
+
+    /**
+     * Parse the full MIME document for an email message, returning the content of the message broken into its constituent pieces
+     * @param string $raw_message the full MIME document of an email message
+     * @return struct the parsed message
+     *     - subject string the subject of the message
+     *     - from_email string the email address of the sender
+     *     - from_name string the alias of the sender (if any)
+     *     - to array an array of any recipients in the message
+     *         - to[] struct the information on a single recipient
+     *             - email string the email address of the recipient
+     *             - name string the alias of the recipient (if any)
+     *     - headers struct the key-value pairs of the MIME headers for the message's main document
+     *     - text string the text part of the message, if any
+     *     - html string the HTML part of the message, if any
+     *     - attachments array an array of any attachments that can be found in the message
+     *         - attachments[] struct information about an individual attachment
+     *             - name string the file name of the attachment
+     *             - type string the MIME type of the attachment
+     *             - binary boolean if this is set to true, the attachment is not pure-text, and the content will be base64 encoded
+     *             - content string the content of the attachment as a text string or a base64 encoded string based on the attachment type
+     *     - images array an array of any embedded images that can be found in the message
+     *         - images[] struct information about an individual image
+     *             - name string the Content-ID of the embedded image
+     *             - type string the MIME type of the image
+     *             - content string the content of the image as a base64 encoded string
+     */
+    public function parse($raw_message) {
+        $_params = array("raw_message" => $raw_message);
+        return $this->master->call('messages/parse', $_params);
+    }
+
+    /**
+     * Take a raw MIME document for a message, and send it exactly as if it were sent through Mandrill's SMTP servers
+     * @param string $raw_message the full MIME document of an email message
+     * @param string|null $from_email optionally define the sender address - otherwise we'll use the address found in the provided headers
+     * @param string|null $from_name optionally define the sender alias
+     * @param array|null $to optionally define the recipients to receive the message - otherwise we'll use the To, Cc, and Bcc headers provided in the document
+     *     - to[] string the email address of the recipient
+     * @param boolean $async enable a background sending mode that is optimized for bulk sending. In async mode, messages/sendRaw will immediately return a status of "queued" for every recipient. To handle rejections when sending in async mode, set up a webhook for the 'reject' event. Defaults to false for messages with no more than 10 recipients; messages with more than 10 recipients are always sent asynchronously, regardless of the value of async.
+     * @param string $ip_pool the name of the dedicated ip pool that should be used to send the message. If you do not have any dedicated IPs, this parameter has no effect. If you specify a pool that does not exist, your default pool will be used instead.
+     * @param string $send_at when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately.
+     * @param string $return_path_domain a custom domain to use for the messages's return-path
+     * @return array of structs for each recipient containing the key "email" with the email address, and details of the message status for that recipient
+     *     - return[] struct the sending results for a single recipient
+     *         - email string the email address of the recipient
+     *         - status string the sending status of the recipient - either "sent", "queued", "scheduled", "rejected", or "invalid"
+     *         - reject_reason string the reason for the rejection if the recipient status is "rejected" - one of "hard-bounce", "soft-bounce", "spam", "unsub", "custom", "invalid-sender", "invalid", "test-mode-limit", or "rule"
+     *         - _id string the message's unique id
+     */
+    public function sendRaw($raw_message, $from_email=null, $from_name=null, $to=null, $async=false, $ip_pool=null, $send_at=null, $return_path_domain=null) {
+        $_params = array("raw_message" => $raw_message, "from_email" => $from_email, "from_name" => $from_name, "to" => $to, "async" => $async, "ip_pool" => $ip_pool, "send_at" => $send_at, "return_path_domain" => $return_path_domain);
+        return $this->master->call('messages/send-raw', $_params);
+    }
+
+    /**
+     * Queries your scheduled emails by sender or recipient, or both.
+     * @param string $to an optional recipient address to restrict results to
+     * @return array a list of up to 1000 scheduled emails
+     *     - return[] struct a scheduled email
+     *         - _id string the scheduled message id
+     *         - created_at string the UTC timestamp when the message was created, in YYYY-MM-DD HH:MM:SS format
+     *         - send_at string the UTC timestamp when the message will be sent, in YYYY-MM-DD HH:MM:SS format
+     *         - from_email string the email's sender address
+     *         - to string the email's recipient
+     *         - subject string the email's subject
+     */
+    public function listScheduled($to=null) {
+        $_params = array("to" => $to);
+        return $this->master->call('messages/list-scheduled', $_params);
+    }
+
+    /**
+     * Cancels a scheduled email.
+     * @param string $id a scheduled email id, as returned by any of the messages/send calls or messages/list-scheduled
+     * @return struct information about the scheduled email that was cancelled.
+     *     - _id string the scheduled message id
+     *     - created_at string the UTC timestamp when the message was created, in YYYY-MM-DD HH:MM:SS format
+     *     - send_at string the UTC timestamp when the message will be sent, in YYYY-MM-DD HH:MM:SS format
+     *     - from_email string the email's sender address
+     *     - to string the email's recipient
+     *     - subject string the email's subject
+     */
+    public function cancelScheduled($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('messages/cancel-scheduled', $_params);
+    }
+
+    /**
+     * Reschedules a scheduled email.
+     * @param string $id a scheduled email id, as returned by any of the messages/send calls or messages/list-scheduled
+     * @param string $send_at the new UTC timestamp when the message should sent. Mandrill can't time travel, so if you specify a time in past the message will be sent immediately
+     * @return struct information about the scheduled email that was rescheduled.
+     *     - _id string the scheduled message id
+     *     - created_at string the UTC timestamp when the message was created, in YYYY-MM-DD HH:MM:SS format
+     *     - send_at string the UTC timestamp when the message will be sent, in YYYY-MM-DD HH:MM:SS format
+     *     - from_email string the email's sender address
+     *     - to string the email's recipient
+     *     - subject string the email's subject
+     */
+    public function reschedule($id, $send_at) {
+        $_params = array("id" => $id, "send_at" => $send_at);
+        return $this->master->call('messages/reschedule', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Metadata.php
+++ b/dependencies/mandrill/Mandrill/Metadata.php
@@ -1,0 +1,64 @@
+<?php
+
+class Mandrill_Metadata {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Get the list of custom metadata fields indexed for the account.
+     * @return array the custom metadata fields for the account
+     *     - return[] struct the individual custom metadata field info
+     *         - name string the unique identifier of the metadata field to update
+     *         - state string the current state of the metadata field, one of "active", "delete", or "index"
+     *         - view_template string Mustache template to control how the metadata is rendered in your activity log
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('metadata/list', $_params);
+    }
+
+    /**
+     * Add a new custom metadata field to be indexed for the account.
+     * @param string $name a unique identifier for the metadata field
+     * @param string $view_template optional Mustache template to control how the metadata is rendered in your activity log
+     * @return struct the information saved about the new metadata field
+     *     - name string the unique identifier of the metadata field to update
+     *     - state string the current state of the metadata field, one of "active", "delete", or "index"
+     *     - view_template string Mustache template to control how the metadata is rendered in your activity log
+     */
+    public function add($name, $view_template=null) {
+        $_params = array("name" => $name, "view_template" => $view_template);
+        return $this->master->call('metadata/add', $_params);
+    }
+
+    /**
+     * Update an existing custom metadata field.
+     * @param string $name the unique identifier of the metadata field to update
+     * @param string $view_template optional Mustache template to control how the metadata is rendered in your activity log
+     * @return struct the information for the updated metadata field
+     *     - name string the unique identifier of the metadata field to update
+     *     - state string the current state of the metadata field, one of "active", "delete", or "index"
+     *     - view_template string Mustache template to control how the metadata is rendered in your activity log
+     */
+    public function update($name, $view_template) {
+        $_params = array("name" => $name, "view_template" => $view_template);
+        return $this->master->call('metadata/update', $_params);
+    }
+
+    /**
+     * Delete an existing custom metadata field. Deletion isn't instataneous, and /metadata/list will continue to return the field until the asynchronous deletion process is complete.
+     * @param string $name the unique identifier of the metadata field to update
+     * @return struct the information for the deleted metadata field
+     *     - name string the unique identifier of the metadata field to update
+     *     - state string the current state of the metadata field, one of "active", "delete", or "index"
+     *     - view_template string Mustache template to control how the metadata is rendered in your activity log
+     */
+    public function delete($name) {
+        $_params = array("name" => $name);
+        return $this->master->call('metadata/delete', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Rejects.php
+++ b/dependencies/mandrill/Mandrill/Rejects.php
@@ -1,0 +1,80 @@
+<?php
+
+class Mandrill_Rejects {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Adds an email to your email rejection blacklist. Addresses that you
+add manually will never expire and there is no reputation penalty
+for removing them from your blacklist. Attempting to blacklist an
+address that has been whitelisted will have no effect.
+     * @param string $email an email address to block
+     * @param string $comment an optional comment describing the rejection
+     * @param string $subaccount an optional unique identifier for the subaccount to limit the blacklist entry
+     * @return struct a status object containing the address and the result of the operation
+     *     - email string the email address you provided
+     *     - added boolean whether the operation succeeded
+     */
+    public function add($email, $comment=null, $subaccount=null) {
+        $_params = array("email" => $email, "comment" => $comment, "subaccount" => $subaccount);
+        return $this->master->call('rejects/add', $_params);
+    }
+
+    /**
+     * Retrieves your email rejection blacklist. You can provide an email
+address to limit the results. Returns up to 1000 results. By default,
+entries that have expired are excluded from the results; set
+include_expired to true to include them.
+     * @param string $email an optional email address to search by
+     * @param boolean $include_expired whether to include rejections that have already expired.
+     * @param string $subaccount an optional unique identifier for the subaccount to limit the blacklist
+     * @return array Up to 1000 rejection entries
+     *     - return[] struct the information for each rejection blacklist entry
+     *         - email string the email that is blocked
+     *         - reason string the type of event (hard-bounce, soft-bounce, spam, unsub, custom) that caused this rejection
+     *         - detail string extended details about the event, such as the SMTP diagnostic for bounces or the comment for manually-created rejections
+     *         - created_at string when the email was added to the blacklist
+     *         - last_event_at string the timestamp of the most recent event that either created or renewed this rejection
+     *         - expires_at string when the blacklist entry will expire (this may be in the past)
+     *         - expired boolean whether the blacklist entry has expired
+     *         - sender struct the sender that this blacklist entry applies to, or null if none.
+     *             - address string the sender's email address
+     *             - created_at string the date and time that the sender was first seen by Mandrill as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *             - sent integer the total number of messages sent by this sender
+     *             - hard_bounces integer the total number of hard bounces by messages by this sender
+     *             - soft_bounces integer the total number of soft bounces by messages by this sender
+     *             - rejects integer the total number of rejected messages by this sender
+     *             - complaints integer the total number of spam complaints received for messages by this sender
+     *             - unsubs integer the total number of unsubscribe requests received for messages by this sender
+     *             - opens integer the total number of times messages by this sender have been opened
+     *             - clicks integer the total number of times tracked URLs in messages by this sender have been clicked
+     *             - unique_opens integer the number of unique opens for emails sent for this sender
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender
+     *         - subaccount string the subaccount that this blacklist entry applies to, or null if none.
+     */
+    public function getList($email=null, $include_expired=false, $subaccount=null) {
+        $_params = array("email" => $email, "include_expired" => $include_expired, "subaccount" => $subaccount);
+        return $this->master->call('rejects/list', $_params);
+    }
+
+    /**
+     * Deletes an email rejection. There is no limit to how many rejections
+you can remove from your blacklist, but keep in mind that each deletion
+has an affect on your reputation.
+     * @param string $email an email address
+     * @param string $subaccount an optional unique identifier for the subaccount to limit the blacklist deletion
+     * @return struct a status object containing the address and whether the deletion succeeded.
+     *     - email string the email address that was removed from the blacklist
+     *     - deleted boolean whether the address was deleted successfully.
+     *     - subaccount string the subaccount blacklist that the address was removed from, if any
+     */
+    public function delete($email, $subaccount=null) {
+        $_params = array("email" => $email, "subaccount" => $subaccount);
+        return $this->master->call('rejects/delete', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Senders.php
+++ b/dependencies/mandrill/Mandrill/Senders.php
@@ -1,0 +1,218 @@
+<?php
+
+class Mandrill_Senders {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Return the senders that have tried to use this account.
+     * @return array an array of sender data, one for each sending addresses used by the account
+     *     - return[] struct the information on each sending address in the account
+     *         - address string the sender's email address
+     *         - created_at string the date and time that the sender was first seen by Mandrill as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the total number of messages sent by this sender
+     *         - hard_bounces integer the total number of hard bounces by messages by this sender
+     *         - soft_bounces integer the total number of soft bounces by messages by this sender
+     *         - rejects integer the total number of rejected messages by this sender
+     *         - complaints integer the total number of spam complaints received for messages by this sender
+     *         - unsubs integer the total number of unsubscribe requests received for messages by this sender
+     *         - opens integer the total number of times messages by this sender have been opened
+     *         - clicks integer the total number of times tracked URLs in messages by this sender have been clicked
+     *         - unique_opens integer the number of unique opens for emails sent for this sender
+     *         - unique_clicks integer the number of unique clicks for emails sent for this sender
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('senders/list', $_params);
+    }
+
+    /**
+     * Returns the sender domains that have been added to this account.
+     * @return array an array of sender domain data, one for each sending domain used by the account
+     *     - return[] struct the information on each sending domain for the account
+     *         - domain string the sender domain name
+     *         - created_at string the date and time that the sending domain was first seen as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - spf struct details about the domain's SPF record
+     *             - valid boolean whether the domain's SPF record is valid for use with Mandrill
+     *             - valid_after string when the domain's SPF record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *             - error string an error describing the spf record, or null if the record is correct
+     *         - dkim struct details about the domain's DKIM record
+     *             - valid boolean whether the domain's DKIM record is valid for use with Mandrill
+     *             - valid_after string when the domain's DKIM record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *             - error string an error describing the DKIM record, or null if the record is correct
+     *         - verified_at string if the domain has been verified, this indicates when that verification occurred as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - valid_signing boolean whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail
+     */
+    public function domains() {
+        $_params = array();
+        return $this->master->call('senders/domains', $_params);
+    }
+
+    /**
+     * Adds a sender domain to your account. Sender domains are added automatically as you
+send, but you can use this call to add them ahead of time.
+     * @param string $domain a domain name
+     * @return struct information about the domain
+     *     - domain string the sender domain name
+     *     - created_at string the date and time that the sending domain was first seen as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - spf struct details about the domain's SPF record
+     *         - valid boolean whether the domain's SPF record is valid for use with Mandrill
+     *         - valid_after string when the domain's SPF record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the spf record, or null if the record is correct
+     *     - dkim struct details about the domain's DKIM record
+     *         - valid boolean whether the domain's DKIM record is valid for use with Mandrill
+     *         - valid_after string when the domain's DKIM record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the DKIM record, or null if the record is correct
+     *     - verified_at string if the domain has been verified, this indicates when that verification occurred as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - valid_signing boolean whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail
+     */
+    public function addDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('senders/add-domain', $_params);
+    }
+
+    /**
+     * Checks the SPF and DKIM settings for a domain. If you haven't already added this domain to your
+account, it will be added automatically.
+     * @param string $domain a domain name
+     * @return struct information about the sender domain
+     *     - domain string the sender domain name
+     *     - created_at string the date and time that the sending domain was first seen as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - spf struct details about the domain's SPF record
+     *         - valid boolean whether the domain's SPF record is valid for use with Mandrill
+     *         - valid_after string when the domain's SPF record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the spf record, or null if the record is correct
+     *     - dkim struct details about the domain's DKIM record
+     *         - valid boolean whether the domain's DKIM record is valid for use with Mandrill
+     *         - valid_after string when the domain's DKIM record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the DKIM record, or null if the record is correct
+     *     - verified_at string if the domain has been verified, this indicates when that verification occurred as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - valid_signing boolean whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail
+     */
+    public function checkDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('senders/check-domain', $_params);
+    }
+
+    /**
+     * Sends a verification email in order to verify ownership of a domain.
+Domain verification is an optional step to confirm ownership of a domain. Once a
+domain has been verified in a Mandrill account, other accounts may not have their
+messages signed by that domain unless they also verify the domain. This prevents
+other Mandrill accounts from sending mail signed by your domain.
+     * @param string $domain a domain name at which you can receive email
+     * @param string $mailbox a mailbox at the domain where the verification email should be sent
+     * @return struct information about the verification that was sent
+     *     - status string "sent" indicates that the verification has been sent, "already_verified" indicates that the domain has already been verified with your account
+     *     - domain string the domain name you provided
+     *     - email string the email address the verification email was sent to
+     */
+    public function verifyDomain($domain, $mailbox) {
+        $_params = array("domain" => $domain, "mailbox" => $mailbox);
+        return $this->master->call('senders/verify-domain', $_params);
+    }
+
+    /**
+     * Return more detailed information about a single sender, including aggregates of recent stats
+     * @param string $address the email address of the sender
+     * @return struct the detailed information on the sender
+     *     - address string the sender's email address
+     *     - created_at string the date and time that the sender was first seen by Mandrill as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *     - sent integer the total number of messages sent by this sender
+     *     - hard_bounces integer the total number of hard bounces by messages by this sender
+     *     - soft_bounces integer the total number of soft bounces by messages by this sender
+     *     - rejects integer the total number of rejected messages by this sender
+     *     - complaints integer the total number of spam complaints received for messages by this sender
+     *     - unsubs integer the total number of unsubscribe requests received for messages by this sender
+     *     - opens integer the total number of times messages by this sender have been opened
+     *     - clicks integer the total number of times tracked URLs in messages by this sender have been clicked
+     *     - stats struct an aggregate summary of the sender's sending stats
+     *         - today struct stats for this sender so far today
+     *             - sent integer the number of emails sent for this sender so far today
+     *             - hard_bounces integer the number of emails hard bounced for this sender so far today
+     *             - soft_bounces integer the number of emails soft bounced for this sender so far today
+     *             - rejects integer the number of emails rejected for sending this sender so far today
+     *             - complaints integer the number of spam complaints for this sender so far today
+     *             - unsubs integer the number of unsubscribes for this sender so far today
+     *             - opens integer the number of times emails have been opened for this sender so far today
+     *             - unique_opens integer the number of unique opens for emails sent for this sender so far today
+     *             - clicks integer the number of URLs that have been clicked for this sender so far today
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender so far today
+     *         - last_7_days struct stats for this sender in the last 7 days
+     *             - sent integer the number of emails sent for this sender in the last 7 days
+     *             - hard_bounces integer the number of emails hard bounced for this sender in the last 7 days
+     *             - soft_bounces integer the number of emails soft bounced for this sender in the last 7 days
+     *             - rejects integer the number of emails rejected for sending this sender in the last 7 days
+     *             - complaints integer the number of spam complaints for this sender in the last 7 days
+     *             - unsubs integer the number of unsubscribes for this sender in the last 7 days
+     *             - opens integer the number of times emails have been opened for this sender in the last 7 days
+     *             - unique_opens integer the number of unique opens for emails sent for this sender in the last 7 days
+     *             - clicks integer the number of URLs that have been clicked for this sender in the last 7 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender in the last 7 days
+     *         - last_30_days struct stats for this sender in the last 30 days
+     *             - sent integer the number of emails sent for this sender in the last 30 days
+     *             - hard_bounces integer the number of emails hard bounced for this sender in the last 30 days
+     *             - soft_bounces integer the number of emails soft bounced for this sender in the last 30 days
+     *             - rejects integer the number of emails rejected for sending this sender in the last 30 days
+     *             - complaints integer the number of spam complaints for this sender in the last 30 days
+     *             - unsubs integer the number of unsubscribes for this sender in the last 30 days
+     *             - opens integer the number of times emails have been opened for this sender in the last 30 days
+     *             - unique_opens integer the number of unique opens for emails sent for this sender in the last 30 days
+     *             - clicks integer the number of URLs that have been clicked for this sender in the last 30 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender in the last 30 days
+     *         - last_60_days struct stats for this sender in the last 60 days
+     *             - sent integer the number of emails sent for this sender in the last 60 days
+     *             - hard_bounces integer the number of emails hard bounced for this sender in the last 60 days
+     *             - soft_bounces integer the number of emails soft bounced for this sender in the last 60 days
+     *             - rejects integer the number of emails rejected for sending this sender in the last 60 days
+     *             - complaints integer the number of spam complaints for this sender in the last 60 days
+     *             - unsubs integer the number of unsubscribes for this sender in the last 60 days
+     *             - opens integer the number of times emails have been opened for this sender in the last 60 days
+     *             - unique_opens integer the number of unique opens for emails sent for this sender in the last 60 days
+     *             - clicks integer the number of URLs that have been clicked for this sender in the last 60 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender in the last 60 days
+     *         - last_90_days struct stats for this sender in the last 90 days
+     *             - sent integer the number of emails sent for this sender in the last 90 days
+     *             - hard_bounces integer the number of emails hard bounced for this sender in the last 90 days
+     *             - soft_bounces integer the number of emails soft bounced for this sender in the last 90 days
+     *             - rejects integer the number of emails rejected for sending this sender in the last 90 days
+     *             - complaints integer the number of spam complaints for this sender in the last 90 days
+     *             - unsubs integer the number of unsubscribes for this sender in the last 90 days
+     *             - opens integer the number of times emails have been opened for this sender in the last 90 days
+     *             - unique_opens integer the number of unique opens for emails sent for this sender in the last 90 days
+     *             - clicks integer the number of URLs that have been clicked for this sender in the last 90 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this sender in the last 90 days
+     */
+    public function info($address) {
+        $_params = array("address" => $address);
+        return $this->master->call('senders/info', $_params);
+    }
+
+    /**
+     * Return the recent history (hourly stats for the last 30 days) for a sender
+     * @param string $address the email address of the sender
+     * @return array the array of history information
+     *     - return[] struct the stats for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent during the hour
+     *         - hard_bounces integer the number of emails that hard bounced during the hour
+     *         - soft_bounces integer the number of emails that soft bounced during the hour
+     *         - rejects integer the number of emails that were rejected during the hour
+     *         - complaints integer the number of spam complaints received during the hour
+     *         - opens integer the number of emails opened during the hour
+     *         - unique_opens integer the number of unique opens generated by messages sent during the hour
+     *         - clicks integer the number of tracked URLs clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated by messages sent during the hour
+     */
+    public function timeSeries($address) {
+        $_params = array("address" => $address);
+        return $this->master->call('senders/time-series', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Subaccounts.php
+++ b/dependencies/mandrill/Mandrill/Subaccounts.php
@@ -1,0 +1,171 @@
+<?php
+
+class Mandrill_Subaccounts {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Get the list of subaccounts defined for the account, optionally filtered by a prefix
+     * @param string $q an optional prefix to filter the subaccounts' ids and names
+     * @return array the subaccounts for the account, up to a maximum of 1,000
+     *     - return[] struct the individual subaccount info
+     *         - id string a unique indentifier for the subaccount
+     *         - name string an optional display name for the subaccount
+     *         - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *         - status string the current sending status of the subaccount, one of "active" or "paused"
+     *         - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *         - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *         - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *         - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function getList($q=null) {
+        $_params = array("q" => $q);
+        return $this->master->call('subaccounts/list', $_params);
+    }
+
+    /**
+     * Add a new subaccount
+     * @param string $id a unique identifier for the subaccount to be used in sending calls
+     * @param string $name an optional display name to further identify the subaccount
+     * @param string $notes optional extra text to associate with the subaccount
+     * @param integer $custom_quota an optional manual hourly quota for the subaccount. If not specified, Mandrill will manage this based on reputation
+     * @return struct the information saved about the new subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function add($id, $name=null, $notes=null, $custom_quota=null) {
+        $_params = array("id" => $id, "name" => $name, "notes" => $notes, "custom_quota" => $custom_quota);
+        return $this->master->call('subaccounts/add', $_params);
+    }
+
+    /**
+     * Given the ID of an existing subaccount, return the data about it
+     * @param string $id the unique identifier of the subaccount to query
+     * @return struct the information about the subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - notes string optional extra text to associate with the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     *     - sent_hourly integer the number of emails the subaccount has sent in the last hour
+     *     - hourly_quota integer the current hourly quota for the subaccount, either manual or reputation-based
+     *     - last_30_days struct stats for this subaccount in the last 30 days
+     *         - sent integer the number of emails sent for this subaccount in the last 30 days
+     *         - hard_bounces integer the number of emails hard bounced for this subaccount in the last 30 days
+     *         - soft_bounces integer the number of emails soft bounced for this subaccount in the last 30 days
+     *         - rejects integer the number of emails rejected for sending this subaccount in the last 30 days
+     *         - complaints integer the number of spam complaints for this subaccount in the last 30 days
+     *         - unsubs integer the number of unsbuscribes for this subaccount in the last 30 days
+     *         - opens integer the number of times emails have been opened for this subaccount in the last 30 days
+     *         - unique_opens integer the number of unique opens for emails sent for this subaccount in the last 30 days
+     *         - clicks integer the number of URLs that have been clicked for this subaccount in the last 30 days
+     *         - unique_clicks integer the number of unique clicks for emails sent for this subaccount in the last 30 days
+     */
+    public function info($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('subaccounts/info', $_params);
+    }
+
+    /**
+     * Update an existing subaccount
+     * @param string $id the unique identifier of the subaccount to update
+     * @param string $name an optional display name to further identify the subaccount
+     * @param string $notes optional extra text to associate with the subaccount
+     * @param integer $custom_quota an optional manual hourly quota for the subaccount. If not specified, Mandrill will manage this based on reputation
+     * @return struct the information for the updated subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function update($id, $name=null, $notes=null, $custom_quota=null) {
+        $_params = array("id" => $id, "name" => $name, "notes" => $notes, "custom_quota" => $custom_quota);
+        return $this->master->call('subaccounts/update', $_params);
+    }
+
+    /**
+     * Delete an existing subaccount. Any email related to the subaccount will be saved, but stats will be removed and any future sending calls to this subaccount will fail.
+     * @param string $id the unique identifier of the subaccount to delete
+     * @return struct the information for the deleted subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function delete($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('subaccounts/delete', $_params);
+    }
+
+    /**
+     * Pause a subaccount's sending. Any future emails delivered to this subaccount will be queued for a maximum of 3 days until the subaccount is resumed.
+     * @param string $id the unique identifier of the subaccount to pause
+     * @return struct the information for the paused subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function pause($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('subaccounts/pause', $_params);
+    }
+
+    /**
+     * Resume a paused subaccount's sending
+     * @param string $id the unique identifier of the subaccount to resume
+     * @return struct the information for the resumed subaccount
+     *     - id string a unique indentifier for the subaccount
+     *     - name string an optional display name for the subaccount
+     *     - custom_quota integer an optional manual hourly quota for the subaccount. If not specified, the hourly quota will be managed based on reputation
+     *     - status string the current sending status of the subaccount, one of "active" or "paused"
+     *     - reputation integer the subaccount's current reputation on a scale from 0 to 100
+     *     - created_at string the date and time that the subaccount was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - first_sent_at string the date and time that the subaccount first sent as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - sent_weekly integer the number of emails the subaccount has sent so far this week (weeks start on midnight Monday, UTC)
+     *     - sent_monthly integer the number of emails the subaccount has sent so far this month (months start on midnight of the 1st, UTC)
+     *     - sent_total integer the number of emails the subaccount has sent since it was created
+     */
+    public function resume($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('subaccounts/resume', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Tags.php
+++ b/dependencies/mandrill/Mandrill/Tags.php
@@ -1,0 +1,174 @@
+<?php
+
+class Mandrill_Tags {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Return all of the user-defined tag information
+     * @return array a list of user-defined tags
+     *     - return[] struct a user-defined tag
+     *         - tag string the actual tag as a string
+     *         - reputation integer the tag's current reputation on a scale from 0 to 100.
+     *         - sent integer the total number of messages sent with this tag
+     *         - hard_bounces integer the total number of hard bounces by messages with this tag
+     *         - soft_bounces integer the total number of soft bounces by messages with this tag
+     *         - rejects integer the total number of rejected messages with this tag
+     *         - complaints integer the total number of spam complaints received for messages with this tag
+     *         - unsubs integer the total number of unsubscribe requests received for messages with this tag
+     *         - opens integer the total number of times messages with this tag have been opened
+     *         - clicks integer the total number of times tracked URLs in messages with this tag have been clicked
+     *         - unique_opens integer the number of unique opens for emails sent with this tag
+     *         - unique_clicks integer the number of unique clicks for emails sent with this tag
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('tags/list', $_params);
+    }
+
+    /**
+     * Deletes a tag permanently. Deleting a tag removes the tag from any messages
+that have been sent, and also deletes the tag's stats. There is no way to
+undo this operation, so use it carefully.
+     * @param string $tag a tag name
+     * @return struct the tag that was deleted
+     *     - tag string the actual tag as a string
+     *     - reputation integer the tag's current reputation on a scale from 0 to 100.
+     *     - sent integer the total number of messages sent with this tag
+     *     - hard_bounces integer the total number of hard bounces by messages with this tag
+     *     - soft_bounces integer the total number of soft bounces by messages with this tag
+     *     - rejects integer the total number of rejected messages with this tag
+     *     - complaints integer the total number of spam complaints received for messages with this tag
+     *     - unsubs integer the total number of unsubscribe requests received for messages with this tag
+     *     - opens integer the total number of times messages with this tag have been opened
+     *     - clicks integer the total number of times tracked URLs in messages with this tag have been clicked
+     *     - unique_opens integer the number of unique opens for emails sent with this tag
+     *     - unique_clicks integer the number of unique clicks for emails sent with this tag
+     */
+    public function delete($tag) {
+        $_params = array("tag" => $tag);
+        return $this->master->call('tags/delete', $_params);
+    }
+
+    /**
+     * Return more detailed information about a single tag, including aggregates of recent stats
+     * @param string $tag an existing tag name
+     * @return struct the detailed information on the tag
+     *     - tag string the actual tag as a string
+     *     - sent integer the total number of messages sent with this tag
+     *     - hard_bounces integer the total number of hard bounces by messages with this tag
+     *     - soft_bounces integer the total number of soft bounces by messages with this tag
+     *     - rejects integer the total number of rejected messages with this tag
+     *     - complaints integer the total number of spam complaints received for messages with this tag
+     *     - unsubs integer the total number of unsubscribe requests received for messages with this tag
+     *     - opens integer the total number of times messages with this tag have been opened
+     *     - clicks integer the total number of times tracked URLs in messages with this tag have been clicked
+     *     - stats struct an aggregate summary of the tag's sending stats
+     *         - today struct stats with this tag so far today
+     *             - sent integer the number of emails sent with this tag so far today
+     *             - hard_bounces integer the number of emails hard bounced with this tag so far today
+     *             - soft_bounces integer the number of emails soft bounced with this tag so far today
+     *             - rejects integer the number of emails rejected for sending this tag so far today
+     *             - complaints integer the number of spam complaints with this tag so far today
+     *             - unsubs integer the number of unsubscribes with this tag so far today
+     *             - opens integer the number of times emails have been opened with this tag so far today
+     *             - unique_opens integer the number of unique opens for emails sent with this tag so far today
+     *             - clicks integer the number of URLs that have been clicked with this tag so far today
+     *             - unique_clicks integer the number of unique clicks for emails sent with this tag so far today
+     *         - last_7_days struct stats with this tag in the last 7 days
+     *             - sent integer the number of emails sent with this tag in the last 7 days
+     *             - hard_bounces integer the number of emails hard bounced with this tag in the last 7 days
+     *             - soft_bounces integer the number of emails soft bounced with this tag in the last 7 days
+     *             - rejects integer the number of emails rejected for sending this tag in the last 7 days
+     *             - complaints integer the number of spam complaints with this tag in the last 7 days
+     *             - unsubs integer the number of unsubscribes with this tag in the last 7 days
+     *             - opens integer the number of times emails have been opened with this tag in the last 7 days
+     *             - unique_opens integer the number of unique opens for emails sent with this tag in the last 7 days
+     *             - clicks integer the number of URLs that have been clicked with this tag in the last 7 days
+     *             - unique_clicks integer the number of unique clicks for emails sent with this tag in the last 7 days
+     *         - last_30_days struct stats with this tag in the last 30 days
+     *             - sent integer the number of emails sent with this tag in the last 30 days
+     *             - hard_bounces integer the number of emails hard bounced with this tag in the last 30 days
+     *             - soft_bounces integer the number of emails soft bounced with this tag in the last 30 days
+     *             - rejects integer the number of emails rejected for sending this tag in the last 30 days
+     *             - complaints integer the number of spam complaints with this tag in the last 30 days
+     *             - unsubs integer the number of unsubscribes with this tag in the last 30 days
+     *             - opens integer the number of times emails have been opened with this tag in the last 30 days
+     *             - unique_opens integer the number of unique opens for emails sent with this tag in the last 30 days
+     *             - clicks integer the number of URLs that have been clicked with this tag in the last 30 days
+     *             - unique_clicks integer the number of unique clicks for emails sent with this tag in the last 30 days
+     *         - last_60_days struct stats with this tag in the last 60 days
+     *             - sent integer the number of emails sent with this tag in the last 60 days
+     *             - hard_bounces integer the number of emails hard bounced with this tag in the last 60 days
+     *             - soft_bounces integer the number of emails soft bounced with this tag in the last 60 days
+     *             - rejects integer the number of emails rejected for sending this tag in the last 60 days
+     *             - complaints integer the number of spam complaints with this tag in the last 60 days
+     *             - unsubs integer the number of unsubscribes with this tag in the last 60 days
+     *             - opens integer the number of times emails have been opened with this tag in the last 60 days
+     *             - unique_opens integer the number of unique opens for emails sent with this tag in the last 60 days
+     *             - clicks integer the number of URLs that have been clicked with this tag in the last 60 days
+     *             - unique_clicks integer the number of unique clicks for emails sent with this tag in the last 60 days
+     *         - last_90_days struct stats with this tag in the last 90 days
+     *             - sent integer the number of emails sent with this tag in the last 90 days
+     *             - hard_bounces integer the number of emails hard bounced with this tag in the last 90 days
+     *             - soft_bounces integer the number of emails soft bounced with this tag in the last 90 days
+     *             - rejects integer the number of emails rejected for sending this tag in the last 90 days
+     *             - complaints integer the number of spam complaints with this tag in the last 90 days
+     *             - unsubs integer the number of unsubscribes with this tag in the last 90 days
+     *             - opens integer the number of times emails have been opened with this tag in the last 90 days
+     *             - unique_opens integer the number of unique opens for emails sent with this tag in the last 90 days
+     *             - clicks integer the number of URLs that have been clicked with this tag in the last 90 days
+     *             - unique_clicks integer the number of unique clicks for emails sent with this tag in the last 90 days
+     */
+    public function info($tag) {
+        $_params = array("tag" => $tag);
+        return $this->master->call('tags/info', $_params);
+    }
+
+    /**
+     * Return the recent history (hourly stats for the last 30 days) for a tag
+     * @param string $tag an existing tag name
+     * @return array the array of history information
+     *     - return[] struct the stats for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent during the hour
+     *         - hard_bounces integer the number of emails that hard bounced during the hour
+     *         - soft_bounces integer the number of emails that soft bounced during the hour
+     *         - rejects integer the number of emails that were rejected during the hour
+     *         - complaints integer the number of spam complaints received during the hour
+     *         - unsubs integer the number of unsubscribes received during the hour
+     *         - opens integer the number of emails opened during the hour
+     *         - unique_opens integer the number of unique opens generated by messages sent during the hour
+     *         - clicks integer the number of tracked URLs clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated by messages sent during the hour
+     */
+    public function timeSeries($tag) {
+        $_params = array("tag" => $tag);
+        return $this->master->call('tags/time-series', $_params);
+    }
+
+    /**
+     * Return the recent history (hourly stats for the last 30 days) for all tags
+     * @return array the array of history information
+     *     - return[] struct the stats for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent during the hour
+     *         - hard_bounces integer the number of emails that hard bounced during the hour
+     *         - soft_bounces integer the number of emails that soft bounced during the hour
+     *         - rejects integer the number of emails that were rejected during the hour
+     *         - complaints integer the number of spam complaints received during the hour
+     *         - unsubs integer the number of unsubscribes received during the hour
+     *         - opens integer the number of emails opened during the hour
+     *         - unique_opens integer the number of unique opens generated by messages sent during the hour
+     *         - clicks integer the number of tracked URLs clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated by messages sent during the hour
+     */
+    public function allTimeSeries() {
+        $_params = array();
+        return $this->master->call('tags/all-time-series', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Templates.php
+++ b/dependencies/mandrill/Mandrill/Templates.php
@@ -1,0 +1,235 @@
+<?php
+
+class Mandrill_Templates {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Add a new template
+     * @param string $name the name for the new template - must be unique
+     * @param string $from_email a default sending address for emails sent using this template
+     * @param string $from_name a default from name to be used
+     * @param string $subject a default subject line to be used
+     * @param string $code the HTML code for the template with mc:edit attributes for the editable elements
+     * @param string $text a default text part to be used when sending with this template
+     * @param boolean $publish set to false to add a draft template without publishing
+     * @param array $labels an optional array of up to 10 labels to use for filtering templates
+     *     - labels[] string a single label
+     * @return struct the information saved about the new template
+     *     - slug string the immutable unique code name of the template
+     *     - name string the name of the template
+     *     - labels array the list of labels applied to the template
+     *         - labels[] string a single label
+     *     - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *     - subject string the subject line of the template, if provided - draft version
+     *     - from_email string the default sender address for the template, if provided - draft version
+     *     - from_name string the default sender from name for the template, if provided - draft version
+     *     - text string the default text part of messages sent with the template, if provided - draft version
+     *     - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *     - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *     - publish_subject string the subject line of the template, if provided
+     *     - publish_from_email string the default sender address for the template, if provided
+     *     - publish_from_name string the default sender from name for the template, if provided
+     *     - publish_text string the default text part of messages sent with the template, if provided
+     *     - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *     - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function add($name, $from_email=null, $from_name=null, $subject=null, $code=null, $text=null, $publish=true, $labels=array()) {
+        $_params = array("name" => $name, "from_email" => $from_email, "from_name" => $from_name, "subject" => $subject, "code" => $code, "text" => $text, "publish" => $publish, "labels" => $labels);
+        return $this->master->call('templates/add', $_params);
+    }
+
+    /**
+     * Get the information for an existing template
+     * @param string $name the immutable name of an existing template
+     * @return struct the requested template information
+     *     - slug string the immutable unique code name of the template
+     *     - name string the name of the template
+     *     - labels array the list of labels applied to the template
+     *         - labels[] string a single label
+     *     - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *     - subject string the subject line of the template, if provided - draft version
+     *     - from_email string the default sender address for the template, if provided - draft version
+     *     - from_name string the default sender from name for the template, if provided - draft version
+     *     - text string the default text part of messages sent with the template, if provided - draft version
+     *     - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *     - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *     - publish_subject string the subject line of the template, if provided
+     *     - publish_from_email string the default sender address for the template, if provided
+     *     - publish_from_name string the default sender from name for the template, if provided
+     *     - publish_text string the default text part of messages sent with the template, if provided
+     *     - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *     - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function info($name) {
+        $_params = array("name" => $name);
+        return $this->master->call('templates/info', $_params);
+    }
+
+    /**
+     * Update the code for an existing template. If null is provided for any fields, the values will remain unchanged.
+     * @param string $name the immutable name of an existing template
+     * @param string $from_email the new default sending address
+     * @param string $from_name the new default from name
+     * @param string $subject the new default subject line
+     * @param string $code the new code for the template
+     * @param string $text the new default text part to be used
+     * @param boolean $publish set to false to update the draft version of the template without publishing
+     * @param array $labels an optional array of up to 10 labels to use for filtering templates
+     *     - labels[] string a single label
+     * @return struct the template that was updated
+     *     - slug string the immutable unique code name of the template
+     *     - name string the name of the template
+     *     - labels array the list of labels applied to the template
+     *         - labels[] string a single label
+     *     - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *     - subject string the subject line of the template, if provided - draft version
+     *     - from_email string the default sender address for the template, if provided - draft version
+     *     - from_name string the default sender from name for the template, if provided - draft version
+     *     - text string the default text part of messages sent with the template, if provided - draft version
+     *     - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *     - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *     - publish_subject string the subject line of the template, if provided
+     *     - publish_from_email string the default sender address for the template, if provided
+     *     - publish_from_name string the default sender from name for the template, if provided
+     *     - publish_text string the default text part of messages sent with the template, if provided
+     *     - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *     - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function update($name, $from_email=null, $from_name=null, $subject=null, $code=null, $text=null, $publish=true, $labels=null) {
+        $_params = array("name" => $name, "from_email" => $from_email, "from_name" => $from_name, "subject" => $subject, "code" => $code, "text" => $text, "publish" => $publish, "labels" => $labels);
+        return $this->master->call('templates/update', $_params);
+    }
+
+    /**
+     * Publish the content for the template. Any new messages sent using this template will start using the content that was previously in draft.
+     * @param string $name the immutable name of an existing template
+     * @return struct the template that was published
+     *     - slug string the immutable unique code name of the template
+     *     - name string the name of the template
+     *     - labels array the list of labels applied to the template
+     *         - labels[] string a single label
+     *     - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *     - subject string the subject line of the template, if provided - draft version
+     *     - from_email string the default sender address for the template, if provided - draft version
+     *     - from_name string the default sender from name for the template, if provided - draft version
+     *     - text string the default text part of messages sent with the template, if provided - draft version
+     *     - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *     - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *     - publish_subject string the subject line of the template, if provided
+     *     - publish_from_email string the default sender address for the template, if provided
+     *     - publish_from_name string the default sender from name for the template, if provided
+     *     - publish_text string the default text part of messages sent with the template, if provided
+     *     - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *     - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function publish($name) {
+        $_params = array("name" => $name);
+        return $this->master->call('templates/publish', $_params);
+    }
+
+    /**
+     * Delete a template
+     * @param string $name the immutable name of an existing template
+     * @return struct the template that was deleted
+     *     - slug string the immutable unique code name of the template
+     *     - name string the name of the template
+     *     - labels array the list of labels applied to the template
+     *         - labels[] string a single label
+     *     - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *     - subject string the subject line of the template, if provided - draft version
+     *     - from_email string the default sender address for the template, if provided - draft version
+     *     - from_name string the default sender from name for the template, if provided - draft version
+     *     - text string the default text part of messages sent with the template, if provided - draft version
+     *     - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *     - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *     - publish_subject string the subject line of the template, if provided
+     *     - publish_from_email string the default sender address for the template, if provided
+     *     - publish_from_name string the default sender from name for the template, if provided
+     *     - publish_text string the default text part of messages sent with the template, if provided
+     *     - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *     - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function delete($name) {
+        $_params = array("name" => $name);
+        return $this->master->call('templates/delete', $_params);
+    }
+
+    /**
+     * Return a list of all the templates available to this user
+     * @param string $label an optional label to filter the templates
+     * @return array an array of structs with information about each template
+     *     - return[] struct the information on each template in the account
+     *         - slug string the immutable unique code name of the template
+     *         - name string the name of the template
+     *         - labels array the list of labels applied to the template
+     *             - labels[] string a single label
+     *         - code string the full HTML code of the template, with mc:edit attributes marking the editable elements - draft version
+     *         - subject string the subject line of the template, if provided - draft version
+     *         - from_email string the default sender address for the template, if provided - draft version
+     *         - from_name string the default sender from name for the template, if provided - draft version
+     *         - text string the default text part of messages sent with the template, if provided - draft version
+     *         - publish_name string the same as the template name - kept as a separate field for backwards compatibility
+     *         - publish_code string the full HTML code of the template, with mc:edit attributes marking the editable elements that are available as published, if it has been published
+     *         - publish_subject string the subject line of the template, if provided
+     *         - publish_from_email string the default sender address for the template, if provided
+     *         - publish_from_name string the default sender from name for the template, if provided
+     *         - publish_text string the default text part of messages sent with the template, if provided
+     *         - published_at string the date and time the template was last published as a UTC string in YYYY-MM-DD HH:MM:SS format, or null if it has not been published
+     *         - created_at string the date and time the template was first created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - updated_at string the date and time the template was last modified as a UTC string in YYYY-MM-DD HH:MM:SS format
+     */
+    public function getList($label=null) {
+        $_params = array("label" => $label);
+        return $this->master->call('templates/list', $_params);
+    }
+
+    /**
+     * Return the recent history (hourly stats for the last 30 days) for a template
+     * @param string $name the name of an existing template
+     * @return array the array of history information
+     *     - return[] struct the stats for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent during the hour
+     *         - hard_bounces integer the number of emails that hard bounced during the hour
+     *         - soft_bounces integer the number of emails that soft bounced during the hour
+     *         - rejects integer the number of emails that were rejected during the hour
+     *         - complaints integer the number of spam complaints received during the hour
+     *         - opens integer the number of emails opened during the hour
+     *         - unique_opens integer the number of unique opens generated by messages sent during the hour
+     *         - clicks integer the number of tracked URLs clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated by messages sent during the hour
+     */
+    public function timeSeries($name) {
+        $_params = array("name" => $name);
+        return $this->master->call('templates/time-series', $_params);
+    }
+
+    /**
+     * Inject content and optionally merge fields into a template, returning the HTML that results
+     * @param string $template_name the immutable name of a template that exists in the user's account
+     * @param array $template_content an array of template content to render.  Each item in the array should be a struct with two keys - name: the name of the content block to set the content for, and content: the actual content to put into the block
+     *     - template_content[] struct the injection of a single piece of content into a single editable region
+     *         - name string the name of the mc:edit editable region to inject into
+     *         - content string the content to inject
+     * @param array $merge_vars optional merge variables to use for injecting merge field content.  If this is not provided, no merge fields will be replaced.
+     *     - merge_vars[] struct a single merge variable
+     *         - name string the merge variable's name. Merge variable names are case-insensitive and may not start with _
+     *         - content string the merge variable's content
+     * @return struct the result of rendering the given template with the content and merge field values injected
+     *     - html string the rendered HTML as a string
+     */
+    public function render($template_name, $template_content, $merge_vars=null) {
+        $_params = array("template_name" => $template_name, "template_content" => $template_content, "merge_vars" => $merge_vars);
+        return $this->master->call('templates/render', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Urls.php
+++ b/dependencies/mandrill/Mandrill/Urls.php
@@ -1,0 +1,108 @@
+<?php
+
+class Mandrill_Urls {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Get the 100 most clicked URLs
+     * @return array the 100 most clicked URLs and their stats
+     *     - return[] struct the individual URL stats
+     *         - url string the URL to be tracked
+     *         - sent integer the number of emails that contained the URL
+     *         - clicks integer the number of times the URL has been clicked from a tracked email
+     *         - unique_clicks integer the number of unique emails that have generated clicks for this URL
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('urls/list', $_params);
+    }
+
+    /**
+     * Return the 100 most clicked URLs that match the search query given
+     * @param string $q a search query
+     * @return array the 100 most clicked URLs matching the search query
+     *     - return[] struct the URL matching the query
+     *         - url string the URL to be tracked
+     *         - sent integer the number of emails that contained the URL
+     *         - clicks integer the number of times the URL has been clicked from a tracked email
+     *         - unique_clicks integer the number of unique emails that have generated clicks for this URL
+     */
+    public function search($q) {
+        $_params = array("q" => $q);
+        return $this->master->call('urls/search', $_params);
+    }
+
+    /**
+     * Return the recent history (hourly stats for the last 30 days) for a url
+     * @param string $url an existing URL
+     * @return array the array of history information
+     *     - return[] struct the information for a single hour
+     *         - time string the hour as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the number of emails that were sent with the URL during the hour
+     *         - clicks integer the number of times the URL was clicked during the hour
+     *         - unique_clicks integer the number of unique clicks generated for emails sent with this URL during the hour
+     */
+    public function timeSeries($url) {
+        $_params = array("url" => $url);
+        return $this->master->call('urls/time-series', $_params);
+    }
+
+    /**
+     * Get the list of tracking domains set up for this account
+     * @return array the tracking domains and their status
+     *     - return[] struct the individual tracking domain
+     *         - domain string the tracking domain name
+     *         - created_at string the date and time that the tracking domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - cname struct details about the domain's CNAME record
+     *             - valid boolean whether the domain's CNAME record is valid for use with Mandrill
+     *             - valid_after string when the domain's CNAME record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *             - error string an error describing the CNAME record, or null if the record is correct
+     *         - valid_tracking boolean whether this domain can be used as a tracking domain for email.
+     */
+    public function trackingDomains() {
+        $_params = array();
+        return $this->master->call('urls/tracking-domains', $_params);
+    }
+
+    /**
+     * Add a tracking domain to your account
+     * @param string $domain a domain name
+     * @return struct information about the domain
+     *     - domain string the tracking domain name
+     *     - created_at string the date and time that the tracking domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - cname struct details about the domain's CNAME record
+     *         - valid boolean whether the domain's CNAME record is valid for use with Mandrill
+     *         - valid_after string when the domain's CNAME record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the CNAME record, or null if the record is correct
+     *     - valid_tracking boolean whether this domain can be used as a tracking domain for email.
+     */
+    public function addTrackingDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('urls/add-tracking-domain', $_params);
+    }
+
+    /**
+     * Checks the CNAME settings for a tracking domain. The domain must have been added already with the add-tracking-domain call
+     * @param string $domain an existing tracking domain name
+     * @return struct information about the tracking domain
+     *     - domain string the tracking domain name
+     *     - created_at string the date and time that the tracking domain was added as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_tested_at string when the domain's DNS settings were last tested as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - cname struct details about the domain's CNAME record
+     *         - valid boolean whether the domain's CNAME record is valid for use with Mandrill
+     *         - valid_after string when the domain's CNAME record will be considered valid for use with Mandrill as a UTC string in YYYY-MM-DD HH:MM:SS format. If set, this indicates that the record is valid now, but was previously invalid, and Mandrill will wait until the record's TTL elapses to start using it.
+     *         - error string an error describing the CNAME record, or null if the record is correct
+     *     - valid_tracking boolean whether this domain can be used as a tracking domain for email.
+     */
+    public function checkTrackingDomain($domain) {
+        $_params = array("domain" => $domain);
+        return $this->master->call('urls/check-tracking-domain', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Users.php
+++ b/dependencies/mandrill/Mandrill/Users.php
@@ -1,0 +1,132 @@
+<?php
+
+class Mandrill_Users {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Return the information about the API-connected user
+     * @return struct the user information including username, key, reputation, quota, and historical sending stats
+     *     - username string the username of the user (used for SMTP authentication)
+     *     - created_at string the date and time that the user's Mandrill account was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - public_id string a unique, permanent identifier for this user
+     *     - reputation integer the reputation of the user on a scale from 0 to 100, with 75 generally being a "good" reputation
+     *     - hourly_quota integer the maximum number of emails Mandrill will deliver for this user each hour.  Any emails beyond that will be accepted and queued for later delivery.  Users with higher reputations will have higher hourly quotas
+     *     - backlog integer the number of emails that are queued for delivery due to exceeding your monthly or hourly quotas
+     *     - stats struct an aggregate summary of the account's sending stats
+     *         - today struct stats for this user so far today
+     *             - sent integer the number of emails sent for this user so far today
+     *             - hard_bounces integer the number of emails hard bounced for this user so far today
+     *             - soft_bounces integer the number of emails soft bounced for this user so far today
+     *             - rejects integer the number of emails rejected for sending this user so far today
+     *             - complaints integer the number of spam complaints for this user so far today
+     *             - unsubs integer the number of unsubscribes for this user so far today
+     *             - opens integer the number of times emails have been opened for this user so far today
+     *             - unique_opens integer the number of unique opens for emails sent for this user so far today
+     *             - clicks integer the number of URLs that have been clicked for this user so far today
+     *             - unique_clicks integer the number of unique clicks for emails sent for this user so far today
+     *         - last_7_days struct stats for this user in the last 7 days
+     *             - sent integer the number of emails sent for this user in the last 7 days
+     *             - hard_bounces integer the number of emails hard bounced for this user in the last 7 days
+     *             - soft_bounces integer the number of emails soft bounced for this user in the last 7 days
+     *             - rejects integer the number of emails rejected for sending this user in the last 7 days
+     *             - complaints integer the number of spam complaints for this user in the last 7 days
+     *             - unsubs integer the number of unsubscribes for this user in the last 7 days
+     *             - opens integer the number of times emails have been opened for this user in the last 7 days
+     *             - unique_opens integer the number of unique opens for emails sent for this user in the last 7 days
+     *             - clicks integer the number of URLs that have been clicked for this user in the last 7 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this user in the last 7 days
+     *         - last_30_days struct stats for this user in the last 30 days
+     *             - sent integer the number of emails sent for this user in the last 30 days
+     *             - hard_bounces integer the number of emails hard bounced for this user in the last 30 days
+     *             - soft_bounces integer the number of emails soft bounced for this user in the last 30 days
+     *             - rejects integer the number of emails rejected for sending this user in the last 30 days
+     *             - complaints integer the number of spam complaints for this user in the last 30 days
+     *             - unsubs integer the number of unsubscribes for this user in the last 30 days
+     *             - opens integer the number of times emails have been opened for this user in the last 30 days
+     *             - unique_opens integer the number of unique opens for emails sent for this user in the last 30 days
+     *             - clicks integer the number of URLs that have been clicked for this user in the last 30 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this user in the last 30 days
+     *         - last_60_days struct stats for this user in the last 60 days
+     *             - sent integer the number of emails sent for this user in the last 60 days
+     *             - hard_bounces integer the number of emails hard bounced for this user in the last 60 days
+     *             - soft_bounces integer the number of emails soft bounced for this user in the last 60 days
+     *             - rejects integer the number of emails rejected for sending this user in the last 60 days
+     *             - complaints integer the number of spam complaints for this user in the last 60 days
+     *             - unsubs integer the number of unsubscribes for this user in the last 60 days
+     *             - opens integer the number of times emails have been opened for this user in the last 60 days
+     *             - unique_opens integer the number of unique opens for emails sent for this user in the last 60 days
+     *             - clicks integer the number of URLs that have been clicked for this user in the last 60 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this user in the last 60 days
+     *         - last_90_days struct stats for this user in the last 90 days
+     *             - sent integer the number of emails sent for this user in the last 90 days
+     *             - hard_bounces integer the number of emails hard bounced for this user in the last 90 days
+     *             - soft_bounces integer the number of emails soft bounced for this user in the last 90 days
+     *             - rejects integer the number of emails rejected for sending this user in the last 90 days
+     *             - complaints integer the number of spam complaints for this user in the last 90 days
+     *             - unsubs integer the number of unsubscribes for this user in the last 90 days
+     *             - opens integer the number of times emails have been opened for this user in the last 90 days
+     *             - unique_opens integer the number of unique opens for emails sent for this user in the last 90 days
+     *             - clicks integer the number of URLs that have been clicked for this user in the last 90 days
+     *             - unique_clicks integer the number of unique clicks for emails sent for this user in the last 90 days
+     *         - all_time struct stats for the lifetime of the user's account
+     *             - sent integer the number of emails sent in the lifetime of the user's account
+     *             - hard_bounces integer the number of emails hard bounced in the lifetime of the user's account
+     *             - soft_bounces integer the number of emails soft bounced in the lifetime of the user's account
+     *             - rejects integer the number of emails rejected for sending this user so far today
+     *             - complaints integer the number of spam complaints in the lifetime of the user's account
+     *             - unsubs integer the number of unsubscribes in the lifetime of the user's account
+     *             - opens integer the number of times emails have been opened in the lifetime of the user's account
+     *             - unique_opens integer the number of unique opens for emails sent in the lifetime of the user's account
+     *             - clicks integer the number of URLs that have been clicked in the lifetime of the user's account
+     *             - unique_clicks integer the number of unique clicks for emails sent in the lifetime of the user's account
+     */
+    public function info() {
+        $_params = array();
+        return $this->master->call('users/info', $_params);
+    }
+
+    /**
+     * Validate an API key and respond to a ping
+     * @return string the string "PONG!"
+     */
+    public function ping() {
+        $_params = array();
+        return $this->master->call('users/ping', $_params);
+    }
+
+    /**
+     * Validate an API key and respond to a ping (anal JSON parser version)
+     * @return struct a struct with one key "PING" with a static value "PONG!"
+     */
+    public function ping2() {
+        $_params = array();
+        return $this->master->call('users/ping2', $_params);
+    }
+
+    /**
+     * Return the senders that have tried to use this account, both verified and unverified
+     * @return array an array of sender data, one for each sending addresses used by the account
+     *     - return[] struct the information on each sending address in the account
+     *         - address string the sender's email address
+     *         - created_at string the date and time that the sender was first seen by Mandrill as a UTC date string in YYYY-MM-DD HH:MM:SS format
+     *         - sent integer the total number of messages sent by this sender
+     *         - hard_bounces integer the total number of hard bounces by messages by this sender
+     *         - soft_bounces integer the total number of soft bounces by messages by this sender
+     *         - rejects integer the total number of rejected messages by this sender
+     *         - complaints integer the total number of spam complaints received for messages by this sender
+     *         - unsubs integer the total number of unsubscribe requests received for messages by this sender
+     *         - opens integer the total number of times messages by this sender have been opened
+     *         - clicks integer the total number of times tracked URLs in messages by this sender have been clicked
+     *         - unique_opens integer the number of unique opens for emails sent for this sender
+     *         - unique_clicks integer the number of unique clicks for emails sent for this sender
+     */
+    public function senders() {
+        $_params = array();
+        return $this->master->call('users/senders', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Webhooks.php
+++ b/dependencies/mandrill/Mandrill/Webhooks.php
@@ -1,0 +1,122 @@
+<?php
+
+class Mandrill_Webhooks {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Get the list of all webhooks defined on the account
+     * @return array the webhooks associated with the account
+     *     - return[] struct the individual webhook info
+     *         - id integer a unique integer indentifier for the webhook
+     *         - url string The URL that the event data will be posted to
+     *         - description string a description of the webhook
+     *         - auth_key string the key used to requests for this webhook
+     *         - events array The message events that will be posted to the hook
+     *             - events[] string the individual message event (send, hard_bounce, soft_bounce, open, click, spam, unsub, or reject)
+     *         - created_at string the date and time that the webhook was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - last_sent_at string the date and time that the webhook last successfully received events as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *         - batches_sent integer the number of event batches that have ever been sent to this webhook
+     *         - events_sent integer the total number of events that have ever been sent to this webhook
+     *         - last_error string if we've ever gotten an error trying to post to this webhook, the last error that we've seen
+     */
+    public function getList() {
+        $_params = array();
+        return $this->master->call('webhooks/list', $_params);
+    }
+
+    /**
+     * Add a new webhook
+     * @param string $url the URL to POST batches of events
+     * @param string $description an optional description of the webhook
+     * @param array $events an optional list of events that will be posted to the webhook
+     *     - events[] string the individual event to listen for
+     * @return struct the information saved about the new webhook
+     *     - id integer a unique integer indentifier for the webhook
+     *     - url string The URL that the event data will be posted to
+     *     - description string a description of the webhook
+     *     - auth_key string the key used to requests for this webhook
+     *     - events array The message events that will be posted to the hook
+     *         - events[] string the individual message event (send, hard_bounce, soft_bounce, open, click, spam, unsub, or reject)
+     *     - created_at string the date and time that the webhook was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_sent_at string the date and time that the webhook last successfully received events as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - batches_sent integer the number of event batches that have ever been sent to this webhook
+     *     - events_sent integer the total number of events that have ever been sent to this webhook
+     *     - last_error string if we've ever gotten an error trying to post to this webhook, the last error that we've seen
+     */
+    public function add($url, $description=null, $events=array()) {
+        $_params = array("url" => $url, "description" => $description, "events" => $events);
+        return $this->master->call('webhooks/add', $_params);
+    }
+
+    /**
+     * Given the ID of an existing webhook, return the data about it
+     * @param integer $id the unique identifier of a webhook belonging to this account
+     * @return struct the information about the webhook
+     *     - id integer a unique integer indentifier for the webhook
+     *     - url string The URL that the event data will be posted to
+     *     - description string a description of the webhook
+     *     - auth_key string the key used to requests for this webhook
+     *     - events array The message events that will be posted to the hook
+     *         - events[] string the individual message event (send, hard_bounce, soft_bounce, open, click, spam, unsub, or reject)
+     *     - created_at string the date and time that the webhook was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_sent_at string the date and time that the webhook last successfully received events as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - batches_sent integer the number of event batches that have ever been sent to this webhook
+     *     - events_sent integer the total number of events that have ever been sent to this webhook
+     *     - last_error string if we've ever gotten an error trying to post to this webhook, the last error that we've seen
+     */
+    public function info($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('webhooks/info', $_params);
+    }
+
+    /**
+     * Update an existing webhook
+     * @param integer $id the unique identifier of a webhook belonging to this account
+     * @param string $url the URL to POST batches of events
+     * @param string $description an optional description of the webhook
+     * @param array $events an optional list of events that will be posted to the webhook
+     *     - events[] string the individual event to listen for
+     * @return struct the information for the updated webhook
+     *     - id integer a unique integer indentifier for the webhook
+     *     - url string The URL that the event data will be posted to
+     *     - description string a description of the webhook
+     *     - auth_key string the key used to requests for this webhook
+     *     - events array The message events that will be posted to the hook
+     *         - events[] string the individual message event (send, hard_bounce, soft_bounce, open, click, spam, unsub, or reject)
+     *     - created_at string the date and time that the webhook was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_sent_at string the date and time that the webhook last successfully received events as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - batches_sent integer the number of event batches that have ever been sent to this webhook
+     *     - events_sent integer the total number of events that have ever been sent to this webhook
+     *     - last_error string if we've ever gotten an error trying to post to this webhook, the last error that we've seen
+     */
+    public function update($id, $url, $description=null, $events=array()) {
+        $_params = array("id" => $id, "url" => $url, "description" => $description, "events" => $events);
+        return $this->master->call('webhooks/update', $_params);
+    }
+
+    /**
+     * Delete an existing webhook
+     * @param integer $id the unique identifier of a webhook belonging to this account
+     * @return struct the information for the deleted webhook
+     *     - id integer a unique integer indentifier for the webhook
+     *     - url string The URL that the event data will be posted to
+     *     - description string a description of the webhook
+     *     - auth_key string the key used to requests for this webhook
+     *     - events array The message events that will be posted to the hook
+     *         - events[] string the individual message event (send, hard_bounce, soft_bounce, open, click, spam, unsub, or reject)
+     *     - created_at string the date and time that the webhook was created as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - last_sent_at string the date and time that the webhook last successfully received events as a UTC string in YYYY-MM-DD HH:MM:SS format
+     *     - batches_sent integer the number of event batches that have ever been sent to this webhook
+     *     - events_sent integer the total number of events that have ever been sent to this webhook
+     *     - last_error string if we've ever gotten an error trying to post to this webhook, the last error that we've seen
+     */
+    public function delete($id) {
+        $_params = array("id" => $id);
+        return $this->master->call('webhooks/delete', $_params);
+    }
+
+}
+
+

--- a/dependencies/mandrill/Mandrill/Whitelists.php
+++ b/dependencies/mandrill/Mandrill/Whitelists.php
@@ -1,0 +1,52 @@
+<?php
+
+class Mandrill_Whitelists {
+    public function __construct(Mandrill $master) {
+        $this->master = $master;
+    }
+
+    /**
+     * Adds an email to your email rejection whitelist. If the address is
+currently on your blacklist, that blacklist entry will be removed
+automatically.
+     * @param string $email an email address to add to the whitelist
+     * @param string $comment an optional description of why the email was whitelisted
+     * @return struct a status object containing the address and the result of the operation
+     *     - email string the email address you provided
+     *     - added boolean whether the operation succeeded
+     */
+    public function add($email, $comment=null) {
+        $_params = array("email" => $email, "comment" => $comment);
+        return $this->master->call('whitelists/add', $_params);
+    }
+
+    /**
+     * Retrieves your email rejection whitelist. You can provide an email
+address or search prefix to limit the results. Returns up to 1000 results.
+     * @param string $email an optional email address or prefix to search by
+     * @return array up to 1000 whitelist entries
+     *     - return[] struct the information for each whitelist entry
+     *         - email string the email that is whitelisted
+     *         - detail string a description of why the email was whitelisted
+     *         - created_at string when the email was added to the whitelist
+     */
+    public function getList($email=null) {
+        $_params = array("email" => $email);
+        return $this->master->call('whitelists/list', $_params);
+    }
+
+    /**
+     * Removes an email address from the whitelist.
+     * @param string $email the email address to remove from the whitelist
+     * @return struct a status object containing the address and whether the deletion succeeded
+     *     - email string the email address that was removed from the blacklist
+     *     - deleted boolean whether the address was deleted successfully
+     */
+    public function delete($email) {
+        $_params = array("email" => $email);
+        return $this->master->call('whitelists/delete', $_params);
+    }
+
+}
+
+

--- a/sources/Afup/AFUP_Mail.php
+++ b/sources/Afup/AFUP_Mail.php
@@ -1,0 +1,103 @@
+<?php
+
+require_once dirname(__FILE__) . '/AFUP_Configuration.php';
+require_once dirname(__FILE__) . '/../../dependencies/mandrill/Mandrill.php';
+
+/**
+ * Send emails via Mandrill
+ */
+class AFUP_Mail
+{
+
+    protected $_apiKey;
+    protected $_mandrill;
+    
+    /**
+     * Init the object by getting the Maindrill API key
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        // Get the API key
+        $this->_apiKey = $this->_getConfig()->obtenir('mandrill|key');
+    }
+
+    /**
+     * Retrieve the configuration
+     * @throws Exception
+     * @return AFUP_Configuration
+     */
+    protected function _getConfig()
+    {
+        if (!isset($GLOBALS['AFUP_CONF'])) {
+            throw new Exception("Please include configuration.");
+        }
+
+        return $GLOBALS['AFUP_CONF'];
+    }
+
+    /**
+     * Retrieve Mandrill
+     * @return \Mandrill
+     */
+    public function getMandrill()
+    {
+        if (null === $this->_mandrill) {
+            $this->_mandrill = new Mandrill($this->_apiKey);
+        }
+        return $this->_mandrill;
+    }
+
+    /**
+     * Send an email
+     * @see https://mandrillapp.com/api/docs/messages.php.html#method=send-template
+     *
+     * @param string $template Template identifier
+     * @param array $receiver Receiver's data like ['email' => 'foo@bar.baz', 'name' => 'John Doe']
+     * @param array $data Data to put in the email
+     * @param boolean $async See Mandrill::sendTemplate()
+     * @param string $ipPool See Mandrill::sendTemplate()
+     * @param string $sendAt See Mandrill::sendTemplate()
+     * @return bool TRUE on success, FALSE on failure
+     */
+    public function send($template, array $receiver, array $data = array(), array $parameters = array(), $async = false, $ipPool = null, $sendAt = null)
+    {
+        // Receiver
+        if (!isset($parameters['to'])) {
+            $parameters['to'] = array($receiver);
+        }
+
+        // Blind copy
+        if (!isset($parameters['bcc_address'])) {
+            $parameters['bcc_address'] = $this->_getConfig()->obtenir('mandrill|bcc');
+        }
+
+        // Vars in the content
+        $vars = array();
+        foreach (($receiver + $data) as $key => $value) {
+            $vars[] = array(
+                'name'    => $key,
+                'content' => $value,
+            );
+        }
+
+        // Send the email using template
+        try {
+            $resp = $this->getMandrill()->messages->sendTemplate(
+                $template,
+                $vars,
+                $parameters,
+                $async,
+                $ipPool,
+                $sendAt
+            );
+        } catch(Mandrill_Error $e) {
+            return false;
+        }
+
+        return ($resp[0]['status'] === 'sent');
+    }
+
+}
+


### PR DESCRIPTION
Op !

Ajout de la classe `AFUP_Mandrill` avec une méthode `send` pour envoyer un email avec un template pré-enregistré dans Mandrill.

```php
$mail = new AFUP_Mail();
$receiver = array(
    'email' => 'jab@monsieurbiz.com',
    'name' => 'John'
);
$data = array(
    'varname' => 'content'
);
$parameters = array(
    'subject' => 'Hello World!'
);
if ($mail->send('template-identifier', $receiver, $data, $parameters)) {
    echo "email sent";
} else {
    echo "email not sent";
}
```