### PR TITLE
correction de la condition d'affichage des photos des speakers dans le BO

### DIFF
--- a/htdocs/pages/administration/forum_conferenciers.php
+++ b/htdocs/pages/administration/forum_conferenciers.php
@@ -239,8 +239,7 @@ if ($action == 'inscrire_forum') {
         $formulaire->addElement('file', 'photo', 'Photo (90x120)');
     }
     if ($action == 'modifier') {
-
-        if (intval($valeurs['id_forum']) < ID_FORUM_PHOTO_STORAGE) {
+        if (intval($champs['id_forum']) < ID_FORUM_PHOTO_STORAGE) {
             if (is_file($imagePath)) {
                 $formulaire->addElement('static', 'html', '', '<img src="/templates/' . $rs['path'] . '/images/intervenants/' . $_GET['id'] . '.jpg" /><br />');
             }


### PR DESCRIPTION
Les photos des speakers n'étaient pas affichées dans le BO car l'id du forum était toujours NULL.