### PR TITLE
Paybox : retour serveur à serveur

### DIFF
--- a/dependencies/paybox/payboxv2.inc
+++ b/dependencies/paybox/payboxv2.inc
@@ -10,6 +10,7 @@ var $cmd;
 var $porteur;
 
 var $effectue;
+var $repondreA;
 var $refuse;
 var $annule;
 var $erreur;
@@ -256,6 +257,38 @@ function check_effectue($effectue) {
 
 function get_effectue() {
     return($this->effectue);
+}
+
+////////////////////////////////////////////////////////////////
+// Gestion de la variable IBS_EFFECTUE
+////////////////////////////////////////////////////////////////
+function set_repondreA($repondreA) {
+    $erreur = Paybox::check_repondreA($repondreA);
+    if (is_string($erreur)) {
+        $this->paybox_erreur('IBS_REPONDRE_A', $erreur);
+        return;
+    }
+    $this->repondreA = $repondreA;
+}
+
+function check_repondreA($repondreA) {
+    if (12 > strlen($repondreA)) {
+        return "L'adresse de la page de retour serveur à serveur est trop courte. "
+        . "Elle doit comporter au moins 12 caractères.";
+    }
+    if (150 < strlen($repondreA)) {
+        return "L'adresse de la page de retour serveur à serveur est trop longue. "
+        . "Elle doit comporter au plus 150 caractères.";
+    }
+    if (preg_match('/[\"\'$]/is', $repondreA)) {
+        return "IBS_EFFECTUE: L'adresse ne doit pas contenir de guillemets "
+        . "ou de signe dollar.";
+    }
+    return true;
+}
+
+function get_repondreA() {
+    return($this->repondreA);
 }
 
 ////////////////////////////////////////////////////////////////
@@ -643,6 +676,14 @@ function paiement() {
         }
         $commande .= "PBX_EFFECTUE=" . escapeshellarg($effectue) . " ";
     }
