### PR TITLE
Improve registration error messages

### DIFF
--- a/sources/Afup/AFUP_Base_De_Donnees.php
+++ b/sources/Afup/AFUP_Base_De_Donnees.php
@@ -205,6 +205,15 @@ class AFUP_Base_De_Donnees
     }
 
     /**
+     * Retrieve the last error message
+     * @return string
+     */
+    public function getLastErrorMessage()
+    {
+        return mysqli_error($this->_lien);
+    }
+
+    /**
      * Exécute une requête SQL
      *
      * @param string    $requete    Requête à exécuter
@@ -214,9 +223,6 @@ class AFUP_Base_De_Donnees
     function executer($requete)
     {
         $result = mysqli_query($this->_lien, $requete);
-        //if (!$result) {
-        //    mysql_error();
-        //}
         return $result;
     }
 


### PR DESCRIPTION
close #117 

I just improve the registration process with a "simple" `throwsException` flag.
I made some updates in the `AFUP_Personnes_Physiques` class.

Now we have complete messages. :sunglasses: 