### PR TITLE
Fix #135 Suppression de l'annuaire aux membres

### DIFF
--- a/configs/application/pages.php
+++ b/configs/application/pages.php
@@ -48,7 +48,7 @@ $pages = array(
 		    ),
             'membres_liste' => array(
                 'nom' => 'Annuaire',
-                'niveau' => AFUP_DROITS_NIVEAU_MEMBRE,
+                'niveau' => AFUP_DROITS_NIVEAU_ADMINISTRATEUR,
             ),
 		),
     ),


### PR DESCRIPTION
Corrige #135 

cc @hellosct1 et @perrick mais il me semble que cela suffise avant de développer une solution plus évoluée ? Si la liste des personnes doit être publique intra-afup, je ferai un autre commit.