### PR TITLE
Fix affichage BO billets gratuits

### DIFF
--- a/htdocs/pages/administration/forum_inscriptions.php
+++ b/htdocs/pages/administration/forum_inscriptions.php
@@ -32,7 +32,7 @@ function updateGlobalsForTarif(
     global $AFUP_Tarifs_Forum, $AFUP_Tarifs_Forum_Lib;
     $event = $eventRepository->get($forumId);
     $ticketTypes = $ticketEventTypeRepository->getTicketsByEvent($event, false, false);
-    $AFUP_Tarifs_Forum_Lib = $AFUP_Tarifs_Forum = [];
+
     foreach ($ticketTypes as $ticketType) {
         /**
          * @var $ticketType \AppBundle\Event\Model\TicketEventType

--- a/htdocs/templates/administration/forum_inscriptions.html
+++ b/htdocs/templates/administration/forum_inscriptions.html
@@ -68,37 +68,6 @@
 
     <br/>
 
-    <strong>Nombre de personnes validées par type d'inscription</strong>
-
-    <ul>
-        <li>
-            Journée fonctionnelle :
-            {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PREMIERE_JOURNEE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PREMIERE_JOURNEE_ETUDIANT_PREVENTE]}
-            <em>dont {$statistiques.types_inscriptions.payants[$smarty.const.AFUP_FORUM_PREMIERE_JOURNEE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PREMIERE_JOURNEE_ETUDIANT_PREVENTE]} payants</em>
-        </li>
-        <li>
-            Journée technique :
-            {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_DEUXIEME_JOURNEE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_DEUXIEME_JOURNEE_ETUDIANT_PREVENTE]}
-            <em>dont {$statistiques.types_inscriptions.payants[$smarty.const.AFUP_FORUM_DEUXIEME_JOURNEE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_DEUXIEME_JOURNEE_ETUDIANT_PREVENTE]} payants</em>
-        </li>
-        <li>Deux jours :
-            {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_PREVENTE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_COUPON]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PROF]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_INVITATION]}
-            <em>dont {$statistiques.types_inscriptions.payants[$smarty.const.AFUP_FORUM_2_JOURNEES]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_PREVENTE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_COUPON]} payants</em>
-        </li>
-        <li>
-            Deux jours (membre AFUP) : {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_AFUP]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_AFUP_PREVENTE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_PREVENTE_ADHESION]}
-            <em>dont {$statistiques.types_inscriptions.payants[$smarty.const.AFUP_FORUM_2_JOURNEES_AFUP]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_AFUP_PREVENTE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_PREVENTE_ADHESION]} payants</em>
-        </li>
-        <li>Deux jours (etudiant) :
-            {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_ETUDIANT]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_ETUDIANT_PREVENTE]}
-            <em>dont {$statistiques.types_inscriptions.payants[$smarty.const.AFUP_FORUM_2_JOURNEES_ETUDIANT]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_2_JOURNEES_ETUDIANT_PREVENTE]} payants</em>
-        </li>
-        <li>Organisation, sponsor, presse, conférencier &amp; projets (non payants) :
-            {$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_ORGANISATION]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_SPONSOR]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PRESSE]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_CONFERENCIER]+$statistiques.types_inscriptions.inscrits[$smarty.const.AFUP_FORUM_PROJET]}
-        </li>
-    </ul>
-    <br/>
-
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
     <a href="index.php?page=forum_inscriptions&amp;action=ajouter&amp;id_forum={$id_forum}" title="Ajouter une inscription">Ajouter une inscription</a><br />
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />


### PR DESCRIPTION
Dans le BO les billets gratuits perdaient leurs libellés.

Je supprime également le tableau "Nombre de personnes validées par type d'inscription" qui n'est pas clair et affiche des infos en doublon avec le grand tableau