### PR TITLE
Correction mailing list

### DIFF
--- a/configs/application/config.php.dist
+++ b/configs/application/config.php.dist
@@ -53,6 +53,9 @@ $configuration['sympa']['hote']='localhost';
 $configuration['sympa']['base']='sympa';
 $configuration['sympa']['utilisateur']='sympa';
 $configuration['sympa']['mot_de_passe']='sympa';
+$configuration['sympa']['directory']='http://127.0.0.1/sympa.php';
+$configuration['sympa']['config_url']='http://127.0.0.1/sympa.php';
+$configuration['sympa']['host'] = 'old.afup.org';
 
 $configuration['mandrill']['key'] = '';
 $configuration['mandrill']['bcc'] = 'tresorier@afup.org';

--- a/cron/syncAfupSympa.php
+++ b/cron/syncAfupSympa.php
@@ -1,8 +1,8 @@
 <?php
 use Afup\Site\Association\Assemblee_Generale;
 use Afup\Site\Association\Personnes_Physiques;
-use Afup\Site\Utils\Sympa;
 use Afup\Site\Utils\Base_De_Donnees;
+use Afup\Site\Utils\Sympa;
 
 require_once __DIR__ . '/../sources/Afup/Bootstrap/Cli.php';
 
@@ -25,7 +25,7 @@ $infoMembres = $personnes->obtenirListe('lower(email) as email,nom,prenom', 'ema
 
 echo " - recuperation de toutes les listes Sympa et de leurs lecteurs...\n";
 
-$sympa = new Sympa($sympaBdd, $conf->obtenir('sympa|directory'));
+$sympa = new Sympa($sympaBdd, $conf->obtenir('sympa|config_url'), $conf->obtenir('sympa|host'));
 $tmpListes = $sympa->getAllMailingList();
 $usersSympa = $sympa->getAllUsers();
 

--- a/htdocs/pages/administration/membre_ml.php
+++ b/htdocs/pages/administration/membre_ml.php
@@ -1,8 +1,8 @@
 <?php
 
 // Impossible to access the file itself
-use Afup\Site\Utils\Sympa;
 use Afup\Site\Utils\Base_De_Donnees;
+use Afup\Site\Utils\Sympa;
 
 if (!defined('PAGE_LOADED_USING_INDEX')) {
     trigger_error("Direct access forbidden.", E_USER_ERROR);
@@ -18,7 +18,7 @@ $sympaBdd = new Base_De_Donnees(
     $conf->obtenir('sympa|mot_de_passe')
 );
 
-$sympa = new Sympa($sympaBdd, $conf->obtenir('sympa|config_url'));
+$sympa = new Sympa($sympaBdd, $conf->obtenir('sympa|config_url'), $conf->obtenir('sympa|host'));
 $listes = $sympa->getAllMailingList();
 
 if ($_POST) {

--- a/sources/Afup/Utils/Sympa.php
+++ b/sources/Afup/Utils/Sympa.php
@@ -8,16 +8,22 @@ class Sympa
      */
     private $_bdd;
     private $_configUrl;
+    private $configHost;
 
-    public function __construct($bdd, $configUrl)
+    public function __construct($bdd, $configUrl, $configHost)
     {
         $this->_bdd = $bdd;
         $this->_configUrl = $configUrl;
+        $this->configHost = $configHost;
     }
 
     public function getAllMailingList()
     {
-        return unserialize(file_get_contents($this->_configUrl));
+        $curl = curl_init($this->_configUrl);
+        curl_setopt($curl, CURLOPT_HTTPHEADER, array('Host: ' . $this->configHost));
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+
+        return unserialize($curl);
     }
 
     public function getAllUsers()

--- a/sources/Afup/Utils/Sympa.php
+++ b/sources/Afup/Utils/Sympa.php
@@ -23,7 +23,7 @@ class Sympa
         curl_setopt($curl, CURLOPT_HTTPHEADER, array('Host: ' . $this->configHost));
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 
-        return unserialize($curl);
+        return unserialize(curl_exec($curl));
     }
 
     public function getAllUsers()


### PR DESCRIPTION
La conf actuelle pointe l'ancien domaine old.afup.org. Ce domaine a été coupé, on va donc accéder au serveur via son IP et forcer le host dans le header.