### PR TITLE
correction padding sur pages talks

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -25,7 +25,7 @@
     </head>
     <body id="body">
         {% block header '' %}
-        <div class="container">
+        <div class="container" style="padding: 0px">
             {% for bag in ['notice', 'success', 'error'] %}
                 {% for flash_message in app.session.flashBag.get(bag) %}
                     <div class="flash flash-{{ bag }}">


### PR DESCRIPTION
Il y avait un espacement sur l'historique des conférences, le menu était
donc visible sur mobile sans avoir cliqué sur le hamburger.

Cela car une classe du layout de base a le même nom qu'une classe de la grille.
Afin d'éviter cet espacement, on force le padding sur cet élément.

//cc @mikaelkael 