### PR TITLE
Consistent random

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -3,7 +3,7 @@
 'Toutes les conférences à noter': 'All talks to rate'
 'Les nouvelles conférences à noter': 'New talks to rate'
 'Il n''y a plus aucune conférence à noter !': 'There is no more talks to rate !'
-'Les conférences vous sont présentées dans un ordre aléatoire à chaque affichage': 'Talks are displayed in a random order at every display'
+'Les conférences vous sont présentées dans un ordre pseudo-aléatoire consistant pour l''ensemble de votre session.': 'Talks are displayed in a pseudo-random order, consistant for your session.'
 'Les nouvelles conférences': 'New talks'
 'Toutes les conférences': 'All talks'
 'Fermeture du CFP:': 'CFP closure:'

--- a/app/Resources/views/event/vote/liste.html.twig
+++ b/app/Resources/views/event/vote/liste.html.twig
@@ -11,12 +11,22 @@
         {% else %}
             {% include ':event:star.html.twig' %}
 
-            {% for talk in talks %}
+            {% for talk in talks|slice(0, 10) %}
                 {% include 'event/vote/talk.html.twig' %}
             {% endfor %}
 
-            <div style="clear:both; padding-top:200px;">
-                <p>{{ 'Les conférences vous sont présentées dans un ordre aléatoire à chaque affichage'|trans }}</p>
+            <div class="clear">&nbsp;</div>
+            <div class="event-pagination">
+                {% if page > 1 %}
+                    <div class="event-pagination--prev"><a href="{{ url(route, {page: page-1, eventSlug: event.path}) }}"><< {{ 'Page précédente'|trans }}</a></div>
+                {% endif %}
+                {% if numberOfTalks > 10 %}
+                    <div class="event-pagination--next"><a href="{{ url(route, {page: page+1, eventSlug: event.path}) }}">{{ 'Page suivante'|trans }} >></a></div>
+                {% endif %}
+            </div>
+
+            <div style="clear:both; padding-top:50px;">
+                <p>{{ 'Les conférences vous sont présentées dans un ordre pseudo-aléatoire consistant pour l\'ensemble de votre session.'|trans }}</p>
                 <p><i>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="http://www.flaticon.com" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></i></p>
             </div>
         {% endif %}

--- a/app/Resources/views/event/vote/liste.html.twig
+++ b/app/Resources/views/event/vote/liste.html.twig
@@ -18,10 +18,10 @@
             <div class="clear">&nbsp;</div>
             <div class="event-pagination">
                 {% if page > 1 %}
-                    <div class="event-pagination--prev"><a href="{{ url(route, {page: page-1, eventSlug: event.path}) }}"><< {{ 'Page précédente'|trans }}</a></div>
+                    <div class="event-pagination--prev"><a href="{{ url(route, {page: page-1, eventSlug: event.path}) }}">« {{ 'Page précédente'|trans }}</a></div>
                 {% endif %}
                 {% if numberOfTalks > 10 %}
-                    <div class="event-pagination--next"><a href="{{ url(route, {page: page+1, eventSlug: event.path}) }}">{{ 'Page suivante'|trans }} >></a></div>
+                    <div class="event-pagination--next"><a href="{{ url(route, {page: page+1, eventSlug: event.path}) }}">{{ 'Page suivante'|trans }} »</a></div>
                 {% endif %}
             </div>
 

--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -8,11 +8,23 @@ event:
 
 vote_index:
   path: /{eventSlug}/vote
+  defaults: {_controller: AppBundle:Vote:index, all: false, page: 1}
+
+vote_index_paginated:
+  path: /{eventSlug}/vote/{page}
   defaults: {_controller: AppBundle:Vote:index, all: false}
+  requirements:
+    page: '\d+'
 
 vote_all:
   path: /{eventSlug}/vote-all
+  defaults: {_controller: AppBundle:Vote:index, all: true, page: 1}
+
+vote_all_paginated:
+  path: /{eventSlug}/vote-all/{page}
   defaults: {_controller: AppBundle:Vote:index, all: true}
+  requirements:
+    page: '\d+'
 
 vote_new:
   path: /{eventSlug}/vote/new/{talkId}

--- a/htdocs/css/vote.css
+++ b/htdocs/css/vote.css
@@ -1015,3 +1015,31 @@ div.photo-container{
 .cfp--votes ul li{
     margin: 2em 0;
 }
+
+/**************************************
+* Pagination des votes
+***************************************/
+.event-pagination{
+    clear:both;
+    margin: 2em 0;
+}
+
+.event-pagination div{
+    display:inline-block;
+}
+
+.event-pagination div a{
+    background-color:#4c6eaf;
+    border: 1px #3d588b solid;
+    color: white;
+    text-decoration:none;
+    padding: 1.5em;
+}
+
+.event-pagination--prev{
+    float:left;
+}
+
+.event-pagination--next{
+    float:right;
+}

--- a/sources/AppBundle/Controller/VoteController.php
+++ b/sources/AppBundle/Controller/VoteController.php
@@ -20,10 +20,11 @@ class VoteController extends EventBaseController
 
     /**
      * @param $eventSlug
+     * @param int $page
      * @param bool $all if true => show all talks to rate even if already rated by the current user
      * @return Response
      */
-    public function indexAction($eventSlug, $all = false)
+    public function indexAction($eventSlug, $page = 1, $all = false)
     {
         $event = $this->checkEventSlug($eventSlug);
         if ($event->getDateEndCallForPapers() < new \DateTime()) {
@@ -37,9 +38,9 @@ class VoteController extends EventBaseController
 
         // Get a random list of unrated talks
         if ($all === false) {
-            $talks = $talkRepository->getNewTalksToRate($event, $this->getUser());
+            $talks = $talkRepository->getNewTalksToRate($event, $this->getUser(), crc32($this->get('session')->getId()), $page);
         } else {
-            $talks = $talkRepository->getTalksNotRatedByUser($event, $this->getUser());
+            $talks = $talkRepository->getAllTalksAndRatingsForUser($event, $this->getUser(), crc32($this->get('session')->getId()), $page);
         }
 
         $vote = new Vote();
@@ -65,6 +66,8 @@ class VoteController extends EventBaseController
             'event/vote/liste.html.twig',
             [
                 'numberOfTalks' => $talks->count(),
+                'route' => ($all === true ? 'vote_all_paginated':'vote_index_paginated'),
+                'page' => $page,
                 'talks' => $forms(),
                 'event' => $event,
                 'all' => $all


### PR DESCRIPTION
On gère la pagination en récupérant 11 résultats par page au lieu de 10 => pas besoin de connaitre le nombre total de résultats pour afficher le lien vers la page suivante

On utilise l'id de la session (transformée en entier grâce à crc32) pour créer un ordre aléatoire "consistant" pour toute la session mais unique par utilisateur.