### PR TITLE
on passe le nombre de meetups par page à 14

### DIFF
--- a/htdocs/js/meetups/list.js
+++ b/htdocs/js/meetups/list.js
@@ -16,7 +16,7 @@ search.addWidget(
 
 search.addWidget(
     instantsearch.widgets.hits({
-        hitsPerPage: 7,
+        hitsPerPage: 14,
         container: '#hits-container',
         templates: {
             empty: "Pas de résultat",


### PR DESCRIPTION
Cela permettra d'avoir tous les meetups à venir de chaque antenne
sur la première page si chaque antenne à un meetup à venir.