### PR TITLE
ajout d'un bouton pour voir plus de speakers

### DIFF
--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -192,6 +192,13 @@ search.addWidget(
         templates: {
             header: "<h4>Conférencier</h4>",
             item: refinementItemTemplate
+        },
+        showMore: {
+            limit: 20,
+            templates: {
+                active: '<a class="ais-show-more ais-show-more__inactive">Voir moins</a>',
+                inactive: '<a class="ais-show-more ais-show-more__inactive">Voir plus</a>'
+            }
         }
     })
 );


### PR DESCRIPTION
Ajout d'une bouton permettant d'afficher plus de speakers
(dans la limite de 20).

![screen shot 2017-02-11 at 09 27 22](https://cloud.githubusercontent.com/assets/320372/22852425/56b6baf0-f03c-11e6-859d-83f16e6e98e6.png)
