### PR TITLE
add call for speakers in en for forum 2015

### DIFF
--- a/htdocs/pages/forumphp2015/appel-a-conferenciers-en.php
+++ b/htdocs/pages/forumphp2015/appel-a-conferenciers-en.php
@@ -12,7 +12,7 @@ $smarty->assign('date_fin_appel_en', strftime('%A %B %d, %Y at %H:%M:%S', $fin_d
 
 setlocale(LC_TIME, 'fr_FR');
 if ((time() - $fin_de_lappel) > 0) {
-    $smarty->display('fin_appel.html');
+    $smarty->display('fin_appel_en.html');
     exit();
 }
 
@@ -142,7 +142,8 @@ if ($formulaire->validate()) {
             $conf->envoyerEmail($$var);
         }
     }
-    $smarty->display('soumission_engistree.html');
+
+    $smarty->display('soumission_enregistree_en.html');
     exit(0);
 }
 $smarty->assign('formulaire', genererFormulaire($formulaire));

--- a/htdocs/templates/forumphp2015/appel-a-conferenciers-en.html
+++ b/htdocs/templates/forumphp2015/appel-a-conferenciers-en.html
@@ -8,46 +8,50 @@
       <a href="appel-a-conferenciers.php" hreflang="en"><img src="{$chemin_template}images/fr.png" alt="Version française"/>&nbsp;Voir la version française de l'appel à conférenciers</a>
     </p>
 
-
-    <p>AFUP, the French Association of PHP Users, is pleased to announce that the 2015 edition of its national event, the Forum PHP, will be held on october 23rd and 24th in Paris.</p>
-
 <p>
-
-Submit a talk or workshop and come share your expertise at the Forum PHP, the annual French rendezvous of all PHP communities, professional and open-source!
-</p>
-
-<h2>"From idea to production, PHP first at the finish line".</h2>
-<p>
-This year the French PHP Association AFUP welcomes you at the Beffroi de Montrouge the 23d and 24th of October 2015 around the motto <strong>"From idea to production, PHP first at the finish line"</strong>
-When one needs to pick the best language for web development, debates are endless: Java is the most stable, Ruby is the most flexible, Python is the cleanest... But in the end PHP delivers first! Isn't that a sign that PHP is the most versatile cumulating qualities at every step of a web project? PHP is a great language to prototype, with a very rich set of great open-source products, a huge developer community, dozens of great tools to help them, a mature professional ecosystem, an ease of administration in production and extreme feedbacks from the biggest websites in the world! These are all the thematics that we would like to address in this 2015 edition of the Forum PHP!
+<strong>Come and join us to present your PHP talk at Forum PHP 2015, our annual conference gathering all PHP and Open Source communities, pros and PHP lovers.</strong>
 </p>
 <p>
-You have an expertise you want to share with the French PHP community? And your subject tackles one of the following thematics? Perfect! Your subject is less clearly related to one particular thematic? Do still submit, we will discuss which thematic is the most appropriate and how to adapt the content for our audience.
+This year, the event will be held at Beffroi de Montrouge, on November, 23rd and 24th.
 </p>
-
+<p>
+<strong>“PHP’s 20th anniversary : 20 years of web, 20 years of global success, 20 years of innovation”</strong>
+</p>
+<p>
+    In 1995, Rasmus Lerdorf started creating PHP. 20 years later, 80% of websites in the world use the language.
+</p>
+<p>
+  PHP is a great language for quick set-up, with a very rich set of great open-source products, a huge developer community, dozens of great tools to help them, a mature professional ecosystem, an ease of administration in production and extreme feedbacks from the biggest websites in the world!
+</p>
+<p>
+  These are all the thematics that we would like to address in this 2015 edition of the Forum PHP!
+</p>
+<p>
+  You have an expertise you want to share with the French PHP community? And your subject tackles one of the following thematics? Perfect! Your subject is less clearly related to one particular thematic? Do still submit, we will discuss which thematic is the most appropriate and how to adapt the content for our audience.
+</p>
 <ul>
   <li>
