### PR TITLE
639 ajouter une option pour activer ou non ga

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -14,14 +14,17 @@
         <link rel="icon" type="image/x-icon" href="{{ asset('/images/favicon.ico') }}" />
         <link rel="icon" type="image/png" sizes="64x64" href="{{ asset('/images/favicon.png') }}">
         <link rel="apple-touch-icon" sizes="57x57" href="{{ asset('/images/apple-touch-icon.png') }}">
-        <script>
-            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-            ga('create', 'UA-192127-3', 'auto');
-            ga('send', 'pageview');
-        </script>
+
+        {% if google_analytics_enabled %}
+            <script>
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+                ga('create', '{{ google_analytics_id }}', 'auto');
+                ga('send', 'pageview');
+            </script>
+        {% endif %}
     </head>
     <body id="body">
         <div id="afup-global-menu">

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -47,3 +47,6 @@ parameters:
     techno_watch_calendar_key: "9Yt0feebMyMrUWx"
 
     super_apero_csv_url: ""
+
+    google_analytics_enabled: false
+    google_analytics_id: "UA-192127-3"

--- a/app/config/parameters.yml.dist-docker
+++ b/app/config/parameters.yml.dist-docker
@@ -48,3 +48,6 @@ parameters:
     techno_watch_calendar_key: "9Yt0feebMyMrUWx"
 
     super_apero_csv_url: ""
+
+    google_analytics_enabled: false
+    google_analytics_id: "UA-192127-3"

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -4,16 +4,31 @@
 namespace AppBundle\Twig;
 
 use AppBundle\Routing\LegacyRouter;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
 
 class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
+    /**
+     * @var LegacyRouter
+     */
     private $legacyRouter;
+
+    /**
+     * @var \Parsedown
+     */
     private $parsedown;
 
-    public function __construct(LegacyRouter $legacyRouter, \Parsedown $parsedown)
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function __construct(LegacyRouter $legacyRouter, \Parsedown $parsedown, ContainerInterface $container)
     {
         $this->legacyRouter = $legacyRouter;
         $this->parsedown = $parsedown;
+        $this->container = $container;
     }
 
     /**
@@ -47,7 +62,11 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
 
     public function getGlobals()
     {
-        return ['legacy_router' => $this->legacyRouter];
+        return [
+            'legacy_router' => $this->legacyRouter,
+            'google_analytics_enabled' => $this->container->getParameter('google_analytics_enabled'),
+            'google_analytics_id' => $this->container->getParameter('google_analytics_id')
+        ];
     }
 
     /**


### PR DESCRIPTION
# Description
- Ajout de paramètres pour l'ID Google Analytics & son utilisation ou non (à `false` par défaut)
- Injection des variables en tant que globales dans `Twig_Environment`
- Utilisation de ces variables pour afficher / ou non GA

⚠️ Lors du déploiement il faut bien penser à ajouter les options correspondantes dans le fichier `parameters.yml`

# Tickets
- Fixes #639 