### PR TITLE
FIX #445 nombre membres & roles

### DIFF
--- a/htdocs/pages/administration/personnes_morales.php
+++ b/htdocs/pages/administration/personnes_morales.php
@@ -86,7 +86,7 @@ if ($action == 'lister') {
     $formulaire->addElement('header'  , ''                   , 'Paramétres');
     $formulaire->addElement('select'  , 'etat'               , 'Etat'        , array(AFUP_DROITS_ETAT_ACTIF   => 'Actif',
                                                                                    AFUP_DROITS_ETAT_INACTIF => 'Inactif'));
-    $formulaire->addElement('select'  , 'max_members'        , 'Membres maximums', array_combine(range(3, 18, 3), range(3, 18, 3)));
+    $formulaire->addElement('select'  , 'max_members'        , 'Membres maximums', array_combine($maxMembers = range(3, 18, 3), $maxMembers));
     $formulaire->addElement('static', 'info' , '    '        , 'Nombre de membres rattachés autorisé par la cotisation');
 
     $formulaire->addElement('header'  , 'boutons'            , '');

--- a/htdocs/pages/administration/personnes_morales.php
+++ b/htdocs/pages/administration/personnes_morales.php
@@ -52,10 +52,10 @@ if ($action == 'lister') {
         $formulaire->setDefaults(array('civilite' => 'M.',
                                        'id_pays' => 'FR',
                                        'niveau'  => AFUP_DROITS_NIVEAU_REDACTEUR,
-                                       'etat'    => AFUP_DROITS_ETAT_ACTIF));
+                                       'etat'    => AFUP_DROITS_ETAT_ACTIF,
+                                        'max_members' => 3));
     } else {
         $champs = $personnes_morales->obtenir($_GET['id']);
-        unset($champs['mot_de_passe']);
         $formulaire->setDefaults($champs);
     }
 
