### PR TITLE
Ajout d'une page de détail des conférences

### DIFF
--- a/app/Resources/views/event/base.html.twig
+++ b/app/Resources/views/event/base.html.twig
@@ -4,6 +4,7 @@
 
 {% block stylesheets %}
     {{ parent() }}
+    <link rel="stylesheet" href="/css/grid.css">
     <link rel="stylesheet" href="/css/vote.css">
 {% endblock %}
 

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -51,7 +51,7 @@
                         {% endif %}
 
                         {% if talk.hasJoindinId %}
-                            <a class="talk-list-button" href="{{ talk.getJoindinUrl }}"><i class="fa fa-comments"></i> Fiche joinin</a>
+                            <a class="talk-list-button" href="{{ talk.getJoindinUrl }}"><i class="fa fa-comments"></i> Fiche joindIn</a>
                         {% endif %}
                     </div>
                 </div>

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -1,0 +1,108 @@
+{% extends ':site:base.html.twig' %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="/css/grid.css">
+    <link rel="stylesheet" href="/css/talk/list.css">
+    <link rel="stylesheet" href="/css/talk/show.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+{% endblock %}
+
+{% block metas %}
+    {{ parent() }}
+{% endblock %}
+
+{% block content %}
+    <div class="mw1400p center" id="container">
+        <div class="container">
+            <div class="col-md-12 talk-title">
+                <h1>{{ talk.title }}<h1>
+            </div>
+        </div>
+
+        <div class="container">
+            <div class="col-md-{% if talk.hasYoutubeId %}8{% else %}12"{% endif %}">
+                <div class="container">
+                    <div class="col-md-12">
+                        <h2>Description</h2>
+                        {{ talk.abstract|raw }}
+                    </div>
+                </div>
+                <div class="container talk-date-container">
+                    <div class="col-md-12">
+                        Conférence donnée lors du {{ event.title }}, ayant eut lieu les {{ event.dateStart|date('d/m/Y') }} et {{ event.dateEnd|date('d/m/Y') }}.
+                    </div>
+                </div>
+
+                {% if talk.hasSlidesUrl or talk.hasBlogPostUrl or talk.hasJoindinId %}
+                <div class="container">
+                    <div class="col-md-12">
+                        <h2>Informations complémentaires</h2>
+                        {% if talk.hasSlidesUrl %}
+                            <a class="talk-list-button" href="{{ talk.getSlidesurl }}"><i class="fa fa-slideshare"></i> Slides</a>
+                        {% endif %}
+
+                        {% if talk.hasBlogPostUrl %}
+                            <a class="talk-list-button" href="{{ talk.getBlogPostUrl }}"><i class="fa fa-rss"></i> Article</a>
+                        {% endif %}
+
+                        {% if talk.hasJoindinId %}
+                            <a class="talk-list-button" href="{{ talk.getJoindinUrl }}"><i class="fa fa-comments"></i> Fiche joinin</a>
+                        {% endif %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+            {% if talk.hasYoutubeId %}
+            <div class="col-md-4">
+                <h2>Vidéo</h2>
+                <div class="responsive-video-container">
+                    <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ talk.youtubeId }}" frameborder="0" allowfullscreen></iframe>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+
+        <div class="container">
+            <div class="col-md-12">
+                <div class="container speaker-title-container">
+                    <div class="col-md-12">
+                        <h2>{% if speakers|length > 1 %}Les speakers{% else %}Le speaker{% endif %}</h2>
+                    </div>
+                </div>
+
+                {% for speaker in speakers %}
+                    <div class="container speaker-name-container">
+                        <div class="col-md-12">
+                            <h3 class="speaker-name">
+                            {{ speaker.label }}
+                            </h3>
+                            {% if speaker.twitter %}
+                                <a href="http://twitter.com/{{ speaker.twitter }}">
+                                    <i class="fa fa-twitter"></i>
+                                </a>
+                            {% endif %}
+                        </div>
+                    </div>
+                    <div class="container">
+                        <div class="col-md-2">
+                            <img src="{{ photo_storage.getUrl(speaker) }}" class="speaker-photo" />
+                        </div>
+                        <div class="col-md-10">
+                            {{ speaker.biography }}
+                            <div class="speaker-talks-link">
+                                <a href="{{ url('talks_list', {"dFR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous les talks de ce speaker.</a>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+
+            </div>
+        </div>
+
+    </div>
+{% endblock %}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -36,6 +36,8 @@ framework:
 twig:
     debug:            "%kernel.debug%"
     strict_variables: "%kernel.debug%"
