### PR TITLE
correction sur la modification de soumission

### DIFF
--- a/app/Resources/views/event/cfp/edit.html.twig
+++ b/app/Resources/views/event/cfp/edit.html.twig
@@ -64,11 +64,9 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-		document.querySelector('#talk_abstract').required = false;
 		var simplemde = new SimpleMDE({
 			spellChecker: false,
 			hideIcons: ['side-by-side', 'fullscreen']
 		});
-		document.querySelector('.CodeMirror textarea').required = true;
     </script>
 {% endblock %}

--- a/app/Resources/views/event/cfp/propose.html.twig
+++ b/app/Resources/views/event/cfp/propose.html.twig
@@ -18,11 +18,9 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-		document.querySelector('#talk_abstract').required = false;
 		var simplemde = new SimpleMDE({
 			spellChecker: false,
 			hideIcons: ['side-by-side', 'fullscreen']
 		});
-		document.querySelector('.CodeMirror textarea').required = true;
     </script>
 {% endblock %}

--- a/sources/AppBundle/Event/Form/TalkType.php
+++ b/sources/AppBundle/Event/Form/TalkType.php
@@ -19,7 +19,7 @@ class TalkType extends AbstractType
     {
         $builder
             ->add('title', TextType::class, ['label' => 'Titre'])
-            ->add('abstract', TextareaType::class, ['label' => 'Résumé'])
+            ->add('abstract', TextareaType::class, ['label' => 'Résumé', 'required' => false])
             ->add(
                 'staffNotes',
                 TextareaType::class,


### PR DESCRIPTION
Si on allait sur la page de modification d'une soumission, puis que l'on
soumettais le formulaire sans effectuer une modfication nous tombions
sur un message d'erreur car le champ un champ était requis.

Cela était dû à simpleMde. Afin de limiter les problèmes, on supprime la
validation html5. Il y a des contraintes sur l'objet talk, on a donc
des messages d'affichés si on ne saisi rien dans l'abstract.