### PR TITLE
FIX #519: Changement règles inscriptions entreprises

### DIFF
--- a/app/Resources/translations/validators.fr.yml
+++ b/app/Resources/translations/validators.fr.yml
@@ -1,1 +1,7 @@
 'Another entity exists for this data: {{ data }}': 'Un autre compte existe avec cette information: {{ data }}'
+'You cannot order as many tickets at the discounted rate': 'Vous ne pouvez pas commander autant de billets au tarif réduit'
+'You must be connected to order this ticket.': 'Vous devez être connecté pour commander ce ticket.'
+'You must have paid your membership fee to order this ticket.': 'Vous devez être à jour de cotisation pour commander ce ticket.'
+'This ticket is not available anymore.': "Ce ticket n'est plus disponible."
+'You must use the same email for your ticket and you membership.': "Vous devez utiliser l'adresse email liée à votre adhésion pour ce billet."
+'You must be connected with a valid membership to order this ticket.': "Vous devez être connecté et avoir une adhésion en cours de validité pour commander ce billet"

--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -56,11 +56,15 @@
         <div class="tickets--members-detail">
             {% if app.user %}
                 {% if app.user.companyId > 0 %}
-                    <p>{{ 'Vous êtes connecté avec un compte AFUP d\'entreprise. Pour acheter des places au tarif AFUP, celles-ci doivent être enregistrées pour les membres de votre adhésion.'|trans }}</p>
+                    <p>{{ 'Vous êtes connecté avec le compte AFUP de l\'entreprise %company%. Votre cotisation est valable pour %maxMembers% salarié·e·s. Vous pouvez donc acheter %maxMembers% tickets au tarif AFUP pour cet événement - pour qui vous voulez !'|trans({ '%maxMembers%': app.user.company.maxMembers, '%company%': app.user.company.companyName}) }}</p>
+                    <p>{{ 'Vous avez déjà acheté %soldTickets% ticket(s) au tarif AFUP pour cet événément.'|trans({'%soldTickets%': soldTicketsForMember}) }}</p>
                 {% else %}
-                    <p>{{ 'Vous êtes connecté avec un compte AFUP personnel. Vous pouvez acheter une place au tarif membre pour vous seul.'|trans }}</p>
+                    <p>{{ 'Vous êtes connecté avec un compte AFUP personnel. Vous pouvez acheter une place au tarif membre pour vous seul. Pour être valable, cette place doit être enregistrée avec l\'adresse %mail%.'|trans({'%mail%': app.user.email}) }}</p>
                 {% endif %}
-                {% if app.user.lastSubscription < event.dateEnd %}
+
+                {% if app.user.lastSubscription < date() %}
+                    <p><strong>{{ "Attention votre cotisation est expirée. Pour souscrire des places au tarif afup, renouvelez votre cotisation dans le <a href='%url%'>back-office</a>."|trans({'%url%': url('admin_login' ) })|raw }}</strong></p>
+                {% elseif app.user.lastSubscription < event.dateEnd %}
                     <p><strong>{{ "Attention votre cotisation ne sera plus valable le jour de l'événement. Vous pouvez commander des billets au tarif AFUP mais vous devrez renouveler votre cotisation pour pouvoir accéder à l'événement."|trans }}</strong></p>
                 {% endif %}
             {% else %}
@@ -71,6 +75,7 @@
         {% if not ticketForm.vars.valid %}
             <div class="tickets--errors">
                 {{ 'Une ou plusieurs erreurs sont survenues. Merci de vérifier le formulaire' }}
+                {{ form_errors(ticketForm) }}
             </div>
         {% endif %}
 

--- a/htdocs/css/tickets.css
+++ b/htdocs/css/tickets.css
@@ -164,6 +164,11 @@ div.tickets--bankwire{
     display: none;
     margin-left:200px;
 }
+
+div.tickets--errors ul.tickets--errors{
+    margin-left: 1em;
+}
+
 ul.tickets--errors, #fieldset--7 div{
     margin-left:200px;
 }

