### PR TITLE
631 rendre le champ societe optionnel lors de la creation dun profil de speaker

### DIFF
--- a/db/seeds/Event.php
+++ b/db/seeds/Event.php
@@ -24,7 +24,7 @@ class Event extends AbstractSeed
                 'date_debut' => date('Y-m-d', $event),
                 'date_fin' => date('Y-m-d', $event + $oneDayInSeconds),
                 'annee' => date('Y', $event),
-                'text' => 'Lorem ipsum dolor amet cronut four loko cloud bread, chicharrones salvia chia vice aesthetic edison bulb ugh hashtag kogi venmo. Shaman raclette humblebrag cray tousled. Direct trade cliche keffiyeh small batch mustache. Marfa heirloom mixtape fingerstache deep v. 3 wolf moon keytar unicorn kitsch, pabst biodiesel umami pok pok ugh normcore iPhone tofu squid. Green juice vexillologist edison bulb echo park air plant adaptogen. Everyday carry flexitarian green juice, unicorn leggings mixtape prism knausgaard chambray cray woke helvetica tousled cred.',
+                'text' => '{"fr":"François le français", "en": "Henri l\'anglais"}',
                 'date_fin_appel_projet' => $now + $oneMonthInSeconds,
                 'date_fin_appel_conferencier' => $event - $oneMonthInSeconds * 2,
                 'date_fin_vote' => date('Y-m-d H:i:s', ($event - $oneMonthInSeconds * 2) + $oneDayInSeconds * 7),

--- a/db/seeds/Event.php
+++ b/db/seeds/Event.php
@@ -1,0 +1,48 @@
+<?php
+
+use Phinx\Seed\AbstractSeed;
+
+class Event extends AbstractSeed
+{
+    const ID_FORUM = 1;
+
+    public function run()
+    {
+        $now = time();
+        $oneDayInSeconds = 60*60*24;
+        $oneMonthInSeconds = $oneDayInSeconds*30;
+        $event = $now + $oneMonthInSeconds * 5;
+
+        $data = [
+            [
+                'id' => self::ID_FORUM,
+                'titre' => 'forum',
+                'path' => 'forum',
+                'trello_list_id' => null,
+                'logo_url' => 'http://78.media.tumblr.com/tumblr_lgkqc0mz9d1qfyzelo1_1280.jpg', // oui, c'est un chat
+                'nb_places' => 500,
+                'date_debut' => date('Y-m-d', $event),
+                'date_fin' => date('Y-m-d', $event + $oneDayInSeconds),
+                'annee' => date('Y', $event),
+                'text' => 'Lorem ipsum dolor amet cronut four loko cloud bread, chicharrones salvia chia vice aesthetic edison bulb ugh hashtag kogi venmo. Shaman raclette humblebrag cray tousled. Direct trade cliche keffiyeh small batch mustache. Marfa heirloom mixtape fingerstache deep v. 3 wolf moon keytar unicorn kitsch, pabst biodiesel umami pok pok ugh normcore iPhone tofu squid. Green juice vexillologist edison bulb echo park air plant adaptogen. Everyday carry flexitarian green juice, unicorn leggings mixtape prism knausgaard chambray cray woke helvetica tousled cred.',
+                'date_fin_appel_projet' => $now + $oneMonthInSeconds,
+                'date_fin_appel_conferencier' => $event - $oneMonthInSeconds * 2,
+                'date_fin_vote' => date('Y-m-d H:i:s', ($event - $oneMonthInSeconds * 2) + $oneDayInSeconds * 7),
+                'date_fin_prevente' => $now + $oneMonthInSeconds,
+                'date_fin_vente' => $event - $oneDayInSeconds * 7,
+                'date_fin_saisie_repas_speakers' => $event - $oneDayInSeconds * 7,
+                'date_fin_saisie_nuites_hotel' => $event - $oneDayInSeconds * 7,
+                'place_name' => 'Paris',
+                'place_address' => 'Marriott Rive Gauche'
+            ],
+        ];
+
+        $table = $this->table('afup_forum');
+        $table->truncate();
+
+        $table
+            ->insert($data)
+            ->save()
+        ;
+    }
+}

--- a/db/seeds/Users.php
+++ b/db/seeds/Users.php
@@ -28,14 +28,16 @@ class Users extends AbstractSeed
             ->save()
         ;
 
+        $now = time();
+        $oneMonthInSeconds = 60*60*24*30;
 
         $data = [
             [
-                'date_debut' => 1514761200, // 2018-01-01
+                'date_debut' => $now - $oneMonthInSeconds,
                 'type_personne' => 0, // AFUP_PERSONNE_PHYSIQUE
                 'id_personne' => self::ID_USER_ADMIN,
                 'montant' => 25,
-                'date_fin' => 1546300799, // 2018-12-31
+                'date_fin' => $now + $oneMonthInSeconds * 12,
             ]
         ];
 

--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -59,7 +59,6 @@ class Speaker implements NotifyPropertyInterface
     private $email;
 
     /**
-     * @Assert\NotBlank()
      * @var string
      */
     private $company;


### PR DESCRIPTION
J'avais commencé à regarder l'issue #631 et j'ai vu que c'était sur events.
Bref j'ai fait un seeder, autant le garder ça peut servir et j'ai modifier le seeder User pour qu'il soit toujours bon.

EDIT: Au final, après un peu de creusage j'ai réussi à accéder à la page correspondante et ai pu corrigé / tester le soucis.

# Issues
- Fixes #631 