### PR TITLE
On permet de filtrer sur la langue des conférences

### DIFF
--- a/app/Resources/views/site/talks/list.html.twig
+++ b/app/Resources/views/site/talks/list.html.twig
@@ -35,6 +35,7 @@
                     <div id="refinement-has-slides"></div>
                     <div id="refinement-has-blog-post"></div>
                     <div id="refinement-event"></div>
+                    <div id="refinement-language"></div>
                     <div id="refinement-speaker"></div>
                 </div>
 

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -169,6 +169,18 @@ search.addWidget(
 
 search.addWidget(
     instantsearch.widgets.refinementList({
+        container: '#refinement-language',
+        operator: "and",
+        attributeName: 'language.label',
+        templates: {
+            header: "<h4>Langue</h4>",
+            item: refinementItemTemplate
+        }
+    })
+);
+
+search.addWidget(
+    instantsearch.widgets.refinementList({
         container: '#refinement-speaker',
         attributeName: 'speakers.label',
         operator: "and",

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -6,6 +6,7 @@ use Afup\Site\Forum\AppelConferencier;
 use Afup\Site\Droits;
 use Afup\Site\Utils\Pays;
 use Afup\Site\Utils\Logs;
+use AppBundle\Event\Model\Talk;
 
 if (!defined('PAGE_LOADED_USING_INDEX')) {
     trigger_error("Direct access forbidden.", E_USER_ERROR);
@@ -322,6 +323,7 @@ if ($action == 'lister') {
         $formulaire->addElement('text'    , 'youtube_id'          , 'Id de la conférence sur youtube' , array('size' => 40, 'maxlength' => 30));
         $formulaire->addElement('text'    , 'slides_url'          , 'URL où trouver les slides' , array('size' => 80, 'maxlength' => 255));
         $formulaire->addElement('text'    , 'blog_post_url'          , 'URL de la version  article de blog de la conférence' , array('size' => 80, 'maxlength' => 255));
+        $formulaire->addElement('select', 'language_code', 'Langue', Talk::getLanguageLabelsByKey());
     }
 
     $formulaire->addElement('header', null, 'Conférencier(s)');
@@ -382,7 +384,8 @@ if ($action == 'lister') {
                                                 $valeurs['joindin'],
                                                 $valeurs['youtube_id'],
                                                 $valeurs['slides_url'],
-                                                $valeurs['blog_post_url']
+                                                $valeurs['blog_post_url'],
+                                                $valeurs['language_code']
             );
             $forum_appel->delierSession($session_id);
         }

--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -647,7 +647,7 @@ class AppelConferencier
         return $this->_bdd->obtenirUn('select LAST_INSERT_ID()');
     }
 
-    public function modifierSession($id, $id_forum, $date_soumission, $titre, $abstract, $journee, $genre, $plannifie, $joindin = null, $youtubeId = null, $slidesUrl = null, $blogPostUrl = null)
+    public function modifierSession($id, $id_forum, $date_soumission, $titre, $abstract, $journee, $genre, $plannifie, $joindin = null, $youtubeId = null, $slidesUrl = null, $blogPostUrl = null, $languageCode = null)
     {
         $requete = 'UPDATE afup_sessions SET ';
         $requete .= ' id_forum = ' . $this->_bdd->echapper($id_forum) . ', ';
@@ -667,6 +667,9 @@ class AppelConferencier
         }
         if ($blogPostUrl !== null) {
             $requete .= ' blog_post_url = ' . $this->_bdd->echapper($blogPostUrl) . ', ';
+        }
+        if ($languageCode !== null) {
+            $requete .= ' language_code = ' . $this->_bdd->echapper($languageCode) . ', ';
         }
         $requete .= ' plannifie = ' . $this->_bdd->echapper($plannifie) . ' ';
         $requete .= ' WHERE session_id = ' . (int)$id;

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -182,6 +182,11 @@ class TalkRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'joindinId',
                 'type' => 'string'
             ])
+            ->addField([
+                'columnName' => 'language_code',
+                'fieldName' => 'languageCode',
+                'type' => 'string'
+            ])
         ;
 
         return $metadata;

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -20,6 +20,9 @@ class Talk implements NotifyPropertyInterface
     const SKILL_SENIOR = 3;
     const SKILL_NA = 0;
 
+    const LANGUAGE_CODE_FR = 'fr';
+    const LANGUAGE_CODE_EN = 'en';
+
     /**
      * @var int
      */
@@ -92,6 +95,11 @@ class Talk implements NotifyPropertyInterface
      * @var string|null
      */
     private $joindinId;
+
+    /**
+     * @var string|null
+     */
+    private $languageCode;
 
     /**
      * @return int
@@ -443,5 +451,54 @@ class Talk implements NotifyPropertyInterface
     {
         $slugify = new Slugify();
         return $slugify->slugify($this->getTitle());
+    }
+
+    /**
+     * @return array
+     */
+    public static function getLanguageLabelsByKey()
+    {
+        return [
+            self::LANGUAGE_CODE_FR => 'Français',
+            self::LANGUAGE_CODE_EN => 'Anglais',
+        ];
+    }
+
+    /**
+     * @return string
+     *
+     * @throws \Exception
+     */
+    public function getLanguageLabel()
+    {
+        $languageCde = $this->getLanguageCode();
+        $mapping = self::getLanguageLabelsByKey();
+
+        if (!isset($mapping[$languageCde])) {
+            throw new \Exception(sprintf('Code de langue inconnu : %s', $languageCde));
+        }
+
+        return $mapping[$languageCde];
+    }
+
+    /**
+     * @return int
+     */
+    public function getLanguageCode()
+    {
+        return $this->languageCode;
+    }
+
+    /**
+     * @param int $languageCode
+     *
+     * @return Talk
+     */
+    public function setLanguageCode($languageCode)
+    {
+        $this->propertyChanged('languageCode', $this->languageCode, $languageCode);
+        $this->languageCode = $languageCode;
+
+        return $this;
     }
 }

