### PR TITLE
Suppression du mot de passe en clair dans les mails

### DIFF
--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -69,7 +69,7 @@ if ($action == 'lister') {
 } elseif ($action == 'envoi_bienvenue') {
     $password = $personnes_physiques->generatePassword($_GET['id']);
     $data = $personnes_physiques->obtenir($_GET['id'], 'prenom, nom, email, login');
-    if ($personnes_physiques->sendWelcomeMailWithData($data['prenom'], $data['nom'], $data['login'], $password, $data['email'])) {
+    if ($personnes_physiques->sendWelcomeMailWithData($data['prenom'], $data['nom'], $data['login'], $data['email'])) {
         Logs::log('Envoi d\'un message de bienvenue à la personne physique ' . $_GET['id']);
         afficherMessage('Un mail de bienvenue a été envoyé à la personne physique', 'index.php?page=personnes_physiques&action=lister');
     } else {

--- a/sources/Afup/Association/Personnes_Physiques.php
+++ b/sources/Afup/Association/Personnes_Physiques.php
@@ -427,13 +427,13 @@ SQL;
         return false;
     }
 
-    public function sendWelcomeMailWithData($firstName, $lastName, $login, $password, $email)
+    public function sendWelcomeMailWithData($firstName, $lastName, $login, $email)
     {
         $mail = new Mail();
         return $mail->send(
             'confirmation-cr-ation-de-compte',
             ['email' => $email, 'name' => sprintf('%s %s', $firstName, $lastName)],
-            ['login' => $login, 'password' => $password]
+            ['login' => $login]
         );
     }
 

--- a/sources/AppBundle/Controller/LegacyController.php
+++ b/sources/AppBundle/Controller/LegacyController.php
@@ -173,7 +173,6 @@ class LegacyController extends Controller
                         $formulaire->exportValue('prenom'),
                         $formulaire->exportValue('nom'),
                         $formulaire->exportValue('login'),
-                        $formulaire->exportValue('mot_de_passe'),
                         $formulaire->exportValue('email')
                     );
 


### PR DESCRIPTION
Suite au tweet https://twitter.com/eliesse/status/908695853795127296, voici le fix pour supprimer l'envoi des mots de passe en clair dans les mails d'inscriptions.

Il est possible qu'un tour sur le template 'confirmation-cr-ation-de-compte' doit être fait avant le merge.