### PR TITLE
Remplacer les boutons se connecter et adhérer si utilisateur loggué

### DIFF
--- a/app/Resources/views/site/base.html.twig
+++ b/app/Resources/views/site/base.html.twig
@@ -18,8 +18,12 @@
     <header>
         <div class="mw1400p center">
             <div id="espace-membre" class="w33 tablet-hidden">
-                <a href="/pages/administration" class="header-button header-button__connect">Se connecter</a>
-                <a href="{{ path('become_member') }}" class="header-button header-button__become-member">Adhérer</a>
+                {% if app.user %}
+                    <a href="/pages/administration" class="header-button header-button__connect">Administration</a>
+                {%  else  %}
+                    <a href="/pages/administration" class="header-button header-button__connect">Se connecter</a>
+                    <a href="{{ path('become_member') }}" class="header-button header-button__become-member">Adhérer</a>
+                {% endif %}
             </div>
             <h1 id="logo">
                 <a href="/">

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -28,6 +28,7 @@ security:
                     - app.legacy_authenticator
                     - app.legacy_hash_authenticator
                 entry_point: app.legacy_authenticator
+            context: share_context
 
         github_secured_area:
             pattern: ^(/event/.*/(vote|cfp|speaker-infos)|/connect/github/check)
@@ -39,6 +40,7 @@ security:
 
         main:
             anonymous: ~
+            context: share_context
 
     access_control:
         - { path: ^/event/vote/, roles: ROLE_GITHUB }


### PR DESCRIPTION
J'ai rajouter un bouton `Administration` qui vient remplacer les deux boutons cachés lorsqu'on est loggué.

<img width="838" alt="capture d ecran 2018-07-11 a 23 13 59" src="https://user-images.githubusercontent.com/15214050/42599636-293396f6-8560-11e8-8072-f86a08039f5d.png">

Je n'ai pas pu tester que la correction ne fasse pas de régression avec la partie event/cfp (`
github_secured_area`) car je n'y ai pas accès avec les données de dev. Et je n'avais jamais utilisé avant plusieurs firewalls en parallèle avec des données partagées. Donc si quelqu'un peut confirmer que cette solution n'apporte pas de régression, ça serait cool

Issue #605