### PR TITLE
Amelioration de la vue responsive du planning

### DIFF
--- a/htdocs/templates/forumphp2015/forum_planning.html
+++ b/htdocs/templates/forumphp2015/forum_planning.html
@@ -35,6 +35,13 @@
         table.planning_agenda span.heure_fin{
             display:none;
         }
+        table.planning_agenda td, table.planning_agenda tr {
+            -webkit-hyphens: auto;
+            -moz-hyphens: auto;
+            -ms-hyphens: auto;
+            -o-hyphens: auto;
+            hyphens: auto;
+        }
     }
 </style>
 {/literal}


### PR DESCRIPTION
Pour que les mots soient coupés au bon endroit dans [les navigateurs qui le supportent (autrement dit sur iOS)](http://caniuse.com/#feat=css-hyphens)
