### PR TITLE
contournement membre expiré persistant

### DIFF
--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -514,7 +514,14 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
             $defaultRoles[] = 'ROLE_ANTENNE';
         }
 
-        return array_unique(array_merge($this->roles, $defaultRoles));
+        $userRoles = array_filter(
+            $this->roles,
+            function ($role) {
+                return $role != 'ROLE_MEMBER_EXPIRED';
+            }
+        );
+
+        return array_unique(array_merge($userRoles, $defaultRoles));
     }
 
     /**

--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -514,12 +514,8 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
             $defaultRoles[] = 'ROLE_ANTENNE';
         }
 
-        $userRoles = array_filter(
-            $this->roles,
-            function ($role) {
-                return $role != 'ROLE_MEMBER_EXPIRED';
-            }
-        );
+        // On enlève le rôle ROLE_MEMBER_EXPIRED vu qu'il est défini en fonction de la cotisation dans les defaultRoles
+        $userRoles = array_diff($this->roles, ['ROLE_MEMBER_EXPIRED']);
 
         return array_unique(array_merge($userRoles, $defaultRoles));
     }


### PR DESCRIPTION
Parfois le role MEMBER_EXPIRED reste en base, associé au user même
si celui-ci a payé sa cotisation.

Vu que ce role est recalculé à chaque fois il n'y pas besoin de le récupérer
de la base.

En le supprimant des roles récupérés depuis la base on contourne le problème.