-    <strong>Agile and Devops in PHP.</strong> Your expertise is related to Design thinking, NoPSD, Scrum, Devops, Lean Startup, industrialisation in the large sense? This thematic is for you, be it a theoretical or experimental approach.
+    <strong>PHP, 20 years of community : </strong>
+    you are contributor or simple user of an OpenSource solution ? This subject allows you to highlight the amazing energy of the PHP community through feedbacks.
   </li>
   <li>
-  <strong>Save time with the PHP opensource ecosystem.</strong>
-  You are expert on interoperable PHP opensource librairies or products? Share your technical and pragmatic experience here!
+    <strong>PHP, 20 years of performance :</strong>
+    you know everything about the core language capabilities : PHP7, HHVM, monitoring, scalability. This topic is yours!
+  </li>
+  <li>
+    <strong>PHP, 20 years of production :</strong>
+    your expertise is about PHP applications hosting, deployment, automatisation ? Either you want to give a concrete feedback or a theoretical point of view; this topic is for you.
+  </li>
+  <li>
+    <strong>PHP, 20 years of quality :</strong>
+    you’re fond of functional, unit testing, static or dynamic code analysis; this subject is wildly dedicated to quality through real-life feedbacks.
+  </li>
+  <li>
+    <strong>PHP, 20 years of collaboration :</strong>
+    you’re managing a team or you’re being part of ? This subject focuses on collaboration amongst dev teams.
+  </li>
+</ul>
 
-  </li>
-  <li>
-  <strong>Solutions for Rapid PHP developers.</strong>
-  You are the editor or a power-user of tools for PHP developers (SaaS, opensource, ...) share why your favourite tool is great with practical examples
-
-  </li>
-  <li>
-    <strong>Production-side PHP optimisation.</strong>
-    You know everything about performances at the heart of the language and in production: php6, hhvm, monitoring, scalability... Share it here
-  </li>
-  <li>
-    <strong>Feedback from high-speed PHP usage.</strong>
-
-You manage millions of visitors, faced with regular load challenges? You have tried with more or less success technical and/or organisational solutions? You are often a pioneer, facing challenges for the first time among your peers and want to share your experience to help feel those behind you less lonely? This thematic is for you!
-</li>
 </article>
 
 <article>

--- a/htdocs/templates/forumphp2015/fin_appel_en.html
+++ b/htdocs/templates/forumphp2015/fin_appel_en.html
@@ -1,0 +1,15 @@
+{include file="entete.html"}
+
+<h2>End of the call for speakers</h2>
+
+<article class="first">
+  <div class="spacer">&nbsp;</div>
+  <div class="article-body">
+
+    <p>Thank you for submitting your session proposal .</p>
+    <p>For all those who submitted the proposals you will receive a response <strong>soon</strong>.</p>
+  </div>
+</article>
+
+{include file="sidebar.html"}
+{include file="pied_de_page.html"}

--- a/htdocs/templates/forumphp2015/soumission_enregistree_en.html
+++ b/htdocs/templates/forumphp2015/soumission_enregistree_en.html
@@ -1,0 +1,15 @@
+{include file="entete.html"}
+
+<h2>Thank you !</h2>
+
+<article class="first">
+  <div class="spacer">&nbsp;</div>
+  <div class="article-body">
+    <p>Your submission was sent, you will receive information soon.</p>
+    <p><a href="index.php">Back to Home</a></p>
+  </div>
+</article>
+
+{include file="sidebar.html"}
+
+{include file="pied_de_page.html"}


### PR DESCRIPTION
Ajout du CFP en anglais pour le Forum PHP 2015 :

- Description en anglais du CFP.
- Message de succès en anglais après validation du formulaire.
- Message de fin de l'appel en anglais.