### PR TITLE
Changements sur les facettes

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -25,7 +25,7 @@
     </head>
     <body id="body">
         {% block header '' %}
-        <div class="container">
+        <div class="container" style="padding: 0px">
             {% for bag in ['notice', 'success', 'error'] %}
                 {% for flash_message in app.session.flashBag.get(bag) %}
                     <div class="flash flash-{{ bag }}">

--- a/app/Resources/views/site/talks/list.html.twig
+++ b/app/Resources/views/site/talks/list.html.twig
@@ -33,6 +33,7 @@
                 <div class="col-md-4" id="refinements-container">
                     <div id="refinement-has-video"></div>
                     <div id="refinement-has-slides"></div>
+                    <div id="refinement-has-blog-post"></div>
                     <div id="refinement-event"></div>
                     <div id="refinement-speaker"></div>
                 </div>

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -34,8 +34,9 @@
                 </div>
                 <div class="container talk-date-container">
                     <div class="col-md-12">
-                        Conférence donnée lors du {{ event.title }}, ayant eut lieu les {{ event.dateStart|date('d/m/Y') }} et {{ event.dateEnd|date('d/m/Y') }}.
+                        Conférence donnée lors du <a href="{{ url('talks_list', {"fR": { "event.title" : [ event.title ]}}) }}">{{ event.title }}</a>, ayant eut lieu les {{ event.dateStart|date('d/m/Y') }} et {{ event.dateEnd|date('d/m/Y') }}.
                     </div>
+
                 </div>
 
                 {% if talk.hasSlidesUrl or talk.hasBlogPostUrl or talk.hasJoindinId %}

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -104,7 +104,7 @@
                         <div class="col-md-10">
                             {{ speaker.biography }}
                             <div class="speaker-talks-link">
-                                <a href="{{ url('talks_list', {"dFR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous les talks de ce speaker.</a>
+                                <a href="{{ url('talks_list', {"fR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous les talks de ce speaker.</a>
                             </div>
                         </div>
                     </div>

--- a/htdocs/app.php
+++ b/htdocs/app.php
@@ -3,13 +3,13 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
-if ($_SERVER['HTTP_HOST'] === 'afup.dev') {
+if ($_SERVER['HTTP_HOST'] === 'afup.dev' || isset($_ENV['SF_DEV_ENV'])) {
     if (isset($_SERVER['HTTP_CLIENT_IP'])
         || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
         || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1', '192.168.42.1']) || php_sapi_name() === 'cli-server')
     ) {
-        header('HTTP/1.0 403 Forbidden');
-        exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+        //header('HTTP/1.0 403 Forbidden');
+        //exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
     }
 
     session_start();

--- a/htdocs/app.php
+++ b/htdocs/app.php
@@ -3,13 +3,13 @@
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Debug\Debug;
 
-if ($_SERVER['HTTP_HOST'] === 'afup.dev' || isset($_ENV['SF_DEV_ENV'])) {
+if ($_SERVER['HTTP_HOST'] === 'afup.dev') {
     if (isset($_SERVER['HTTP_CLIENT_IP'])
         || isset($_SERVER['HTTP_X_FORWARDED_FOR'])
         || !(in_array(@$_SERVER['REMOTE_ADDR'], ['127.0.0.1', '::1', '192.168.42.1']) || php_sapi_name() === 'cli-server')
     ) {
-        //header('HTTP/1.0 403 Forbidden');
-        //exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
+        header('HTTP/1.0 403 Forbidden');
+        exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
     }
 
     session_start();

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -140,6 +140,7 @@ search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-speaker',
         attributeName: 'speakers.label',
+        operator: "and",
         templates: {
             header: "<h4>Conférencier</h4>",
             item: refinementItemTemplate

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -125,6 +125,22 @@ search.addWidget(
     })
 );
 
+
+search.addWidget(
+    instantsearch.widgets.toggle({
+        container: '#refinement-has-blog-post',
+        attributeName: 'has_blog_post',
+        label: 'Avec article de blog',
+        values: {
+            on: true
+        },
+        autoHideContainer: false,
+        templates: {
+            item: refinementItemTemplate
+        }
+    })
+);
+
 search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-event',

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -145,6 +145,20 @@ search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-event',
         attributeName: 'event.title',
+        sortBy: function(a, b) {
+            var aYear = parseInt(a.name.substring(a.name.length - 4), 10);
+            var bYear = parseInt(b.name.substring(b.name.length - 4), 10);
+
+            if (aYear < bYear) {
+                return 1;
+            }
+
+            if (aYear > bYear) {
+                return -1;
+            }
+
+            return 0;
+        },
         operator: "and",
         templates: {
             header: "<h4>Événement</h4>",

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -145,6 +145,7 @@ search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-event',
         attributeName: 'event.title',
+        operator: "and",
         templates: {
             header: "<h4>Événement</h4>",
             item: refinementItemTemplate

--- a/sources/AppBundle/Indexation/Talks/Runner.php
+++ b/sources/AppBundle/Indexation/Talks/Runner.php
@@ -72,6 +72,7 @@ class Runner
                 'speakers.label',
                 'has_video',
                 'has_slides',
+                'has_blog_post',
             ],
             'customRanking' => [
                 "desc(event.start_date)",


### PR DESCRIPTION
* correction du lien vers la liste des talks du speaker depuis la page de détail : le filtre était pris en compte, mais la l'item n'était pas coché dans la liste des facettes. On ne pouvait donc pas le décocher et revenir à la liste complète. C'est maintenant corrigé.
* ajout facette article de blog
* ajout d'un lien vers la liste des talks de l'event depuis la page de détail
* tri chronologique des items de la facette événements