### PR TITLE
on permet de saisir l'antenne la plus proche dans le tunnel de commande

### DIFF
--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -102,6 +102,7 @@
                         {{ form_row(ticket.lastname) }}
                         {{ form_row(ticket.email) }}
                         {{ form_row(ticket.phoneNumber) }}
+                        {{ form_row(ticket.nearestOffice) }}
 
                         {{ form_errors(ticket.ticketEventType) }}
                         {{ form_label(ticket.ticketEventType) }}

--- a/db/migrations/20180815214957_tickets_nearest_office.php
+++ b/db/migrations/20180815214957_tickets_nearest_office.php
@@ -1,0 +1,16 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class TicketsNearestOffice extends AbstractMigration
+{
+    public function change()
+    {
+        $sql = <<<SQL
+ALTER TABLE `afup_inscription_forum`
+ADD `nearest_office` varchar(50) DEFAULT NULL
+;
+SQL;
+        $this->execute($sql);
+    }
+}

--- a/sources/AppBundle/Event/Form/TicketType.php
+++ b/sources/AppBundle/Event/Form/TicketType.php
@@ -9,6 +9,7 @@ use AppBundle\Event\Model\Repository\TicketTypeRepository;
 use AppBundle\Event\Model\Ticket;
 use AppBundle\Event\Model\TicketEventType;
 use AppBundle\Event\Ticket\TicketTypeAvailability;
+use AppBundle\Offices\OfficesCollection;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -51,6 +52,11 @@ class TicketType extends AbstractType
      */
     private $ticketTypeRepository;
 
+    /**
+     * @var OfficesCollection
+     */
+    protected $officesCollection;
+
     public function __construct(
         EventRepository $eventRepository,
         TicketEventTypeRepository $ticketEventTypeRepository,
@@ -63,6 +69,7 @@ class TicketType extends AbstractType
         $this->ticketTypeAvailability = $ticketTypeAvailability;
         $this->ticketSpecialPriceRepository = $ticketSpecialPriceRepository;
         $this->ticketTypeRepository = $ticketTypeRepository;
+        $this->officesCollection = new OfficesCollection();
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -99,8 +106,12 @@ class TicketType extends AbstractType
                 'label' => 'Téléphone',
                 'required' => false
             ])
+            ->add('nearestOffice', ChoiceType::class, [
+                'label' => 'Antenne AFUP la plus proche',
+                'required' => false,
+                'choices' => array_flip($this->officesCollection->getOrderedLabelsByKey()),
+            ])
         ;
-
 
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $formEvent) use ($eventTickets, $options, $event) {
             $filteredEventTickets = [];

--- a/sources/AppBundle/Event/Form/TicketType.php
+++ b/sources/AppBundle/Event/Form/TicketType.php
@@ -107,7 +107,7 @@ class TicketType extends AbstractType
                 'required' => false
             ])
             ->add('nearestOffice', ChoiceType::class, [
-                'label' => 'Antenne AFUP la plus proche',
+                'label' => 'Antenne de prédilection',
                 'required' => false,
                 'choices' => array_flip($this->officesCollection->getOrderedLabelsByKey()),
             ])

--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -304,6 +304,11 @@ class TicketRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'specialPriceToken',
                 'type' => 'string'
             ])
+            ->addField([
+                'columnName' => 'nearest_office',
+                'fieldName' => 'nearestOffice',
+                'type' => 'string',
+            ])
         ;
 
         return $metadata;

--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -208,6 +208,11 @@ class Ticket implements NotifyPropertyInterface
     protected $specialPriceToken;
 
     /**
+     * @var null|string
+     */
+    protected $nearestOffice;
+
+    /**
      * @return int
      */
     public function getId()
@@ -720,6 +725,28 @@ class Ticket implements NotifyPropertyInterface
     {
         $this->propertyChanged('specialPriceToken', $this->specialPriceToken, $specialPriceToken);
         $this->specialPriceToken = $specialPriceToken;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getNearestOffice()
+    {
+        return $this->nearestOffice;
+    }
+
+    /**
+     * @param null|string $nearestOffice
+     *
+     * @return $this
+     */
+    public function setNearestOffice($nearestOffice)
+    {
+        $this->propertyChanged('nearestOffice', $this->nearestOffice, $nearestOffice);
+
+        $this->nearestOffice = $nearestOffice;
 
         return $this;
     }


### PR DESCRIPTION
cela sera utile à la fois pour améliorer l'accuracy des badges visiteurs (vu que l'adresse de facturation peux être différente de celle où habitent les inscrits), et sera utile pour savoir d'où viennent les visteurs de l'AFUP Day.

![capture du 2018-08-16 00-04-17](https://user-images.githubusercontent.com/320372/44175935-d1095100-a0df-11e8-8b01-c1b5aed14ea6.png)

