### PR TITLE
ajout export csv de la liste des membres

### DIFF
--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -54,7 +54,8 @@ if ($action == 'lister') {
     $filename = tempnam(sys_get_temp_dir(), 'export_personnes_physiques_');
     $file = new \SplFileObject($filename, 'w');
     $isActive = isset($_GET['is_active']) ? '1' : null;
-    foreach ($personnes_physiques->obtenirListe('*', 'nom, prenom', false, false, false, false, $isActive) as $row) {
+    $aJourCotisation = isset($_GET['a_jour_cotisation']) ? true : null;
+    foreach ($personnes_physiques->obtenirListe('*', 'nom, prenom', false, false, false, false, $isActive, $aJourCotisation) as $row) {
         $file->fputcsv([
             $row['email'],
             $row['nom'],

--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -11,7 +11,7 @@ if (!defined('PAGE_LOADED_USING_INDEX')) {
     exit;
 }
 
-$action = verifierAction(array('lister', 'ajouter', 'modifier', 'supprimer', 'envoi_mdp', 'envoi_bienvenue'));
+$action = verifierAction(array('lister', 'ajouter', 'modifier', 'supprimer', 'envoi_mdp', 'envoi_bienvenue', 'export'));
 $tris_valides = array('nom' => 'nom <sens>, prenom',
     'prenom' => 'prenom <sens>, nom',
     'etat' => 'etat <sens>, prenom, nom');
@@ -50,6 +50,21 @@ if ($action == 'lister') {
     } else {
         afficherMessage('Une erreur est survenue lors de l\'envoi d\'un nouveau mot de passe à la personne physique', 'index.php?page=personnes_physiques&action=lister', true);
     }
+} elseif ($action == 'export') {
+    $filename = tempnam(sys_get_temp_dir(), 'export_personnes_physiques_');
+    $file = new \SplFileObject($filename, 'w');
+    $isActive = isset($_GET['is_active']) ? '1' : null;
+    foreach ($personnes_physiques->obtenirListe('*', 'nom, prenom', false, false, false, false, $isActive) as $row) {
+        $file->fputcsv([
+            $row['email'],
+            $row['nom'],
+            $row['prenom'],
+        ]);
+    }
+    header("Content-disposition: attachment;filename=export_personnes_physiques.csv");
+    readfile($filename);
+    unlink($filename);
+    exit(0);
 } elseif ($action == 'envoi_bienvenue') {
     $password = $personnes_physiques->generatePassword($_GET['id']);
     $data = $personnes_physiques->obtenir($_GET['id'], 'prenom, nom, email, login');

--- a/htdocs/templates/administration/personnes_physiques.html
+++ b/htdocs/templates/administration/personnes_physiques.html
@@ -2,6 +2,9 @@
     <h2>Liste des personnes physiques</h2>
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" /><a href="index.php?page=personnes_physiques&amp;action=ajouter" title="Ajouter une personne physique">Ajouter une personne physique</a><br />
     <br/>
+    <a href="index.php?page=personnes_physiques&amp;action=export" title="Export en CSV">Export de toutes les personnes physiques en CSV</a><br />
+    <a href="index.php?page=personnes_physiques&amp;action=export&amp;is_active=1" title="Export en CSV">Export des personnes physiques actives en CSV</a><br />
+    <br />
     <table>
       <form method="GET" name="filtre" class="js-form-search">
       <input type="hidden" name="page" value="personnes_physiques" />

--- a/htdocs/templates/administration/personnes_physiques.html
+++ b/htdocs/templates/administration/personnes_physiques.html
@@ -4,6 +4,7 @@
     <br/>
     <a href="index.php?page=personnes_physiques&amp;action=export" title="Export en CSV">Export de toutes les personnes physiques en CSV</a><br />
     <a href="index.php?page=personnes_physiques&amp;action=export&amp;is_active=1" title="Export en CSV">Export des personnes physiques actives en CSV</a><br />
+    <a href="index.php?page=personnes_physiques&amp;action=export&amp;is_active=1&a_jour_cotisation=1" title="Export en CSV">Export des personnes physiques actives à jour de cotisation en CSV</a><br />
     <br />
     <table>
       <form method="GET" name="filtre" class="js-form-search">

--- a/sources/Afup/Association/Personnes_Physiques.php
+++ b/sources/Afup/Association/Personnes_Physiques.php
@@ -48,7 +48,9 @@ class Personnes_Physiques
                           $id_personne_morale = false,
                           $associatif = false,
                           $id_personne_physique = false,
-                          $is_active = NULL)
+                          $is_active = NULL,
+                          $a_jour_de_cotisation = null
+    )
     {
         $requete = 'SELECT';
         $requete .= '  ' . $champs . ' ';
@@ -76,6 +78,15 @@ class Personnes_Physiques
         if ($is_active !== NULL) {
             $requete .= 'AND etat = ' . $is_active . ' ';
         }
+
+        if ($a_jour_de_cotisation) {
+            $requete .= " AND id IN (
+                SELECT id_personne
+                FROM afup_cotisations
+                WHERE date_debut <= NOW() AND date_fin <= NOW()
+            ) ";
+        }
+
         $requete .= 'ORDER BY ' . $ordre;
         if ($associatif) {
             return $this->_bdd->obtenirAssociatif($requete);


### PR DESCRIPTION
Ajout de liens pour exporter la liste des membres: il y a deux liens, exporter tous les membres et exporter les membres actifs.

Capture d'écran du BO :
![capture du 2017-01-09 07 24 20](https://cloud.githubusercontent.com/assets/320372/21758627/e393410a-d63d-11e6-83a0-9511c800fe48.png)

Sont exportés dans le CSV:
* email
* nom
* prenom

cf https://github.com/afup/web/pull/275
