### PR TITLE
correction des tweets automatiques quand le compte twitter en base est l'url vers celui-ci

### DIFF
--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -278,13 +278,7 @@ class Speaker implements NotifyPropertyInterface
     {
         $twitter = $this->getTwitter();
         $twitter = trim($twitter, '@');
-        if (0 === strpos($twitter, 'https://twitter.com/')) {
-            $twitter = substr($twitter, strlen('https://twitter.com/'));
-        }
-
-        if (0 === strpos($twitter, 'http://twitter.com/')) {
-            $twitter = substr($twitter, strlen('http://twitter.com/'));
-        }
+        $twitter = preg_replace('!^https?://twitter.com/!', '', $twitter);
 
         if (0 === strlen(trim($twitter))) {
             return null;

--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -282,6 +282,10 @@ class Speaker implements NotifyPropertyInterface
             $twitter = substr($twitter, strlen('https://twitter.com/'));
         }
 
+        if (0 === strpos($twitter, 'http://twitter.com/')) {
+            $twitter = substr($twitter, strlen('http://twitter.com/'));
+        }
+
         if (0 === strlen(trim($twitter))) {
             return null;
         }

--- a/sources/AppBundle/VideoNotifier/TweetGenerator.php
+++ b/sources/AppBundle/VideoNotifier/TweetGenerator.php
@@ -29,13 +29,10 @@ class TweetGenerator
     {
         $twitters = [];
         foreach ($speakers as $speaker) {
-            if (!$twitter = $speaker->getTwitter()) {
+            if (!$twitter = $speaker->getCleanedTwitter()) {
                 $twitters[] = $speaker->getLabel();
             } else {
-                if ($twitter[0] != '@') {
-                    $twitter = '@' . $twitter;
-                }
-                $twitters[] = $twitter;
+                $twitters[] = "@" . $twitter;
             }
         }
 

--- a/tests/units/AppBundle/VideoNotifier/TweetGenerator.php
+++ b/tests/units/AppBundle/VideoNotifier/TweetGenerator.php
@@ -169,6 +169,38 @@ class TweetGenerator extends \atoum
                 ],
                 'expected' => "Et si on utilisait WordPress ? La conférence de @BoiteAWeb à revoir sur le site de l'AFUP : https://afup.org/talks/1295-et-si-on-utilisait-wordpress",
 
+            ],
+            [
+                'case' => "Speaker avec compte twitter ayant une URL complète en http",
+                'talk' => [
+                    'id' => 2314,
+                    'title' => 'Les hexagones de la Ruche qui dit Oui !',
+                ],
+                'speakers' => [
+                    [
+                        'firstname' => 'Benoit',
+                        'lastname' => 'Merlet',
+                        'twitter' => "http://twitter.com/trompouet",
+                    ]
+                ],
+                'expected' => "Les hexagones de la Ruche qui dit Oui ! La conférence de @trompouet à revoir sur le site de l'AFUP : https://afup.org/talks/2314-les-hexagones-de-la-ruche-qui-dit-oui",
+
+            ],
+            [
+                'case' => "Speaker avec compte twitter ayant une URL complète en https",
+                'talk' => [
+                    'id' => 2314,
+                    'title' => 'Les hexagones de la Ruche qui dit Oui !',
+                ],
+                'speakers' => [
+                    [
+                        'firstname' => 'Benoit',
+                        'lastname' => 'Merlet',
+                        'twitter' => "https://twitter.com/trompouet",
+                    ]
+                ],
+                'expected' => "Les hexagones de la Ruche qui dit Oui ! La conférence de @trompouet à revoir sur le site de l'AFUP : https://afup.org/talks/2314-les-hexagones-de-la-ruche-qui-dit-oui",
+
             ]
         ];
     }


### PR DESCRIPTION
Nous pouvions avoir des cas comme celui-ci qui se produisaient :

```
Les hexagones de la Ruche qui dit Oui ! La conférence de @https://twitter.com/trompouet à revoir sur le site de l'AFUP : https://afup.org/talks/2314-les-hexagones-de-la-ruche-qui-dit-oui
```