### PR TITLE
amélioration seo des titres sur event.afup.org

### DIFF
--- a/event/resources/themes/basis_child/header.php
+++ b/event/resources/themes/basis_child/header.php
@@ -10,7 +10,28 @@
 <!--[if IE 9]>    <html class="no-js IE9 IE" <?php language_attributes(); ?>> <![endif]-->
 <!--[if gt IE 9]><!--> <html class="no-js" <?php language_attributes(); ?>> <!--<![endif]-->
 <head>
-	<title><?php wp_title( ' | ', true, 'right' ); ?></title>
+    <title>
+        <?php
+            $current = $post->ID;
+            $parent = $post->post_parent;
+            $categories = get_the_category();
+            $category = null;
+            if (isset($categories[0])) {
+                $category = $categories[0];
+            }
+        ?>
+        <?php if ($parent): ?>
+            <?php echo get_the_title($current) ?> | <?php echo get_the_title($parent) ?>
+        <?php elseif (null !== $category && isset($posts) && count($posts) > 1): ?>
+            <?php echo $category->name ?>
+        <?php elseif (count($childPages = get_pages(['parent' => $current]))): ?>
+            <?php echo get_the_title($current) ?>
+        <?php elseif (null !== $category): ?>
+            <?php echo $post->post_title ?> | <?php echo $category->name ?>
+        <?php else: ?>
+            <?php wp_title( ' | ', true, 'right' ); ?>
+        <?php endif ?>
+    </title>
 
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
On change les titres des pages sur event.afup.org afin de mieux référencer celles-ci :

| Page            | Titre avant                                               | Titre après                                          |
| --------------- |-----------------------------------------------------------| -----------------------------------------------------|
| Home            | `Forum PHP 2018`                                          | `Forum PHP 2018`                                     |
| Home Tour 2018  | `PHP Tour Montpellier 2018  \|   Forum PHP 2018`           | `PHP Tour Montpellier 2018`                          |
| Sponsors Forum  | `Sponsors  \|   Forum PHP 2018`                            | `Sponsors \| Forum PHP 2018`                          |
| Sponsors Tour   | `Sponsors  \|   Forum PHP 2018`                            | `Sponsors \| PHP Tour Montpellier 2018`               |
| Infos Forum     | `Infos pratiques  \|   Forum PHP 2018`                     | `Infos pratiques \| Forum PHP 2018`                   |
| Interviews Tour | `PHPTour 2018  \|   Forum PHP 2018`                        | `PHPTour 2018`                                       |
| Interview Tour  | `La parole est aux sponsors : Altran  \|   Forum PHP 2018` | `La parole est aux sponsors : Altran \| PHPTour 2018` |


// cc @bGaetan