+    globals:
+      photo_storage: "@app.photo_storage"
 
 ting:
     connections:

--- a/app/config/routing/talks.yml
+++ b/app/config/routing/talks.yml
@@ -1,3 +1,7 @@
 talks_list:
   path: /
   defaults: {_controller: AppBundle:Talks:list}
+
+talks_show:
+  path: /{slug}
+  defaults: {_controller: AppBundle:Talks:show}

--- a/app/config/routing/talks.yml
+++ b/app/config/routing/talks.yml
@@ -3,5 +3,5 @@ talks_list:
   defaults: {_controller: AppBundle:Talks:list}
 
 talks_show:
-  path: /{slug}
+  path: /{id}-{slug}
   defaults: {_controller: AppBundle:Talks:show}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -88,6 +88,10 @@ services:
         class: AppBundle\Slack\MessageFactory
         autowire: true
 
+    app.slack_notifier:
+        class: AppBundle\Notifier\SlackNotifier
+        arguments: ["%slack_url%", "@app.slack_message_factory", "@jms_serializer.serializer"]
+
     app.algolia_client:
         class: AlgoliaSearch\Client
         arguments: [%algolia_app_id%, %algolia_backend_api_key%]

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "knpuniversity/oauth2-client-bundle": "^1.4",
     "twig/extensions": "^1.4",
     "jms/serializer-bundle": "^1.1",
-    "algolia/algoliasearch-client-php": "^1.12"
+    "algolia/algoliasearch-client-php": "^1.12",
+    "cocur/slugify": "^2.3"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a07a9f71fec6c79c089a78480bfa767b",
-    "content-hash": "e40e3a2aad58df4cac3086201e962eab",
+    "hash": "c30b25125e94d9127e828e68e655d34e",
+    "content-hash": "1d733ef1bc1e685297c87625d4466028",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -202,6 +202,70 @@
             ],
             "description": "Symfony 2 bundle for ccmbenchmark/ting",
             "time": "2016-03-21 16:17:44"
+        },
+        {
+            "name": "cocur/slugify",
+            "version": "v2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cocur/slugify.git",
+                "reference": "57a00e06a382928e350cc7bbb13b19f1b8f4e73a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cocur/slugify/zipball/57a00e06a382928e350cc7bbb13b19f1b8f4e73a",
+                "reference": "57a00e06a382928e350cc7bbb13b19f1b8f4e73a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "require-dev": {
+                "laravel/framework": "~5.1",
+                "latte/latte": "~2.2",
+                "league/container": "^2.2.0",
+                "mikey179/vfsstream": "~1.6",
+                "mockery/mockery": "~0.9",
+                "nette/di": "~2.2",
+                "phpunit/phpunit": "~4.8|~5.2",
+                "pimple/pimple": "~1.1",
+                "plumphp/plum": "~0.1",
+                "silex/silex": "~1.3",
+                "symfony/config": "~2.4|~3.0",
+                "symfony/dependency-injection": "~2.4|~3.0",
+                "symfony/http-kernel": "~2.4|~3.0",
+                "twig/twig": "~1.12",
+                "zendframework/zend-modulemanager": "~2.2",
+                "zendframework/zend-servicemanager": "~2.2",
+                "zendframework/zend-view": "~2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cocur\\Slugify\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ivo Bathke",
+                    "email": "ivo.bathke@gmail.com"
+                },
+                {
+                    "name": "Florian Eckerstorfer",
+                    "email": "florian@eckerstorfer.co",
+                    "homepage": "https://florian.ec"
+                }
+            ],
+            "description": "Converts a string into a slug.",
+            "keywords": [
+                "slug",
+                "slugify"
+            ],
+            "time": "2016-08-09 20:10:17"
         },
         {
             "name": "doctrine/annotations",

--- a/htdocs/css/grid.css
+++ b/htdocs/css/grid.css
@@ -1,0 +1,55 @@
+div.container {
+    padding: 10px;
+}
+
+div.container, div.container * {
+    box-sizing: border-box;
+}
+
+div.container:before,
+div.container:after {
+    content: " ";
+    display: table;
+}
+
+div.container:after {
+    clear: both;
+}
+
+@media (min-width: 992px) {
+    .col-md-12 {
+        width: 100%;
+    }
+    .col-md-10 {
+        width: 83.333333333%;
+    }
+    .col-md-8 {
+        width: 66.66667%;
+    }
+    .col-md-4 {
+        width: 33.33333%;
+    }
+    .col-md-2 {
+        width: 16.666666667%;
+    }
+
+    .col-md-2,
+    .col-md-4,
+    .col-md-8,
+    .col-md-10,
+    .col-md-12 {
+        float: left;
+    }
+}
+
+.col-md-2,
+.col-md-4,
+.col-md-8,
+.col-md-10,
+.col-md-12
+{
+    position: relative;
+    min-height: 1px;
+    padding-left: 15px;
+    padding-right: 15px;
+}

--- a/htdocs/css/talk/show.css
+++ b/htdocs/css/talk/show.css
@@ -1,0 +1,55 @@
+/* cf http://alistapart.com/article/creating-intrinsic-ratios-for-video
+         et http://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php */
+.responsive-video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 */
+    padding-top: 25px;
+    height: 0;
+}
+.responsive-video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+div.speaker-name-container {
+    padding: 0 10px 10px 10px;
+}
+
+.speaker-name-container .fa-twitter {
+    padding: 10px;
+    font-size: 1.5em;
+}
+
+.speaker-name {
+    display: inline-block;
+}
+
+.speaker-title-container {
+    padding: 10px 10px 0 10px;
+    margin: 0
+}
+
+.speaker-title-container h2 {
+    margin: 0;
+}
+
+.talk-title h1 {
+    font-size: 2.5em;
+}
+
+.talk-date-container {
+    margin: 0 0 10px 0;
+    font-style: italic;
+}
+
+.speaker-talks-link {
+    text-align: right;
+    margin: 15px 0 0 0
+}
+
+.speaker-photo {
+    max-width: 100%;
+}