--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -302,13 +302,18 @@ SQL;
                           $filtre = false)
     {
         $requete = 'SELECT
-          ' . $champs . ' , (SELECT MAX(ac.date_fin) AS lastsubcription
-        FROM afup_personnes_physiques app
-        LEFT JOIN afup_personnes_morales apm ON apm.id = app.id_personne_morale
-        LEFT JOIN afup_cotisations ac ON ac.type_personne = IF(apm.id IS NULL, 0, 1) AND ac.id_personne = IFNULL(apm.id, app.id)
-        WHERE app.email COLLATE latin1_swedish_ci = i.email
-        GROUP BY app.`id`
-        ) AS lastsubscription
+          ' . $champs . ' , 
+            
+            CASE WHEN i.id_member IS NOT NULL
+            THEN ( SELECT MAX(ac.date_fin) AS lastsubcription FROM afup_cotisations ac WHERE ac.type_personne = i.member_type AND ac.id_personne = i.id_member )
+            ELSE (SELECT MAX(ac.date_fin) AS lastsubcription
+                FROM afup_personnes_physiques app
+                LEFT JOIN afup_personnes_morales apm ON apm.id = app.id_personne_morale
+                LEFT JOIN afup_cotisations ac ON ac.type_personne = IF(apm.id IS NULL, 0, 1) AND ac.id_personne = IFNULL(apm.id, app.id)
+                WHERE app.email COLLATE latin1_swedish_ci = i.email
+                GROUP BY app.`id`
+                )
+            END AS lastsubscription
         FROM
           afup_inscription_forum i 
         LEFT JOIN afup_facturation_forum f ON i.reference = f.reference 

--- a/sources/AppBundle/Association/Model/Repository/UserRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/UserRepository.php
@@ -91,7 +91,10 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
          */
         $queryBuilder = $this->getQueryBuilder(self::QUERY_SELECT);
         $queryBuilder
-            ->cols(['app.`id`', 'app.`login`', 'app.`prenom`', 'app.`nom`', 'app.`email`'])
+            ->cols([
+                'app.`id`', 'app.`login`', 'app.`prenom`', 'app.`nom`',
+                'app.`email`', 'apm.`id`', 'apm.`raison_sociale`', 'apm.`max_members`'
+            ])
             ->from('afup_personnes_physiques app')
             ->join('LEFT', 'afup_personnes_morales apm', 'apm.id = app.id_personne_morale')
             ->join('LEFT', 'afup_cotisations ac', 'ac.type_personne = IF(apm.id IS NULL, 0, 1) AND ac.id_personne = IFNULL(apm.id, app.id)')
@@ -137,6 +140,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
         return (new HydratorSingleObject())
             ->mapAliasTo('lastsubcription', 'app', 'setLastSubscription')
             ->mapAliasTo('hash', 'app', 'setHash')
+            ->mapObjectTo('apm', 'app', 'setCompany')
         ;
     }
 

--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -125,6 +125,11 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
     private $lastSubscription;
 
     /**
+     * @var CompanyMember
+     */
+    private $company;
+
+    /**
      * @return int
      */
     public function getId()
@@ -484,6 +489,32 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
         if ($sub !== null) {
             $this->lastSubscription = \DateTimeImmutable::createFromFormat('U', $sub);
         }
