### PR TITLE
correction filtrage sur le format

### DIFF
--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -177,6 +177,7 @@ search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-type',
         attributeName: 'type.label',
+        operator: "and",
         templates: {
             header: "<h4>Format</h4>",
             item: refinementItemTemplate


### PR DESCRIPTION
Il faut effectuer un and et pas un or pour avoir un comportement
cohérent avec les autres filtres de ce type.