### PR TITLE
Ajout du lien twitter pour chaque conférencier si celui-ci est connu

### DIFF
--- a/htdocs/templates/forumphp2015/conferenciers.html
+++ b/htdocs/templates/forumphp2015/conferenciers.html
@@ -4,6 +4,9 @@
 		  {$conferencier.prenom} {$conferencier.nom}
   		{if $conferencier.societe}- <span class="societe">{$conferencier.societe}</span>{/if}
 		</h3>
+    {if $conferencier.twitter}
+      <a class="twitter" href="https://twitter.com/{$conferencier.twitter}"><img src="//g.twimg.com/about/feature-corporate/image/followbutton.png" width="89" height="33" alt="Suivre @{$conferencier.twitter}"/></a>
+    {/if}
     <div class="article-body conferencier">
     <div class="photo">
         <img src="{$chemin_template}images/intervenants/{$conferencier.conferencier_id}.jpg" border="0" />


### PR DESCRIPTION
Le champs "twitter" existe déjà en BDD et est déjà gérable depuis le backend administratif.

CSS permettant d'avoir le bouton twitter à coté du nom:

```css
article.conferenciers h3 {
  float: left;
}

article.conferenciers a.twitter {
￼  margin-left: 20px;
}

article.conferenciers .article-body.conferencier {
  clear: both;
}
```

Cela donnerait le rendu suivant:

![twitter](https://cloud.githubusercontent.com/assets/195277/10134656/ab839052-65e7-11e5-8fe8-3403b1068a66.png)