--- a/htdocs/css/vote.css
+++ b/htdocs/css/vote.css
@@ -750,32 +750,6 @@ h1, h2{
     border-bottom: 1px solid #eee;
 }
 
-/***********
-* Layout
-************/
-div.container {
-    padding: 10px;
-}
-
-@media (min-width: 992px) {
-    .col-md-8 {
-        width: 66.66667%;
-    }
-    .col-md-4 {
-        width: 33.33333%;
-    }
-    .col-md-4, .col-md-8{
-        float: left;
-    }
-}
-
-.col-md-4,.col-md-8{
-    position: relative;
-    min-height: 1px;
-    padding-left: 15px;
-    padding-right: 15px;
-}
-
 a {
     color: #4c6eaf;
     text-decoration: none;

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -50,7 +50,7 @@ search.addWidget(
 );
 
 
-var refienmentItemTemplate = function(data) {
+var refinementItemTemplate = function(data) {
     var content = "";
     content += '<input type="checkbox" ';
     if (data.isRefined) {
@@ -77,7 +77,7 @@ search.addWidget(
         },
         autoHideContainer: false,
         templates: {
-            item: refienmentItemTemplate
+            item: refinementItemTemplate
         }
     })
 );
@@ -92,7 +92,7 @@ search.addWidget(
         },
         autoHideContainer: false,
         templates: {
-            item: refienmentItemTemplate
+            item: refinementItemTemplate
         }
     })
 );
@@ -103,7 +103,7 @@ search.addWidget(
         attributeName: 'event.title',
         templates: {
             header: "Événement",
-            item: refienmentItemTemplate
+            item: refinementItemTemplate
         }
     })
 );
