### PR TITLE
correction commande de création de liste

### DIFF
--- a/sources/AppBundle/Command/TwitterListCreateCommand.php
+++ b/sources/AppBundle/Command/TwitterListCreateCommand.php
@@ -8,6 +8,7 @@ use AppBundle\Twitter\ListCreator;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TwitterListCreateCommand extends ContainerAwareCommand
@@ -19,7 +20,8 @@ class TwitterListCreateCommand extends ContainerAwareCommand
     {
         $this
             ->setName('twitter-list:create')
-            ->addArgument('event-path', null, InputArgument::REQUIRED);
+            ->addArgument('event-path', null, InputArgument::REQUIRED)
+            ->addOption('custom-name', null, InputOption::VALUE_REQUIRED, 'Use this value as list name instead of the event title')
         ;
     }
 
@@ -33,7 +35,7 @@ class TwitterListCreateCommand extends ContainerAwareCommand
         $event = $this->getEventFilter($input);
 
         $twitterListCreator = new ListCreator($container->get('app.twitter_api'), $ting->get(SpeakerRepository::class));
-        $twitterListCreator->create($event);
+        $twitterListCreator->create($event, $input->getOption('custom-name'));
     }
 
     /**

--- a/sources/AppBundle/Twitter/ListCreator.php
+++ b/sources/AppBundle/Twitter/ListCreator.php
@@ -31,14 +31,15 @@ class ListCreator
 
     /**
      * @param Event $event
+     * @param null $customName
      */
-    public function create(Event $event)
+    public function create(Event $event, $customName = null)
     {
         $listJson = $this->twitterAPIExchange->request(
             'https://api.twitter.com/1.1/lists/create.json',
             'POST',
             [
-                'name' => $event->getTitle()
+                'name' => null !== $customName ? $customName : $event->getTitle(),
             ]
         );
 

--- a/sources/AppBundle/Twitter/ListCreator.php
+++ b/sources/AppBundle/Twitter/ListCreator.php
@@ -49,6 +49,10 @@ class ListCreator
             throw new \RuntimeException('Erreur à la lecture des informations de la liste');
         }
 
+        if (isset($list['errors'])) {
+            throw new \RuntimeException('Erreur à la création de la liste : ' . $listJson);
+        }
+
         $this->twitterAPIExchange->request(
             'https://api.twitter.com/1.1/lists/members/create_all.json',
             'POST',


### PR DESCRIPTION
Le PHPTour avec le titre le plus long est : "PHP Tour Clermont-Ferrand 2016".

Quand on tente de créer une liste nommée comme cela l'api twitter nous remonte :
```
  The list failed validation: A list's name can't be this many characters long.
```

On ajoute donc une option a la commande pour pouvoir y mettre le nom que l'on souhaite.