### PR TITLE
Planification publication confs

### DIFF
--- a/db/migrations/20180705202558_conference_publication_date.php
+++ b/db/migrations/20180705202558_conference_publication_date.php
@@ -1,0 +1,16 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ConferencePublicationDate extends AbstractMigration
+{
+    public function change()
+    {
+        $sql = <<<SQL
+ALTER TABLE `afup_sessions`
+ADD `date_publication` datetime DEFAULT NULL
+;
+SQL;
+        $this->execute($sql);
+    }
+}

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -329,7 +329,9 @@ if ($action == 'lister') {
 
         $formulaire->addElement('checkbox'    , 'video_has_fr_subtitles'          , "Sous titres FR présents");
         $formulaire->addElement('checkbox'    , 'video_has_en_subtitles'          , "Sous titres EN présents");
+        $formulaire->addElement('date'  , 'date_publication'       , 'Date de publication'               , array('language' => 'fr', 'format' => "dMYH:i:s", 'minYear' => 2001, 'maxYear' => date('Y') + 5));
     }
+
 
     $formulaire->addElement('header', null, 'Conférencier(s)');
     $conferenciers = array(null => '' ) + $forum_appel->obtenirListeConferenciers($_GET['id_forum'], 'c.conferencier_id, CONCAT(c.nom, " ", c.prenom) as nom', 'c.nom, c.conferencier_id', true);
@@ -399,7 +401,8 @@ if ($action == 'lister') {
                                                 $valeurs['needs_mentoring'],
                                                 $valeurs['use_markdown'],
                                                 $valeurs['video_has_fr_subtitles'],
-                                                $valeurs['video_has_en_subtitles']
+                                                $valeurs['video_has_en_subtitles'],
+                                                $valeurs['date_publication']['Y'].'-'.$valeurs['date_publication']['M'].'-'.$valeurs['date_publication']['d'] . ' ' . $valeurs['date_publication']['H'] . ':' . $valeurs['date_publication']['i'] . ':' . $valeurs['date_publication']['s']
             );
             $forum_appel->delierSession($session_id);
         }

--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -680,7 +680,8 @@ class AppelConferencier
         $needs_mentoring = null,
         $use_markdown = null,
         $video_has_fr_subtitles = null,
-        $video_has_en_subtitles = null
+        $video_has_en_subtitles = null,
+        $date_publication = null
     ) {
         $requete = 'UPDATE afup_sessions SET ';
         $requete .= ' id_forum = ' . $this->_bdd->echapper($id_forum) . ', ';
@@ -717,6 +718,9 @@ class AppelConferencier
         }
         if ($video_has_en_subtitles !== null) {
             $requete .= 'video_has_en_subtitles = ' . $this->_bdd->echapper($video_has_en_subtitles) . ', ';
+        }
+        if ($date_publication !== null) {
+            $requete .= 'date_publication = ' . $this->_bdd->echapper($date_publication) . ', ';
         }
         $requete .= ' plannifie = ' . $this->_bdd->echapper($plannifie) . ' ';
         $requete .= ' WHERE session_id = ' . (int)$id;

--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -49,7 +49,7 @@ class SpeakerRepository extends Repository implements MetadataInitializer
         FROM afup_conferenciers speaker
         INNER JOIN afup_conferenciers_sessions cs ON cs.conferencier_id = speaker.conferencier_id
         INNER JOIN afup_sessions talk ON talk.session_id = cs.session_id
-        WHERE speaker.id_forum = :event AND talk.plannifie=1
+        WHERE speaker.id_forum = :event AND talk.plannifie=1 AND (talk.date_publication < NOW() OR talk.date_publication IS NULL)
         ORDER BY speaker.prenom ASC, speaker.nom ASC
         ')->setParams(['event' => $event->getId()]);
 

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -92,7 +92,7 @@ class TalkRepository extends Repository implements MetadataInitializer
             ->getPreparedQuery(
             'SELECT afup_sessions.*
             FROM afup_sessions
-            WHERE plannifie = 1 and LENGTH(youtube_id) > 0
+            WHERE plannifie = 1 and LENGTH(youtube_id) > 0  AND (afup_sessions.date_publication < NOW() OR afup_sessions.date_publication IS NULL)
             AND id_forum IN (
               SELECT id
               FROM afup_forum
@@ -152,7 +152,7 @@ class TalkRepository extends Repository implements MetadataInitializer
             LEFT JOIN afup_conferenciers speaker ON speaker.conferencier_id = acs.conferencier_id
             LEFT JOIN afup_forum_planning planning ON planning.id_session = talk.session_id
             LEFT JOIN afup_forum_salle room ON planning.id_salle = room.id
-            WHERE talk.session_id = :talk AND plannifie = 1
+            WHERE talk.session_id = :talk AND plannifie = 1 AND (talk.date_publication < NOW() OR talk.date_publication IS NULL)
             ORDER BY planning.debut ASC, room.id ASC, talk.session_id ASC '
         )->setParams(['talk' => $talk->getId()]);
 
@@ -177,7 +177,7 @@ class TalkRepository extends Repository implements MetadataInitializer
             LEFT JOIN afup_conferenciers speaker ON speaker.conferencier_id = acs.conferencier_id
             LEFT JOIN afup_forum_planning planning ON planning.id_session = talk.session_id
             LEFT JOIN afup_forum_salle room ON planning.id_salle = room.id
-            WHERE talk.id_forum = :event AND plannifie = 1
+            WHERE talk.id_forum = :event AND plannifie = 1 AND (talk.date_publication < NOW() OR talk.date_publication IS NULL) 
             ORDER BY planning.debut ASC, room.id ASC, talk.session_id ASC '
         )->setParams(['event' => $event->getId()]);
 


### PR DESCRIPTION
on permet d'indiquer une date de publication des confs.
cela permet de passer les confs sélectionnées en planifiée et leur donner accès à leur page speaker sans qu'ils apparaissent sur le programme / liste des speakers.
Cela permettra de planifier la publication des confs et ne pas être devant sa machine au moment de la publication.