### PR TITLE
on renomme article de blog en transcript

### DIFF
--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -63,7 +63,7 @@
 
                         {% if talk.hasBlogPostUrl %}
                             <li>
-                                <a class="talk-info-link" href="{{ talk.getBlogPostUrl }}"><i class="fa fa-rss"></i> Article</a>
+                                <a class="talk-info-link" href="{{ talk.getBlogPostUrl }}"><i class="fa fa-rss"></i> Transcript</a>
                             </li>
                         {% endif %}
 

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -51,7 +51,7 @@ search.addWidget(
 
 
                 if (typeof data.blog_post_url !== 'undefined') {
-                    content += '<a class="talk-info-link" href="' + data.blog_post_url + '" class="talk-list-" target="blog-post"><i class="fa fa-rss"></i> Article</a>';
+                    content += '<a class="talk-info-link" href="' + data.blog_post_url + '" class="talk-list-" target="blog-post"><i class="fa fa-rss"></i> Transcript</a>';
                 }
 
                 if (typeof data.slides_url !== 'undefined') {
@@ -130,7 +130,7 @@ search.addWidget(
     instantsearch.widgets.toggle({
         container: '#refinement-has-blog-post',
         attributeName: 'has_blog_post',
-        label: 'Avec article de blog',
+        label: 'Avec transcript',
         values: {
             on: true
         },


### PR DESCRIPTION
Cela permettra d'être plus clair sur le type d'article demandé
(pour éviter de mettre par exemple des articles avec seulement un
lien vers les slides).