### PR TITLE
On delete les anciennes photos de comptes déjà sauvegardés

### DIFF
--- a/sources/AppBundle/CFP/PhotoStorage.php
+++ b/sources/AppBundle/CFP/PhotoStorage.php
@@ -39,7 +39,7 @@ class PhotoStorage
         }
 
         // delete all formats
-        if ($speaker->getId() === null) {
+        if ($speaker->getId() !== null) {
             foreach (self::FORMAT as $format => $sizes) {
                 $files = glob($this->basePath . '/' . $speaker->getEventId() . '/' . $format . '/' . $speaker->getId() . '.*');
                 foreach ($files as $file) {


### PR DESCRIPTION
Evidemment le test était à l'envers, les comptes qui n'ont pas d'ID n'ont pas encore de photo associée. 