### PR TITLE
correction présence à l'assemblée non prise en compte sur login via u…

### DIFF
--- a/sources/Afup/Association/Assemblee_Generale.php
+++ b/sources/Afup/Association/Assemblee_Generale.php
@@ -312,7 +312,7 @@ class Assemblee_Generale
         $requete .= '  afup_presences_assemblee_generale.date_modification = ' . time() . ' ';
         $requete .= 'WHERE';
         $requete .= '  afup_presences_assemblee_generale.id_personne_physique = afup_personnes_physiques.id ';
-        $requete .= 'AND afup_personnes_physiques.login = ' . $this->_bdd->echapper($login) . ' ';
+        $requete .= 'AND (afup_personnes_physiques.login = ' . $this->_bdd->echapper($login) . ' OR afup_personnes_physiques.email = ' . $this->_bdd->echapper($login) . ' )';
         $requete .= 'AND afup_presences_assemblee_generale.date = ' . $timestamp;
 
         return $this->_bdd->executer($requete);


### PR DESCRIPTION
…n mail

Il fallait se connecter avec le login afup pour que la présence soit
prise en compte. Si connexion avec l'adresse mail, le présence/pouvoir
n'était pas prise en compte.