### PR TITLE
Fix sur les inscriptions

### DIFF
--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -35,7 +35,7 @@
     <script src="{{ asset('js/inscription.js') }}"></script>
 
     <script type="text/javascript">
-		var nbInscriptions = 1;
+		var nbInscriptions = {{ nbPersonnes }};
     </script>
 
 
@@ -55,6 +55,12 @@
                 <p>Pour acheter des places au tarif AFUP, vous devez vous <a href="{{ url('admin_login') }}">connecter</a>.</p>
             {% endif %}
         </div>
+
+        {% if not ticketForm.vars.valid %}
+            <div class="tickets--errors">
+                {{ 'Une ou plusieurs erreurs sont survenues. Merci de vérifier le formulaire' }}
+            </div>
+        {% endif %}
 
         {{ form_start(ticketForm, {attr: {id: 'formulaire'}}) }}
 

--- a/htdocs/css/tickets.css
+++ b/htdocs/css/tickets.css
@@ -152,7 +152,7 @@ div.tickets--bankwire{
 ul.tickets--errors, #fieldset--7 div{
     margin-left:200px;
 }
-ul.tickets--errors{
+.tickets--errors{
     font-weight: bold;
     color: #B0413E;
 }
@@ -162,13 +162,12 @@ p.tickets--type-stock-limit{
 #tickets--other-payments{
     cursor: pointer;
 }
-div.tickets--members-detail{
+div.tickets--members-detail, div.tickets--errors{
     padding: 0 1em;
     border: 1px #50a0dd solid;
     margin: 1em auto;
     background-color:#f2f2f2;
 }
-
 div.sponsor--become-form {
     margin-top:1em;
 }
@@ -176,7 +175,10 @@ div.sponsor--become-form div.sponsor--become-submit{
     text-align: right;
     margin-right: 30px;
 }
-div.sponsor--become-form label{
+div.sponsor--become-form label {
     min-width: 20%;
-    width:auto;
+    width: auto;
+}
+div.tickets--errors{
+    border-color: #B0413E;
 }

--- a/sources/AppBundle/Event/Form/PurchaseType.php
+++ b/sources/AppBundle/Event/Form/PurchaseType.php
@@ -43,7 +43,8 @@ class PurchaseType extends AbstractType
                 ],
                 'multiple' => false,
                 'expanded' => false,
-                'mapped' => false
+                'mapped' => false,
+                'data' => 1
             ])
             ->add('tickets', CollectionType::class, [
                 // each entry in the array will be an "email" field

--- a/sources/AppBundle/Event/Form/TicketType.php
+++ b/sources/AppBundle/Event/Form/TicketType.php
@@ -76,7 +76,8 @@ class TicketType extends AbstractType
                 'label' => 'Email'
             ])
             ->add('phoneNumber', TextType::class, [
-                'label' => 'Téléphone'
+                'label' => 'Téléphone',
+                'required' => false
             ])
             ->add('ticketEventType', ChoiceType::class, [
                 'expanded' => true,


### PR DESCRIPTION
En vrac:

* On réouvre automatiquement toutes les inscriptions en cas d'erreurs dans le formulaire
* On affiche un message en haut en cas d'erreur
* On autorise la possibilité d'avoir un lien pour revenir sur la page de paiement (via l'invoiceRef passé en get)
* On rend optionnel le numéro de téléphone