### PR TITLE
On autorise moins de 3 membres entreprises

### DIFF
--- a/sources/AppBundle/Controller/MemberShipController.php
+++ b/sources/AppBundle/Controller/MemberShipController.php
@@ -43,6 +43,9 @@ class MemberShipController extends SiteBaseController
             $invitationRepository = $this->get('ting')->get(CompanyMemberInvitationRepository::class);
 
             foreach ($member->getInvitations() as $index => $invitation) {
+                if ($invitation->getEmail() === null) {
+                    continue;
+                }
                 $invitation
                     ->setSubmittedOn(new \DateTime())
                     ->setCompanyId($member->getId())
@@ -56,7 +59,7 @@ class MemberShipController extends SiteBaseController
 
                 $invitationRepository->save($invitation);
 
-                // Send mail to the other guy, begging for him to join the talk
+                // Send mail to the other guy, begging for him to join the company
                 $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($member, $invitation) {
                     $text = $this->get('translator')->trans('mail.invitationMembership.text',
                         [


### PR DESCRIPTION
En passant à la ligne suivante si l'email n'est pas rempli sur une ligne de membre. La première ligne est gérée via la validation front.
Ce n'est pas imparable mais suffisant: au pire l'adhésion sera enregistrée mais aucune personne rattachée