### PR TITLE
Indication sous titrage sur page /talks

### DIFF
--- a/app/Resources/views/site/talks/list.html.twig
+++ b/app/Resources/views/site/talks/list.html.twig
@@ -43,6 +43,7 @@
                     <div id="refinement-has-video"></div>
                     <div id="refinement-has-slides"></div>
                     <div id="refinement-has-blog-post"></div>
+                    <div id="refinement-video-has-fr-subtitles"></div>
                     <div id="refinement-event"></div>
                     <div id="refinement-type"></div>
                     <div id="refinement-language"></div>

--- a/db/migrations/20180607095749_video_subtitles.php
+++ b/db/migrations/20180607095749_video_subtitles.php
@@ -1,0 +1,17 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class VideoSubtitles extends AbstractMigration
+{
+    public function change()
+    {
+$sql = <<<EOF
+ALTER TABLE `afup_sessions`
+  ADD `video_has_fr_subtitles` tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER `youtube_id`,
+  ADD `video_has_en_subtitles` tinyint(1) unsigned NOT NULL DEFAULT '0' AFTER `video_has_fr_subtitles`
+;
+EOF;
+        $this->execute($sql);
+    }
+}

--- a/htdocs/js/talk/list.js
+++ b/htdocs/js/talk/list.js
@@ -142,6 +142,21 @@ search.addWidget(
 );
 
 search.addWidget(
+    instantsearch.widgets.toggle({
+        container: '#refinement-video-has-fr-subtitles',
+        attributeName: 'video_has_fr_subtitles',
+        label: 'Avec sous titres français',
+        values: {
+            on: true
+        },
+        autoHideContainer: false,
+        templates: {
+            item: refinementItemTemplate
+        }
+    })
+);
+
+search.addWidget(
     instantsearch.widgets.refinementList({
         container: '#refinement-event',
         attributeName: 'event.title',

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -326,6 +326,9 @@ if ($action == 'lister') {
         $formulaire->addElement('text'    , 'slides_url'          , 'URL où trouver les slides' , array('size' => 80, 'maxlength' => 255));
         $formulaire->addElement('text'    , 'blog_post_url'          , 'URL de la version  article de blog de la conférence' , array('size' => 80, 'maxlength' => 255));
         $formulaire->addElement('select', 'language_code', 'Langue', Talk::getLanguageLabelsByKey());
+
+        $formulaire->addElement('checkbox'    , 'video_has_fr_subtitles'          , "Sous titres FR présents");
+        $formulaire->addElement('checkbox'    , 'video_has_en_subtitles'          , "Sous titres EN présents");
     }
 
     $formulaire->addElement('header', null, 'Conférencier(s)');
@@ -394,7 +397,9 @@ if ($action == 'lister') {
                                                 $valeurs['language_code'],
                                                 $valeurs['skill'],
                                                 $valeurs['needs_mentoring'],
-                                                $valeurs['use_markdown']
+                                                $valeurs['use_markdown'],
+                                                $valeurs['video_has_fr_subtitles'],
+                                                $valeurs['video_has_en_subtitles']
             );
             $forum_appel->delierSession($session_id);
         }

--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -678,7 +678,9 @@ class AppelConferencier
         $languageCode = null,
         $skill = null,
         $needs_mentoring = null,
-        $use_markdown = null
+        $use_markdown = null,
+        $video_has_fr_subtitles = null,
+        $video_has_en_subtitles = null
     ) {
         $requete = 'UPDATE afup_sessions SET ';
         $requete .= ' id_forum = ' . $this->_bdd->echapper($id_forum) . ', ';
@@ -709,6 +711,12 @@ class AppelConferencier
         }
         if ($use_markdown !== null) {
             $requete .= 'markdown = ' . $this->_bdd->echapper($use_markdown) . ', ';
+        }
+        if ($video_has_fr_subtitles !== null) {
+            $requete .= 'video_has_fr_subtitles = ' . $this->_bdd->echapper($video_has_fr_subtitles) . ', ';
+        }
+        if ($video_has_en_subtitles !== null) {
+            $requete .= 'video_has_en_subtitles = ' . $this->_bdd->echapper($video_has_en_subtitles) . ', ';
         }
         $requete .= ' plannifie = ' . $this->_bdd->echapper($plannifie) . ' ';
         $requete .= ' WHERE session_id = ' . (int)$id;

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -261,6 +261,16 @@ class TalkRepository extends Repository implements MetadataInitializer
                 'type' => 'string'
             ])
             ->addField([
+                'columnName' => 'video_has_fr_subtitles',
+                'fieldName' => 'videoHasFrSubtitles',
+                'type' => 'bool'
+            ])
+            ->addField([
+                'columnName' => 'video_has_en_subtitles',
+                'fieldName' => 'videoHasEnSubtitles',
+                'type' => 'bool'
+            ])
+            ->addField([
                 'columnName' => 'slides_url',
                 'fieldName' => 'slidesUrl',
                 'type' => 'string'

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -92,6 +92,16 @@ class Talk implements NotifyPropertyInterface
     private $youTubeId;
 
     /**
+     * @var bool
+     */
+    private $videoHasFrSubtitles = false;
+
+    /**
+     * @var bool
+     */
+    private $videoHasEnSubtitles = false;
+
+    /**
      * @var string|null
      */
     private $slidesUrl;
@@ -615,6 +625,50 @@ class Talk implements NotifyPropertyInterface
         $useMarkdown = (bool) $useMarkdown;
         $this->propertyChanged('useMarkdown', $this->useMarkdown, $useMarkdown);
         $this->useMarkdown = $useMarkdown;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function videoHasEnSubtitles()
+    {
+        return $this->videoHasEnSubtitles;
+    }
+
+    /**
+     * @param bool $videoHasEnSubtitles
+     *
+     * @return $this
+     */
+    public function setVideoHasEnSubtitles($videoHasEnSubtitles)
+    {
+        $videoHasEnSubtitles = (bool) $videoHasEnSubtitles;
+        $this->propertyChanged('useMarkdown', $this->videoHasEnSubtitles, $videoHasEnSubtitles);
+        $this->videoHasEnSubtitles = $videoHasEnSubtitles;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function videoHasFrSubtitles()
+    {
+        return $this->videoHasFrSubtitles;
+    }
+
+    /**
+     * @param bool $videoHasFrSubtitles
+     *
+     * @return $this
+     */
+    public function setVideoHasFrSubtitles($videoHasFrSubtitles)
+    {
+        $videoHasFrSubtitles = (bool) $videoHasFrSubtitles;
+        $this->propertyChanged('useMarkdown', $this->videoHasFrSubtitles, $videoHasFrSubtitles);
+        $this->videoHasFrSubtitles = $videoHasFrSubtitles;
+
         return $this;
     }
 }

--- a/sources/AppBundle/Indexation/Talks/Runner.php
+++ b/sources/AppBundle/Indexation/Talks/Runner.php
@@ -72,6 +72,8 @@ class Runner
                 'speakers.label',
                 'has_video',
                 'has_slides',
+                'video_has_fr_subtitles',
+                'video_has_en_subtitles',
                 'has_blog_post',
                 'type.label',
                 'language.label',

--- a/sources/AppBundle/Indexation/Talks/Transformer.php
+++ b/sources/AppBundle/Indexation/Talks/Transformer.php
@@ -37,6 +37,8 @@ class Transformer
             'has_slides' => $talk->hasSlidesUrl(),
             'has_joindin' => $talk->hasJoindinId(),
             'has_blog_post' => $talk->hasBlogPostUrl(),
+            'video_has_fr_subtitles' => $talk->videoHasFrSubtitles(),
+            'video_has_en_subtitles' => $talk->videoHasEnSubtitles(),
             'language' => [
                 'code' => $talk->getLanguageCode(),
                 'label' => $talk->getLanguageLabel(),

--- a/tests/units/AppBundle/Indexation/Talks/Transformer.php
+++ b/tests/units/AppBundle/Indexation/Talks/Transformer.php
@@ -97,6 +97,8 @@ class Transformer extends \atoum
                         'has_video' => true,
                         'video_url' => 'https://www.youtube.com/watch?v=hzn0ODTMNDk',
                         'video_id' => 'hzn0ODTMNDk',
+                        'video_has_fr_subtitles' => false,
+                        'video_has_en_subtitles' => false,
                         'has_slides' => true,
                         'slides_url' => 'http://tapoueh.org/images/confs/PHPTour_2014_PostgreSQL.pdf',
                         'has_joindin' => true,


### PR DESCRIPTION
Sur /talks on peux maintenant filtrer sur les talks qui sont sous titrés, via l'ajout de deux booléens en base. Pour l'instant sur la page on ajoute seulement le filtre sous titre français, mais dès qu'on aura des sous titres en anglais, on rajoutera le filtre.

![screenshot-2018-6-10 afup - videos des conferences](https://user-images.githubusercontent.com/320372/41206314-48c844ba-6d02-11e8-92ef-b29c212aec3e.png)