+    $repondreA = $this->get_repondreA();
+    if ('' != $repondreA) {
+        $erreur = Paybox::check_repondreA($repondreA);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $commande .= "PBX_REPONDRE_A=" . escapeshellarg($repondreA) . " ";
+    }
     $refuse = $this->get_refuse();
     if ('' != $refuse) {
         $erreur = Paybox::check_refuse($refuse);
@@ -726,7 +767,7 @@ function paiement() {
     }
 
 // ca finalise la commande...
-    $commande .= 'IBS_RETOUR="total:M;cmd:R;autorisation:A;transaction:T" ';
+    $commande .= 'IBS_RETOUR="total:M;cmd:R;autorisation:A;transaction:T;status:E" ';
     // ajouter l'operateur @, car on ne veut aucun rapport d'erreur
     $exe = ('' == $this->identifiant) ? 'paybox' : 'payboxV2';
     if ($_SERVER['DOCUMENT_ROOT'] == '/var/www/afup.org/htdocs') {

--- a/htdocs/pages/forumphp2015/inscription.php
+++ b/htdocs/pages/forumphp2015/inscription.php
@@ -383,10 +383,18 @@ if ($formulaire->validate()) {
             $paybox->set_cmd($valeurs['reference']);
             $paybox->set_porteur($valeurs['email_facturation']);
 
-            $paybox->set_effectue('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_effectue.php');
-            $paybox->set_refuse('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_refuse.php');
-            $paybox->set_annule('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_annule.php');
-            $paybox->set_erreur('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_erreur.php');
+            if (isset($_GET['repondre_a']) === true) {
+                $paybox->set_repondreA('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_retour.php');
+                $paybox->set_effectue('http://event.afup.org/inscription-confirmee/');
+                $paybox->set_refuse('http://event.afup.org/inscription-refusee/');
+                $paybox->set_annule('http://event.afup.org/inscription-annulee/');
+                $paybox->set_erreur('http://event.afup.org/erreur-de-paiement/');
+            } else {
+                $paybox->set_effectue('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_effectue.php');
+                $paybox->set_refuse('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_refuse.php');
+                $paybox->set_annule('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_annule.php');
+                $paybox->set_erreur('http://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_erreur.php');
+            }
 
             $paybox->set_wait(50000);
             $paybox->set_boutpi('Régler par carte');

--- a/htdocs/pages/forumphp2015/paybox_retour.php
+++ b/htdocs/pages/forumphp2015/paybox_retour.php
@@ -1,0 +1,79 @@
+<?php
+require_once '../../include/prepend.inc.php';
+require_once dirname(__FILE__) . '/_config.inc.php';
+require_once dirname(__FILE__) . '/../../../sources/Afup/Bootstrap/_Common.php';
+require_once dirname(__FILE__).'/../../../sources/Afup/AFUP_Inscriptions_Forum.php';
+require_once dirname(__FILE__).'/../../../sources/Afup/AFUP_Facturation_Forum.php';
+
+$forum_inscriptions = new AFUP_Inscriptions_Forum($bdd);
+$forum_facturation = new AFUP_Facturation_Forum($bdd);
+
+if (in_array($_SERVER['REMOTE_ADDR'], ['195.101.99.73', '195.101.99.76', '194.2.160.66', '194.2.122.158','195.25.7.146', '195.25.7.166']) === false) {
+    /// Ici sont rencensees les IP indiquées par paybox dans leur doc
+    die('...');
+}
+
+
+$status = $_GET['status'];
+$etat = AFUP_FORUM_ETAT_ERREUR;
+
+if ($status === '00000') {
+    $etat = AFUP_FORUM_ETAT_REGLE;
+} elseif ($status === '00015') {
+    // Designe un paiement deja effectue : on a surement deja eu le retour donc on s'arrete
+    die;
+} elseif ($status === '00117') {
+    $etat = AFUP_FORUM_ETAT_ANNULE;
+} elseif (substr($status, 0, 3) === '001') {
+    $etat = AFUP_FORUM_ETAT_REFUSE;
+}
+
+$forum_inscriptions->modifierEtatInscription($_GET['cmd'], $etat);
+$forum_facturation->enregistrerInformationsTransaction($_GET['cmd'], $_GET['autorisation'], $_GET['transaction']);
+
+if ($etat === AFUP_FORUM_ETAT_REGLE && $forum_facturation->estFacture($_GET['cmd'])) {
+    $facture = $forum_facturation->obtenir($_GET['cmd']);
+
+    // Send the invoice
+    $forum_facturation->envoyerFacture($facture);
+
+    // Send register confirmation
+    $mail = new AFUP_Mail();
+    $registrations = $forum_inscriptions->getRegistrationsByReference($facture['reference']);
+
+    foreach ($registrations as $registration) {
+        $receiver = array(
+            'email' => $registration['email'],
+            'name'  => sprintf('%s %s', $registration['prenom'], $registration['nom']),
+        );
+        $data = $registration;
+
+        if (!$mail->send('confirmation-inscription-forum-php-2015', $receiver, $data)) {
+            $message = <<<HTML
+Impossible d'envoyer la confirmation d'inscription après paiement pour le forum en cours.<br>
+Facture : {$registration['reference']}<br/>
+Contact : {$registration['prenom']} {$registration['nom']} &lt;{$registration['email']}&gt;
+HTML;
+            $mail->sendSimpleMessage(
+                "Impossible d'envoyer la confirmation",
+                $message,
+                array(
+                    array(
+                        'name' => 'Trésorier AFUP',
+                        'email' => 'tresocier@afup.org',
+                    ),
+                    array(
+                        'name' => 'Communication AFUP',
+                        'email' => 'communication@afup.org',
+                    ),
+                )
+            );
+        }
+    }
+
+} else {
+    // Send error to default
+    // @TODO check if this happens or not
+    $mail = new AFUP_Mail();
+    $mail->sendSimpleMessage("Impossible d'envoyer la facture", 'Impossible de facturer la commande ' . htmlspecialchars($_GET['cmd']) . ' après paiement inscription forum.');
+}


### PR DESCRIPTION
Activation du mode de retour serveur à serveur sur présence du paramètre $_GET['repondre_a'] sur la page de post de l'inscription.

Cela permet de faire alors une redirection vers le wordpress plutôt que le site legacy.