### PR TITLE
correction de la récupération de la liste des inscrits

### DIFF
--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -53,7 +53,7 @@ class Mailchimp
                 'lists/' . $list . '/members',
                 [
                     'count' => self::MAX_MEMBERS_PER_PAGE,
-                    'offset' => $i,
+                    'offset' => $i * self::MAX_MEMBERS_PER_PAGE,
                     'fields' => 'members.email_address',
                     'status' => 'subscribed',
                 ]


### PR DESCRIPTION
On doit passer un offset et pas un numéro de page.

Cela ne posait pas de réel problème, mais on envoyait des inscriptions
en trop à chaque appel.