### PR TITLE
amélioration cdn du polyfill formdata

### DIFF
--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -42,7 +42,7 @@
 
 {% block content %}
     <script src="{{ asset('templates/site/js/vendor/jquery-1.8.0.min.js') }}"></script>
-    <script src="https://wzrd.in/standalone/formdata-polyfill@3.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/formdata-polyfill@3.0.11/formdata.min.js"></script>
     <script src="{{ asset('js/inscription.js') }}?2"></script>
 
     <script type="text/javascript">


### PR DESCRIPTION
On avait des lenteurs et timeouts sur le cdn du polyfill formdata.
En utilisant un CDN correct cela corrige le problème.

fixes #659