+    }
+
+    /**
+     * @return CompanyMember
+     */
+    public function getCompany()
+    {
+        return $this->company;
+    }
+
+    /**
+     * @param CompanyMember $company
+     * @return User
+     */
+    public function setCompany(CompanyMember $company)
+    {
+        $this->company = $company;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isMemberForCompany()
+    {
+        return ($this->companyId !== null && $this->companyId > 0);
     }
 
     /**

--- a/sources/AppBundle/Controller/TicketController.php
+++ b/sources/AppBundle/Controller/TicketController.php
@@ -202,8 +202,7 @@ class TicketController extends EventBaseController
                 $memberType = UserRepository::USER_TYPE_COMPANY;
             }
 
-            foreach ($tickets as $ticket)
-            {
+            foreach ($tickets as $ticket) {
                 if ($ticket->getTicketEventType()->getTicketType()->getIsRestrictedToMembers()) {
                     if ($user instanceof User && $user->isMemberForCompany()) {
                         $ticket

--- a/sources/AppBundle/Event/Model/Invoice.php
+++ b/sources/AppBundle/Event/Model/Invoice.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Event\Model;
 
 use Afup\Site\Utils\Pays;
+use AppBundle\Event\Validator\Constraints as AfupAssert;
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -116,6 +117,7 @@ class Invoice implements NotifyPropertyInterface
     /**
      * @var Ticket[]
      * @Assert\Valid()
+     * @AfupAssert\CorporateMember(groups={"corporate"})
      */
     private $tickets = [];
 

--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -6,6 +6,7 @@ use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Invoice;
 use AppBundle\Event\Model\Ticket;
 use CCMBenchmark\Ting\Driver\Mysqli\Serializer\Boolean;
+use CCMBenchmark\Ting\Query\QueryException;
 use CCMBenchmark\Ting\Repository\HydratorArray;
 use CCMBenchmark\Ting\Repository\HydratorSingleObject;
 use CCMBenchmark\Ting\Repository\Metadata;
@@ -18,6 +19,27 @@ class TicketRepository extends Repository implements MetadataInitializer
     public function getByReference($reference)
     {
         return $this->getBy(['reference' => $reference]);
+    }
+
+    public function getTotalOfSoldTicketsByMember($userType, $userId, $eventId)
+    {
+        try {
+            return $this->getPreparedQuery(
+                'SELECT COUNT(inscriptions.id) AS total
+            FROM afup_inscription_forum inscriptions
+            WHERE inscriptions.id_member = :member
+            AND inscriptions.member_type = :type
+            AND inscriptions.id_forum = :forum
+            AND inscriptions.etat = :state'
+            )->setParams([
+                'member' => $userId,
+                'type' => $userType,
+                'forum' => $eventId,
+                'state' => Ticket::STATUS_PAID
+            ])->query($this->getCollection(new HydratorArray()))->first()['total'];
+        } catch (QueryException $exception) {
+            return 0;
+        }
     }
 
     public function getByInvoiceWithDetail(Invoice $invoice)
@@ -191,6 +213,16 @@ class TicketRepository extends Repository implements MetadataInitializer
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'forumId',
+                'type' => 'int'
+            ])
+            ->addField([
+                'columnName' => 'id_member',
+                'fieldName' => 'memberId',
+                'type' => 'int'
+            ])
+            ->addField([
+                'columnName' => 'member_type',
+                'fieldName' => 'memberType',
                 'type' => 'int'
             ])
             ->addField([

--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -9,7 +9,6 @@ use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 /**
  * @Assert\LoggedInMember(groups={"personal"})
  * @Assert\PublicTicket(groups={"not_logged_in"})
- * @Assert\CorporateMember(groups={"corporate"})
  * @Assert\AvailableTicket()
  */
 class Ticket implements NotifyPropertyInterface
@@ -160,6 +159,16 @@ class Ticket implements NotifyPropertyInterface
      * @var int
      */
     private $forumId;
+
+    /**
+     * @var int
+     */
+    private $memberType;
+
+    /**
+     * @var int
+     */
+    private $memberId;
 
     /**
      * @var bool
@@ -568,6 +577,48 @@ class Ticket implements NotifyPropertyInterface
     {
         $this->propertyChanged('forumId', $this->forumId, $forumId);
         $this->forumId = $forumId;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemberType()
+    {
+        return $this->memberType;
+    }
+
+    /**
+     * @param int $memberType
+     * @return Ticket
+     */
+    public function setMemberType($memberType)
+    {
+        $memberType = (int) $memberType;
+        $this->propertyChanged('memberType', $this->memberType, $memberType);
+
+        $this->memberType = $memberType;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemberId()
+    {
+        return $this->memberId;
+    }
+
+    /**
+     * @param int $memberId
+     * @return Ticket
+     */
+    public function setMemberId($memberId)
+    {
+        $memberId = (int)$memberId;
+        $this->propertyChanged('memberId', $this->memberId, $memberId);
+
+        $this->memberId = $memberId;
         return $this;
     }
 

--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -615,7 +615,7 @@ class Ticket implements NotifyPropertyInterface
      */
     public function setMemberId($memberId)
     {
-        $memberId = (int)$memberId;
+        $memberId = (int) $memberId;
         $this->propertyChanged('memberId', $this->memberId, $memberId);
 
         $this->memberId = $memberId;

--- a/sources/AppBundle/Event/Validator/Constraints/CorporateMember.php
+++ b/sources/AppBundle/Event/Validator/Constraints/CorporateMember.php
@@ -11,11 +11,11 @@ use Symfony\Component\Validator\Constraint;
 class CorporateMember extends Constraint
 {
     public $messageNotLoggedIn = 'You must be connected to order this ticket.';
-    public $messageBadMail = 'This email is not a valid member of your company. Please check your membership.';
     public $messageFeeOutOfDate = 'You must have paid your membership fee to order this ticket.';
+    public $messageTooMuchRestrictedTickets = 'You cannot order as many tickets at the discounted rate.';
 
     public function getTargets()
     {
-        return self::CLASS_CONSTRAINT;
+        return self::PROPERTY_CONSTRAINT;
     }
 }

--- a/sources/AppBundle/Event/Validator/Constraints/CorporateMemberValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/CorporateMemberValidator.php
@@ -92,13 +92,12 @@ class CorporateMemberValidator extends ConstraintValidator
             $eventId
         );
 
-        if ( ($ticketsSoldToThisCompany + $restrictedTickets) > $company->getMaxMembers() ) {
+        if (($ticketsSoldToThisCompany + $restrictedTickets) > $company->getMaxMembers()) {
             $this->context->buildViolation($constraint->messageTooMuchRestrictedTickets)
                 ->atPath('tickets')
                 ->addViolation()
             ;
             return;
         }
-
     }
 }

--- a/sql/2017-11-28-inscriptions-entreprises.sql
+++ b/sql/2017-11-28-inscriptions-entreprises.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `afup_inscription_forum`
+ADD `id_member` int unsigned NULL AFTER `id_forum`,
+ADD `member_type` int unsigned NULL AFTER `id_member`;
+
+ALTER TABLE `afup_personnes_physiques`
+ADD INDEX `email` (`email`);


### PR DESCRIPTION
Les nouvelles règles d'inscriptions des entreprises incluent le fait qu'elles ont le droit de commander autant de places qu'elles ont de membres autorisés par leur cotisation.

Cette PR effectue donc les changements côté formulaire, ainsi que dans le BO au niveau de l'affichage de la validité des cotisations. Au passage les membres "classiques" profitent d'une amélioration: nous ne nous basons plus sur l'email pour effectuer la vérification de cotisations mais sur l'id du membre. Cela permettra d'éviter des cas de changement d'adresse mail rattachée au compte entre l'inscription et l'événement.