@@ -114,7 +114,7 @@ search.addWidget(
         attributeName: 'speakers.label',
         templates: {
             header: "Conférencier",
-            item: refienmentItemTemplate
+            item: refinementItemTemplate
         }
     })
 );

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -21,7 +21,7 @@ search.addWidget(
         templates: {
             empty: "Pas de résultat",
             item: function(data) {
-                var content = '<div class="conf-title"><a href="/talks/' + data.slug + '">' + data.title + '</a> ' + '<span class="talk-list-event-label-badge">' + data.event.title + '</span></div>'
+                var content = '<div class="conf-title"><a href="/talks/' + data.url_key + '">' + data.title + '</a> ' + '<span class="talk-list-event-label-badge">' + data.event.title + '</span></div>'
                         + ' <i>' + data.speakers_label + '</i>'
                         + '<div style="text-align:right">'
                     ;

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -21,7 +21,7 @@ search.addWidget(
         templates: {
             empty: "Pas de résultat",
             item: function(data) {
-                var content = '<div class="conf-title">' + data.title + ' ' + '<span class="talk-list-event-label-badge">' + data.event.title + '</span></div>'
+                var content = '<div class="conf-title"><a href="/talks/' + data.slug + '">' + data.title + '</a> ' + '<span class="talk-list-event-label-badge">' + data.event.title + '</span></div>'
                         + ' <i>' + data.speakers_label + '</i>'
                         + '<div style="text-align:right">'
                     ;

--- a/sources/AppBundle/Controller/TalksController.php
+++ b/sources/AppBundle/Controller/TalksController.php
@@ -21,14 +21,13 @@ class TalksController extends SiteBaseController
     }
 
     /**
+     * @param integer $id
      * @param string $slug
      *
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function showAction($slug)
+    public function showAction($id, $slug)
     {
-        list($id) = explode('-', $slug, 2);
-
         $talk = $this->get('ting')->get(TalkRepository::class)->get($id);
 
         if (null === $talk || $talk->getSlug() != $slug) {

--- a/sources/AppBundle/Controller/TalksController.php
+++ b/sources/AppBundle/Controller/TalksController.php
@@ -2,6 +2,11 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Event\Model\Repository\EventRepository;
+use AppBundle\Event\Model\Repository\PlanningRepository;
+use AppBundle\Event\Model\Repository\SpeakerRepository;
+use AppBundle\Event\Model\Repository\TalkRepository;
+
 class TalksController extends SiteBaseController
 {
     public function listAction()
@@ -11,6 +16,35 @@ class TalksController extends SiteBaseController
             [
                 'algolia_app_id' => $this->getParameter('algolia_app_id'),
                 'algolia_api_key' => $this->getParameter('algolia_frontend_api_key'),
+            ]
+        );
+    }
+
+    /**
+     * @param string $slug
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     */
+    public function showAction($slug)
+    {
+        list($id) = explode('-', $slug, 2);
+
+        $talk = $this->get('ting')->get(TalkRepository::class)->get($id);
+
+        if (null === $talk || $talk->getSlug() != $slug) {
+            throw $this->createNotFoundException();
+        }
+
+        $speakers = $this->get('ting')->get(SpeakerRepository::class)->getSpeakersByTalk($talk);
+        $planning = $this->get('ting')->get(PlanningRepository::class)->getByTalk($talk);
+        $event = $this->get('ting')->get(EventRepository::class)->get($planning->getEventId());
+
+        return $this->render(
+            ':site:talks/show.html.twig',
+            [
+                'talk' => $talk,
+                'event' => $event,
+                'speakers' => $speakers,
             ]
         );
     }

--- a/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
@@ -3,7 +3,9 @@
 namespace AppBundle\Event\Model\Repository;
 
 use AppBundle\Event\Model\Planning;
+use AppBundle\Event\Model\Talk;
 use CCMBenchmark\Ting\Driver\Mysqli\Serializer\Boolean;
+use CCMBenchmark\Ting\Repository\HydratorSingleObject;
 use CCMBenchmark\Ting\Repository\Metadata;
 use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
@@ -11,6 +13,27 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
 class PlanningRepository extends Repository implements MetadataInitializer
 {
+    /**
+     * @param Talk $talk
+     *
+     * @return mixed|null
+     */
+    public function getByTalk(Talk $talk)
+    {
+        $query = $this
+            ->getQuery('SELECT * FROM afup_forum_planning WHERE id_session= :id_session LIMIT 1')
+        ;
+
+        $query->setParams(['id_session' => $talk->getId()]);
+
+        $plannings = $query->query($this->getCollection(new HydratorSingleObject()));
+        if ($plannings->count() === 0) {
+            return null;
+        }
+
+        return $plannings->first();
+    }
+
     /**
      * @param SerializerFactoryInterface $serializerFactory
      * @param array $options

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -430,6 +430,6 @@ class Talk implements NotifyPropertyInterface
     public function getSlug()
     {
         $slugify = new Slugify();
-        return $slugify->slugify($this->getId() . '-' . $this->getTitle());
+        return $slugify->slugify($this->getTitle());
     }
 }

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -4,6 +4,7 @@ namespace AppBundle\Event\Model;
 
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
+use Cocur\Slugify\Slugify;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class Talk implements NotifyPropertyInterface
@@ -421,5 +422,14 @@ class Talk implements NotifyPropertyInterface
     public function hasBlogPostUrl()
     {
         return null !== $this->getBlogPostUrl();
+    }
+
+    /**
+     * @return string
+     */
+    public function getSlug()
+    {
+        $slugify = new Slugify();
+        return $slugify->slugify($this->getId() . '-' . $this->getTitle());
     }
 }

--- a/sources/AppBundle/Indexation/Talks/Transformer.php
+++ b/sources/AppBundle/Indexation/Talks/Transformer.php
@@ -22,7 +22,7 @@ class Transformer
         $item = [
             'planning_id' => $planning->getId(),
             'talk_id' => $talk->getId(),
-            'slug' => $talk->getSlug(),
+            'url_key' => $talk->getId() . '-' . $talk->getSlug(),
             'title' => $talk->getTitle(),
             'event' => [
                 'id' => $event->getId(),

--- a/sources/AppBundle/Indexation/Talks/Transformer.php
+++ b/sources/AppBundle/Indexation/Talks/Transformer.php
@@ -22,6 +22,7 @@ class Transformer
         $item = [
             'planning_id' => $planning->getId(),
             'talk_id' => $talk->getId(),
+            'slug' => $talk->getSlug(),
             'title' => $talk->getTitle(),
             'event' => [
                 'id' => $event->getId(),

--- a/tests/units/AppBundle/Event/Model/Talk/Talk.php
+++ b/tests/units/AppBundle/Event/Model/Talk/Talk.php
@@ -19,4 +19,18 @@ class Talk extends \atoum
         ;
     }
 
+    public function testSlug()
+    {
+        $this
+            ->given($talk = new TestedClass())
+            ->and(
+                $talk->setId(1007),
+                $talk->setTitle('Utiliser PostgreSQL en 2014')
+            )
+            ->then
+                ->variable($talk->getSlug())
+                ->isEqualTo('1007-utiliser-postgresql-en-2014')
+        ;
+    }
+
 }

--- a/tests/units/AppBundle/Event/Model/Talk/Talk.php
+++ b/tests/units/AppBundle/Event/Model/Talk/Talk.php
@@ -29,7 +29,7 @@ class Talk extends \atoum
             )
             ->then
                 ->variable($talk->getSlug())
-                ->isEqualTo('1007-utiliser-postgresql-en-2014')
+                ->isEqualTo('utiliser-postgresql-en-2014')
         ;
     }
 

--- a/tests/units/AppBundle/Indexation/Talks/Transformer.php
+++ b/tests/units/AppBundle/Indexation/Talks/Transformer.php
@@ -73,7 +73,7 @@ class Transformer extends \atoum
                     ->isEqualTo([
                         'planning_id' => "266",
                         'talk_id' => 1007,
-                        'slug' => '1007-utiliser-postgresql-en-2014',
+                        'url_key' => '1007-utiliser-postgresql-en-2014',
                         'title' => "Utiliser PostgreSQL en 2014",
                         'event' => [
                             'id' => 10,

--- a/tests/units/AppBundle/Indexation/Talks/Transformer.php
+++ b/tests/units/AppBundle/Indexation/Talks/Transformer.php
@@ -73,6 +73,7 @@ class Transformer extends \atoum
                     ->isEqualTo([
                         'planning_id' => "266",
                         'talk_id' => 1007,
+                        'slug' => '1007-utiliser-postgresql-en-2014',
                         'title' => "Utiliser PostgreSQL en 2014",
                         'event' => [
                             'id' => 10,


### PR DESCRIPTION
A merger après avoir mergé la #272 

Ajoute une page semblable à celle-ci: 
(les images ne correspondent pas à la conf)
![screen shot 2017-01-02 at 15 15 18](https://cloud.githubusercontent.com/assets/320372/21590725/80ac1b64-d0fe-11e6-823e-d2b370a08376.png)

Il y a maintenant un lien sur la page de recherche:
![screen shot 2017-01-02 at 15 17 30](https://cloud.githubusercontent.com/assets/320372/21590739/a0b6e47a-d0fe-11e6-808c-a87057c6d0f4.png)
