### PR TITLE
correction notice quand il n'y a aucun article en base

### DIFF
--- a/sources/Afup/AFUP_Site.php
+++ b/sources/Afup/AFUP_Site.php
@@ -275,6 +275,11 @@ class AFUP_Site_Articles {
 
         $ajouts = array();
         $elements = $this->bdd->obtenirTous($requete);
+
+        if (false === $elements) {
+            return $ajouts;
+        }
+
         foreach ($elements as $element) {
             $article = new AFUP_Site_Article(null, $this->bdd);
             $article->remplir($element);


### PR DESCRIPTION
Si il n'y avait aucun article en base, un warning était affiché :

```
  Warning: Invalid argument supplied for foreach() in /var/www/afup/sources/Afup/AFUP_Site.php on line 283
```