### PR TITLE
Correction erreur sql si mobilite reduite non coche

### DIFF
--- a/htdocs/pages/forumphp2015/inscription.php
+++ b/htdocs/pages/forumphp2015/inscription.php
@@ -336,7 +336,7 @@ if ($formulaire->validate()) {
             $valeurs['newsletter_afup'],
             0, //$valeurs['newsletter_nexen'],
             '<tag>'.$tags.'</tags>',
-            $valeurs['mobilite_reduite'.$i],
+            isset($valeurs['mobilite_reduite'.$i]) ? $valeurs['mobilite_reduite'.$i] : 0,
             0 //$valeurs['mail_partenaire']
         );
                 $total += $AFUP_Tarifs_Forum[$valeurs['type_inscription'.$i]];


### PR DESCRIPTION
Le champ mobilite_reduite est obligatoire en base de données.

Si l'utilisateur ne coche pas "Oui" ou "non" sur son inscription, une erreur SQL est générée mais cependant l'inscription peut poursuivre (et donc le paiement, sans trace en base de données).