@@ -86,6 +86,8 @@ if ($action == 'lister') {
     $formulaire->addElement('header'  , ''                   , 'Paramétres');
     $formulaire->addElement('select'  , 'etat'               , 'Etat'        , array(AFUP_DROITS_ETAT_ACTIF   => 'Actif',
                                                                                    AFUP_DROITS_ETAT_INACTIF => 'Inactif'));
+    $formulaire->addElement('select'  , 'max_members'        , 'Membres maximums', array_combine(range(3, 18, 3), range(3, 18, 3)));
+    $formulaire->addElement('static', 'info' , '    '        , 'Nombre de membres rattachés autorisé par la cotisation');
 
     $formulaire->addElement('header'  , 'boutons'            , '');
     $formulaire->addElement('submit'  , 'soumettre'          , ucfirst($action));
@@ -113,7 +115,8 @@ if ($action == 'lister') {
                                               $formulaire->exportValue('id_pays'),
                                               $formulaire->exportValue('telephone_fixe'),
                                               $formulaire->exportValue('telephone_portable'),
-                                              $formulaire->exportValue('etat'));
+                                              $formulaire->exportValue('etat'),
+                                              $formulaire->exportValue('max_members'));
         } else {
             $ok = $personnes_morales->modifier($_GET['id'],
                                                $formulaire->exportValue('civilite'),
@@ -128,7 +131,8 @@ if ($action == 'lister') {
                                                $formulaire->exportValue('id_pays'),
                                                $formulaire->exportValue('telephone_fixe'),
                                                $formulaire->exportValue('telephone_portable'),
-                                               $formulaire->exportValue('etat'));
+                                               $formulaire->exportValue('etat'),
+                                               $formulaire->exportValue('max_members'));
         }
 
         if ($ok) {

--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -79,6 +79,9 @@ if ($action == 'lister') {
     $personnes_morales = new Personnes_Morales($bdd);
     $pays = new Pays($bdd);
 
+    /**
+     * @var $formulaire HTML_QuickForm
+     */
     $formulaire = &instancierFormulaire();
     if ($action == 'ajouter') {
         $mot_de_passe = md5(time());
@@ -100,6 +103,7 @@ if ($action == 'lister') {
     } else {
         $champs = $personnes_physiques->obtenir($_GET['id']);
         unset($champs['mot_de_passe']);
+
         $formulaire->setDefaults($champs);
     }
 
@@ -159,6 +163,7 @@ if ($action == 'lister') {
     }
     $formulaire->addElement('password', 'mot_de_passe' , 'Mot de passe' , array('size' => 30, 'maxlength' => 30));
     $formulaire->addElement('password', 'confirmation_mot_de_passe', '' , array('size' => 30, 'maxlength' => 30));
+    $formulaire->addElement('textarea', 'roles', 'Roles',  array('cols' => 42, 'rows' => 5));
 
     $formulaire->addElement('header' , 'boutons' , '');
     $formulaire->addElement('submit' , 'soumettre' , ucfirst($action));
@@ -172,6 +177,10 @@ if ($action == 'lister') {
     $formulaire->addRule('ville' , 'Ville manquante' , 'required');
     $formulaire->addRule('login' , 'Login manquant' , 'required');
     $formulaire->addRule(array('mot_de_passe', 'confirmation_mot_de_passe'), 'Le mot de passe et sa confirmation ne concordent pas', 'compare');
+
+    if ($formulaire->isSubmitted() && !empty($formulaire->exportValue('roles')) && @json_decode($formulaire->exportValue('roles')) === null) {
+        $formulaire->setElementError('roles', 'Les roles ne sont pas valides');
+    }
 
     if ($formulaire->validate()) {
         if ($action == 'ajouter') {
@@ -228,7 +237,8 @@ if ($action == 'lister') {
                 $formulaire->exportValue('telephone_fixe'),
                 $formulaire->exportValue('telephone_portable'),
                 $formulaire->exportValue('etat'),
-                $formulaire->exportValue('compte_svn'));
+                $formulaire->exportValue('compte_svn'),
+                $formulaire->exportValue('roles'));
         }
 
         if ($ok) {

--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -178,7 +178,7 @@ if ($action == 'lister') {
     $formulaire->addRule('login' , 'Login manquant' , 'required');
     $formulaire->addRule(array('mot_de_passe', 'confirmation_mot_de_passe'), 'Le mot de passe et sa confirmation ne concordent pas', 'compare');
 
-    if ($formulaire->isSubmitted() && !empty($formulaire->exportValue('roles')) && @json_decode($formulaire->exportValue('roles')) === null) {
+    if ($formulaire->isSubmitted() && !empty($formulaire->exportValue('roles')) && json_decode($formulaire->exportValue('roles')) === null) {
         $formulaire->setElementError('roles', 'Les roles ne sont pas valides');
     }
 

--- a/sources/Afup/Association/Personnes_Morales.php
+++ b/sources/Afup/Association/Personnes_Morales.php
@@ -109,24 +109,24 @@ class Personnes_Morales
      * @access public
      * @return bool     Succès de l'ajout
      */
-    function ajouter($civilite, $nom, $prenom, $email, $raison_sociale, $siret, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat)
+    function ajouter($civilite, $nom, $prenom, $email, $raison_sociale, $siret, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat, $max_members)
     {
-        $requete = 'INSERT INTO ';
-        $requete .= '  afup_personnes_morales (civilite, nom, prenom, email, raison_sociale, siret, adresse, code_postal, ville, id_pays, telephone_fixe, telephone_portable, etat) ';
-        $requete .= 'VALUES (';
-        $requete .= $civilite . ',';
-        $requete .= $this->_bdd->echapper($nom) . ',';
-        $requete .= $this->_bdd->echapper($prenom) . ',';
-        $requete .= $this->_bdd->echapper($email) . ',';
-        $requete .= $this->_bdd->echapper($raison_sociale) . ',';
-        $requete .= $this->_bdd->echapper($siret) . ',';
-        $requete .= $this->_bdd->echapper($adresse) . ',';
-        $requete .= $this->_bdd->echapper($code_postal) . ',';
-        $requete .= $this->_bdd->echapper($ville) . ',';
-        $requete .= $this->_bdd->echapper($id_pays) . ',';
-        $requete .= $this->_bdd->echapper($telephone_fixe) . ',';
-        $requete .= $this->_bdd->echapper($telephone_portable) . ',';
-        $requete .= $etat . ')';
+        $requete = 'INSERT INTO
+        afup_personnes_morales (civilite, nom, prenom, email, raison_sociale, siret, adresse, code_postal, ville, id_pays, telephone_fixe, telephone_portable, etat, max_members)
+        VALUES (' . $civilite . ', ' .
+        $this->_bdd->echapper($nom) . ', ' .
+        $this->_bdd->echapper($prenom) . ', ' .
+        $this->_bdd->echapper($email) . ', ' .
+        $this->_bdd->echapper($raison_sociale) . ', ' .
+        $this->_bdd->echapper($siret) . ', ' .
+        $this->_bdd->echapper($adresse) . ', ' .
+        $this->_bdd->echapper($code_postal) . ', ' .
+        $this->_bdd->echapper($ville) . ', ' .
+        $this->_bdd->echapper($id_pays) . ', ' .
+        $this->_bdd->echapper($telephone_fixe) . ', ' .
+        $this->_bdd->echapper($telephone_portable) . ', ' .
+        $this->_bdd->echapper($etat) . ', ' .
+        $this->_bdd->echapper($max_members) . ')';
         return $this->_bdd->executer($requete);
 
     }
@@ -145,26 +145,28 @@ class Personnes_Morales
      * @access public
      * @return bool     Succès de l'ajout
      */
-    function modifier($id, $civilite, $nom, $prenom, $email, $raison_sociale, $siret, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat)
+    function modifier($id, $civilite, $nom, $prenom, $email, $raison_sociale, $siret, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat, $max_members = null)
     {
-        $requete = 'UPDATE ';
-        $requete .= '  afup_personnes_morales ';
-        $requete .= 'SET';
-        $requete .= '  civilite=' . $civilite . ',';
-        $requete .= '  nom=' . $this->_bdd->echapper($nom) . ',';
-        $requete .= '  prenom=' . $this->_bdd->echapper($prenom) . ',';
-        $requete .= '  email=' . $this->_bdd->echapper($email) . ',';
-        $requete .= '  raison_sociale=' . $this->_bdd->echapper($raison_sociale) . ',';
-        $requete .= '  siret=' . $this->_bdd->echapper($siret) . ',';
-        $requete .= '  adresse=' . $this->_bdd->echapper($adresse) . ',';
-        $requete .= '  code_postal=' . $this->_bdd->echapper($code_postal) . ',';
-        $requete .= '  ville=' . $this->_bdd->echapper($ville) . ',';
-        $requete .= '  id_pays=' . $this->_bdd->echapper($id_pays) . ',';
-        $requete .= '  telephone_fixe=' . $this->_bdd->echapper($telephone_fixe) . ',';
-        $requete .= '  telephone_portable=' . $this->_bdd->echapper($telephone_portable) . ',';
-        $requete .= '  etat=' . $this->_bdd->echapper($etat) . ' ';
-        $requete .= 'WHERE';
-        $requete .= '  id=' . $id;
+        $requete  = 'UPDATE 
+          afup_personnes_morales 
+        SET
+          civilite=' . $civilite . ',
+          nom=' . $this->_bdd->echapper($nom) . ',
+          prenom=' . $this->_bdd->echapper($prenom) . ',
+          email=' . $this->_bdd->echapper($email) . ',
+          raison_sociale=' . $this->_bdd->echapper($raison_sociale) . ',
+          siret=' . $this->_bdd->echapper($siret) . ',
+          adresse=' . $this->_bdd->echapper($adresse) . ',
+          code_postal=' . $this->_bdd->echapper($code_postal) . ',
+          ville=' . $this->_bdd->echapper($ville) . ',
+          id_pays=' . $this->_bdd->echapper($id_pays) . ',
+          telephone_fixe=' . $this->_bdd->echapper($telephone_fixe) . ',
+          telephone_portable=' . $this->_bdd->echapper($telephone_portable) . ',
+          etat=' . $this->_bdd->echapper($etat) ;
+        if ($max_members !== null) {
+            $requete .= ', max_members = ' . $this->_bdd->echapper($max_members);
+        }
+        $requete .= 'WHERE  id=' . (int)$id;
         return $this->_bdd->executer($requete);
     }
 

--- a/sources/Afup/Association/Personnes_Physiques.php
+++ b/sources/Afup/Association/Personnes_Physiques.php
@@ -239,7 +239,7 @@ SQL;
      * @return bool Succès de la modification
      */
     function modifier($id, $id_personne_morale, $login, $mot_de_passe, $niveau, $niveau_modules, $civilite, $nom, $prenom,
-                      $email, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat, $compte_svn)
+                      $email, $adresse, $code_postal, $ville, $id_pays, $telephone_fixe, $telephone_portable, $etat, $compte_svn, $roles)
     {
         $erreur = $this->loginExists($id, $login);
         $erreur = $erreur || !$this->_companyExists($id_personne_morale);
@@ -269,6 +269,12 @@ SQL;
             $requete .= '  telephone_fixe=' . $this->_bdd->echapper($telephone_fixe) . ',';
             $requete .= '  telephone_portable=' . $this->_bdd->echapper($telephone_portable) . ',';
             $requete .= '  etat=' . $this->_bdd->echapper($etat) . ',';
+            if ($roles !== null) {
+                if (@json_decode($roles) === null) {
+                    return false;
+                }
+                $requete .= '  roles=' . $this->_bdd->echapper($roles) . ',';
+            }
             $requete .= '  compte_svn=' . $this->_bdd->echapper($compte_svn) . ' ';
             $requete .= 'WHERE';
             $requete .= '  id=' . $id;


### PR DESCRIPTION
Cette PR ajoute sur les pages de gestion des personnes morales la gestion du nombre de membre maximum permis par leur cotisation.
Elle ajoute également un simple champ permettant la gestion des rôles sur la page de gestion des personnes physiques.