### PR TITLE
passage du rebond talks de speakers en dessous de la photo de celui-ci

### DIFF
--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -109,14 +109,14 @@
                         </div>
                     </div>
                     <div class="container">
-                        <div class="col-md-2">
+                        <div class="col-md-2 speaker-photo-container">
                             <img src="{{ photo_storage.getUrl(speaker) }}" class="speaker-photo" />
+                            <div class="speaker-talks-link">
+                                <a href="{{ url('talks_list', {"fR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous ses talks</a>
+                            </div>
                         </div>
                         <div class="col-md-10">
                             {{ speaker.biography }}
-                            <div class="speaker-talks-link">
-                                <a href="{{ url('talks_list', {"fR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous les talks de ce speaker.</a>
-                            </div>
                         </div>
                     </div>
                 {% endfor %}

--- a/htdocs/css/talk/show.css
+++ b/htdocs/css/talk/show.css
@@ -46,9 +46,12 @@ div.speaker-name-container {
     font-style: italic;
 }
 
+.speaker-photo-container {
+    text-align: center;
+}
+
 .speaker-talks-link {
-    text-align: right;
-    margin: 15px 0 0 0
+    margin: 15px 0 0 0;
 }
 
 .speaker-photo {


### PR DESCRIPTION
Le lien sera plus visible et sera mieux intégré lorsque le speaker
n'a pas de description.

avant:
![screen shot 2017-02-11 at 07 53 01](https://cloud.githubusercontent.com/assets/320372/22851903/904920e8-f030-11e6-9480-3001c19ddcad.png)


après:
![screen shot 2017-02-11 at 07 46 36](https://cloud.githubusercontent.com/assets/320372/22851904/967e0186-f030-11e6-8cb9-ddd4044b0d6d.png)

//cc @mikaelrandy 