### PR TITLE
gestion des emojis sur la saisie/export des tags

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -314,7 +314,7 @@ ting:
     connections:
         main:
             namespace: CCMBenchmark\Ting\Driver\Mysqli
-            charset: utf8
+            charset: utf8mb4
             master:
                 host:     "%database_host%"
                 port:     "%database_port%"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -385,4 +385,4 @@ services:
 
     app.registration_export_generator:
         class : AppBundle\Event\Ticket\RegistrationsExportGenerator
-        arguments: ["@app.offices_finder", "@app.legacy_inscriptions", "@app.legacy_cotisations", "@app.invoice_repository", "@app.user_repository"]
+        arguments: ["@app.offices_finder", "@app.legacy_cotisations", "@app.ticket_repository", "@app.invoice_repository", "@app.user_repository"]

--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -86,6 +86,24 @@ class TicketRepository extends Repository implements MetadataInitializer
     }
 
     /**
+     * @param Event $event
+     *
+     * @return Ticket[]
+     */
+    public function getByEvent(Event $event)
+    {
+        $sql = 'SELECT afup_inscription_forum.*
+        FROM afup_inscription_forum
+        WHERE afup_inscription_forum.id_forum = :id_forum
+        ORDER BY afup_inscription_forum.date';
+
+        return $this->getPreparedQuery($sql)
+            ->setParams(['id_forum' => $event->getId()])
+            ->query($this->getCollection(new HydratorSingleObject()))
+        ;
+    }
+
+    /**
      * @return \CCMBenchmark\Ting\Repository\CollectionInterface
      */
     public function getAllTicketsForExport()

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -8,6 +8,7 @@ use AppBundle\Association\Model\User;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\InvoiceRepository;
 use AppBundle\Event\Model\Repository\TicketRepository;
+use AppBundle\Event\Model\Ticket;
 use AppBundle\Offices\OfficeFinder;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
@@ -92,7 +93,7 @@ class RegistrationsExportGenerator
         $tickets = $this->ticketRepository->getByEvent($event);
 
         foreach ($tickets as $ticket) {
-            if ($ticket->getStatus() == AFUP_FORUM_ETAT_ANNULE) {
+            if ($ticket->getStatus() == Ticket::STATUS_CANCELLED) {
                 // On n'exporte pas les billets inscriptions annulées
                 continue;
             }

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -3,11 +3,11 @@
 namespace AppBundle\Event\Ticket;
 
 use Afup\Site\Association\Cotisations;
-use Afup\Site\Forum\Inscriptions;
 use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Association\Model\User;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\InvoiceRepository;
+use AppBundle\Event\Model\Repository\TicketRepository;
 use AppBundle\Offices\OfficeFinder;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
@@ -17,11 +17,6 @@ class RegistrationsExportGenerator
      * @var OfficeFinder
      */
     private $officeFinder;
-
-    /**
-     * @var Inscriptions
-     */
-    private $inscriptions;
 
     /**
      * @var Cotisations
@@ -34,17 +29,22 @@ class RegistrationsExportGenerator
     private $invoiceRepository;
 
     /**
+     * @var TicketRepository
+     */
+    private $ticketRepository;
+
+    /**
      * @param OfficeFinder $officeFinder
-     * @param Inscriptions $inscriptions
      * @param Cotisations $cotisations
+     * @param TicketRepository $ticketRepository
      * @param InvoiceRepository $invoiceRepository
      * @param UserRepository $userRepository
      */
-    public function __construct(OfficeFinder $officeFinder, Inscriptions $inscriptions, Cotisations $cotisations, InvoiceRepository $invoiceRepository, UserRepository $userRepository)
+    public function __construct(OfficeFinder $officeFinder, Cotisations $cotisations, TicketRepository $ticketRepository, InvoiceRepository $invoiceRepository, UserRepository $userRepository)
     {
         $this->officeFinder = $officeFinder;
-        $this->inscriptions = $inscriptions;
         $this->cotisations = $cotisations;
+        $this->ticketRepository = $ticketRepository;
         $this->invoiceRepository = $invoiceRepository;
         $this->userRepository = $userRepository;
     }
@@ -89,30 +89,31 @@ class RegistrationsExportGenerator
      */
     protected function getFromRegistrationsOnEvent(Event $event)
     {
-        $inscriptionsData = $this->inscriptions->obtenirListe($event->getId());
-        foreach ($inscriptionsData as $inscriptionsDataRow) {
-            if ($inscriptionsDataRow['etat'] == AFUP_FORUM_ETAT_ANNULE) {
+        $tickets = $this->ticketRepository->getByEvent($event);
+
+        foreach ($tickets as $ticket) {
+            if ($ticket->getStatus() == AFUP_FORUM_ETAT_ANNULE) {
                 // On n'exporte pas les billets inscriptions annulées
                 continue;
             }
 
-            $invoice = $this->invoiceRepository->getByReference($inscriptionsDataRow['reference']);
+            $invoice = $this->invoiceRepository->getByReference($ticket->getReference());
 
             try {
-                $user = $this->userRepository->loadUserByUsername($inscriptionsDataRow['email']);
+                $user = $this->userRepository->loadUserByUsername($ticket->getEmail());
             } catch (UsernameNotFoundException $exception) {
                 $user = null;
             }
 
             yield [
-                'id' => $inscriptionsDataRow['id'],
+                'id' => $ticket->getId(),
                 'reference' => $invoice->getReference(),
-                'prenom' => $inscriptionsDataRow['prenom'],
-                'nom' => $inscriptionsDataRow['nom'],
+                'prenom' => $ticket->getFirstname(),
+                'nom' => $ticket->getLastname(),
                 'societe' => $invoice->getCompany(),
-                'tags' => $this->extractAndCleanTags($inscriptionsDataRow['commentaires']),
-                'type_pass' => $this->getTypePass($inscriptionsDataRow['type_inscription']),
-                'email' => $inscriptionsDataRow['email'],
+                'tags' => $this->extractAndCleanTags($ticket->getComments()),
+                'type_pass' => $this->getTypePass($ticket->getTicketTypeId()),
+                'email' => $ticket->getEmail(),
                 'member_since' => null !== $user ? $this->comptureSeniority($user) : null,
                 'office' => $this->officeFinder->findOffice($invoice, $user),
                 'distance' => null,

--- a/sql/2018-05-05_emojis_tags.sql
+++ b/sql/2018-05-05_emojis_tags.sql
@@ -1,0 +1,1 @@
+ALTER TABLE afup_inscription_forum CHANGE commentaires commentaires text CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;


### PR DESCRIPTION
les emojis sont maintenant supportés dans la commande de génération des badges.
par contre l'enregistrement en base lors de l'inscription ne fonctionnait pas (ainsi que l'export csv), cette PR corrige cela.