### PR TITLE
Amélioration de la lisibilité du planning

### DIFF
--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -5,7 +5,7 @@
             <caption>Jour {{ loop.index }} : {{ date }}</caption>
             <thead>
             <tr>
-                <th class="horaire">&nbsp;</th>
+                <th class="horaire" colspan="2">&nbsp;</th>
                 {% for room in rooms %}
                     <th class="activite">{{ room.name }}</th>
                 {% endfor %}
@@ -26,12 +26,13 @@
                         {% set minutes = "%02d"|format(precision*loop.index0) %}
                         {# On crée une ligne pour chaque espace de 5 minutes mais on affiche les heures que les 1/4h #}
                         <tr>
-                            {% if loop.index0 * precision % 15 == 0 %}
-                                <td class="col_heure" rowspan="{{ 15 / precision }}" nowrap="nowrap">
+                            {% if loop.index0 * precision % 60 == 0 %}
+                                <td class="col_heure" rowspan="{{ 60 / precision }}" nowrap="nowrap">
                                     {# @TODO Meilleur affichage heures et minutes #}
-                                    {{ hour }}:{{ "%02d"|format(precision*loop.index0) }}
+                                    {{ hour }}h
                                 </td>
                             {% endif %}
+                            <td class="col_heure">{{ "%02d"|format(precision*loop.index0) }}</td>
 
                             {% if planningForADay[date ~ " " ~ hour ~ ":" ~ minutes] is defined %}
                                 {% set slot = planningForADay[date ~ " " ~ hour ~ ":" ~ minutes] %}

--- a/htdocs/css/blog/planning.css
+++ b/htdocs/css/blog/planning.css
@@ -31,7 +31,8 @@ table.planning_agenda tr td:last-child{
 }
 table.planning_agenda td.col_heure{
     border-right:1px solid #898D92;
-    vertical-align: top;
+    vertical-align: middle;
+    width:5%;
 }
 @media (max-width: 1024px) {
     table.planning_agenda span.conferencier{


### PR DESCRIPTION
Je trouve que le planning n'est pas toujours très lisible au niveau des heures, voici un exemple

![lisibilite-avant](https://cloud.githubusercontent.com/assets/2320425/24539136/5819076e-15ed-11e7-96da-0cf48daa2a08.png)
Il est difficile de comprendre précisément à quelle heure une conférence commence ou se termine.

Cette proposition vise donc à ajouter un minutage plus précis visuellement, voici ce que ça pourrait donner:

![lisibilite-apres](https://cloud.githubusercontent.com/assets/2320425/24539141/5f42c750-15ed-11e7-9454-429dbca566fd.png)
