### PR TITLE
ajout d'un champ personalisé pour mettre des metas sur les articles

### DIFF
--- a/event/resources/themes/basis/header.php
+++ b/event/resources/themes/basis/header.php
@@ -15,10 +15,6 @@
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<?php wp_head(); ?>
-    <?php $html_block = get_post_meta(get_the_ID(), 'html_head', true); ?>
-    <?php if ($html_block !== ''): ?>
-        <?php echo $html_block; ?>
-    <?php endif ?>
 </head>
 <body <?php body_class(); ?>>
 

--- a/event/resources/themes/basis/header.php
+++ b/event/resources/themes/basis/header.php
@@ -14,8 +14,11 @@
 
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
 	<?php wp_head(); ?>
+    <?php $html_block = get_post_meta(get_the_ID(), 'html_head', true); ?>
+    <?php if ($html_block !== ''): ?>
+        <?php echo $html_block; ?>
+    <?php endif ?>
 </head>
 <body <?php body_class(); ?>>
 

--- a/event/resources/themes/basis_child/functions.php
+++ b/event/resources/themes/basis_child/functions.php
@@ -31,3 +31,12 @@ function afup_website_func($attrs) {
     return $body;
 }
 add_shortcode('afup_website', 'afup_website_func');
+
+
+function add_custom_head() {
+    $html_block = get_post_meta(get_the_ID(), 'html_head', true);
+    if ($html_block !== '') {
+        echo $html_block;
+    }
+}
+add_filter('wp_head', 'add_custom_head');


### PR DESCRIPTION
On permet de d'ajouter un champ personalisé qui servira à
ajouter des metas afin d'afficher des twitter cards sur
les interviews.

Il existe des extensions, mais qui soient font trop de choses
en ajoutant les cartes en automatique conflictant avec l'extension
multilingue.
ou soit, pour d'autres extensions, permetant d'ajouter des metas,
seraient très fastidieuses à ajouter sur toutes les interviews.