--- a/sources/AppBundle/Indexation/Talks/Runner.php
+++ b/sources/AppBundle/Indexation/Talks/Runner.php
@@ -73,6 +73,7 @@ class Runner
                 'has_video',
                 'has_slides',
                 'has_blog_post',
+                'language.label',
             ],
             'customRanking' => [
                 "desc(event.start_date)",

--- a/sources/AppBundle/Indexation/Talks/Transformer.php
+++ b/sources/AppBundle/Indexation/Talks/Transformer.php
@@ -33,6 +33,10 @@ class Transformer
             'has_slides' => $talk->hasSlidesUrl(),
             'has_joindin' => $talk->hasJoindinId(),
             'has_blog_post' => $talk->hasBlogPostUrl(),
+            'language' => [
+                'code' => $talk->getLanguageCode(),
+                'label' => $talk->getLanguageLabel(),
+            ],
         ];
 
         $speakersLabels = [];

--- a/sql/2016-12-17-sessionLanguage.sql
+++ b/sql/2016-12-17-sessionLanguage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `afup_sessions` ADD `language_code` varchar(2) DEFAULT 'fr' AFTER `blog_post_url`;

--- a/tests/units/AppBundle/Indexation/Talks/Transformer.php
+++ b/tests/units/AppBundle/Indexation/Talks/Transformer.php
@@ -29,6 +29,7 @@ class Transformer extends \atoum
                     ->setSlidesUrl('http://tapoueh.org/images/confs/PHPTour_2014_PostgreSQL.pdf')
                     ->setJoindinId(11214)
                     ->setBlogPostUrl('http://tapoueh.org/confs/2014/06/23-PHPTour-Lyon-2014')
+                    ->setLanguageCode('fr')
             )
             ->and(
                 $planning = new Planning(),
@@ -98,6 +99,10 @@ class Transformer extends \atoum
                         'joindin_url' => 'https://legacy.joind.in/talk/view/11214',
                         'has_blog_post' => true,
                         'blog_post_url' => 'http://tapoueh.org/confs/2014/06/23-PHPTour-Lyon-2014',
+                        'language' => [
+                            'code' => 'fr',
+                            'label' => 'Français',
+                        ]
                     ])
         ;
     }
@@ -106,6 +111,7 @@ class Transformer extends \atoum
     {
         $this
             ->given($talk = new Talk())
+                ->and($talk->setLanguageCode('fr'))
                 ->and($planning = new Planning())
                 ->and($event = new Event())
                 ->and($speakers = new \ArrayObject([new Speaker()]))


### PR DESCRIPTION
* ajout dans le BO d'un sélecteur de langue 
* passage de toutes les langues courantes en français
* ajout d'une facette de langue sur la page de recherche

la facette ressemble à cela:
![screen shot 2017-01-19 at 21 36 48](https://cloud.githubusercontent.com/assets/320372/22124389/f58f3b84-de8f-11e6-8a02-bedcbb578db0.png)

 (il faudra repasser sur les talks en anglais pour modifier le code de langue)