### PR TITLE
ajout shortcode pour inclure infos sur les articles des interviews

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"
+    environment:
+      AFUP_WEBSITE_URL: 'https://apachephp:80'
     volumes:
       - ./:/var/www/html
     links:

--- a/event/resources/themes/basis_child/functions.php
+++ b/event/resources/themes/basis_child/functions.php
@@ -10,3 +10,24 @@ function cc_mime_types($mimes) {
   return $mimes;
 }
 add_filter('upload_mimes', 'cc_mime_types');
+
+
+function afup_website_func($attrs) {
+    $url = $_ENV['AFUP_WEBSITE_URL'] . $attrs['path'];
+    $ch = curl_init();
+
+    if (defined('WP_DEBUG') && WP_DEBUG == true) {
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+      }
+
+    curl_setopt($ch, CURLOPT_HEADER, false);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_URL, $url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $body = curl_exec($ch);
+    curl_close($ch);
+
+    return $body;
+}
+add_shortcode('afup_website', 'afup_website_func');


### PR DESCRIPTION
en incluant :
```
[afup_website path="/blog/talk_widget?ids=2398,2401"]
```

dans les articles, on affichera les confs 2398 et 2401 ainsi
que les speakers liés (cf #446).