### PR TITLE
Forum 2016: Modification de la date du repas conférencier

### DIFF
--- a/htdocs/templates/forumphp2016/appel-a-conferenciers.html
+++ b/htdocs/templates/forumphp2016/appel-a-conferenciers.html
@@ -23,7 +23,7 @@
     <li>{'la couverture des dépenses de voyage'|trans}</li>
     <li>{'deux nuits d\'hôtels'|trans}</li>
     <li>{'accès complet aux deux jours de conférences'|trans}</li>
-    <li>{'un dîner avec les membres de l\'AFUP et les sponsors le soir du premier jour.'|trans}</li>
+    <li>{'un dîner avec les membres de l'AFUP et les sponsors la veille du premier jour de conférences.'|trans}</li>
   </ul>
 </div>
 

--- a/translations/cfp.en.xlf
+++ b/translations/cfp.en.xlf
@@ -107,8 +107,8 @@
                 <target>free access to the two days of conferences and workshop</target>
             </trans-unit>
             <trans-unit id="26">
-                <source>un dîner avec les membres de l'AFUP et les sponsors le soir du premier jour.</source>
-                <target>dinner on the first day with AFUP members and partners</target>
+                <source>un dîner avec les membres de l'AFUP et les sponsors la veille du premier jour de conférences.</source>
+                <target>dinner on the eve of the first conference day with AFUP members and partners.</target>
             </trans-unit>
             <trans-unit id="27">
                 <source>Veuillez utiliser le formulaire ci-dessous pour proposer une conférence ou un atelier.</source>


### PR DESCRIPTION
Description de la demande : 
> tout en bas, après le formulaire, il est indiqué "un dîner avec les membres de l'AFUP et les sponsors le soir du premier jour."
> 
> hors c’est la veille du premier jour...

ping @afup/communication 