### PR TITLE
correction de l'affichage de la page de blog conferenciers quand les …

### DIFF
--- a/sources/AppBundle/Event/JsonLd.php
+++ b/sources/AppBundle/Event/JsonLd.php
@@ -79,19 +79,25 @@ class JsonLd
                 ];
             }
 
-            $subEvents[] = [
+            $subEvent = [
                 '@type' => 'Event',
                 'name' => $talkInfo['talk']->getTitle(),
                 'description' => html_entity_decode(strip_tags($talkInfo['talk']->getDescription())),
                 'location' => [
                     '@type' => 'Place',
-                    'name' => $talkInfo['room']->getName(),
+                    'name' => $talkInfo['room'] ? $talkInfo['room']->getName() : '',
                     'address' => $event->getPlaceAddress()
                 ],
                 'performers' => $performers,
-                'startDate' => $talkInfo['planning']->getStart()->format('c'),
-                'endDate' => $talkInfo['planning']->getEnd()->format('c')
+
             ];
+
+            if ($talkInfo['planning']) {
+                $subEvent['startDate'] = $talkInfo['planning']->getStart()->format('c');
+                $subEvent['endDate'] = $talkInfo['planning']->getEnd()->format('c');
+            }
+
+            $subEvents[] = $subEvent;
         }
 
         $offers = [];


### PR DESCRIPTION
…talks ne sont pas planifiés

Lors de l'annonce du programme les talks ne sont pas encore plannifés,
on fait donc en sorte que le json-ld gère ce cas.