### PR TITLE
Amélioration de la configuration Docker

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,0 +1,2 @@
+## Options to pass to `docker-compose up` command
+#DOCKER_UP_OPTIONS= -d # -d will launch container in detached mode

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.env
+
 deps.lock
 .idea
 # OS X

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,27 @@
-CURRENT_UID=$(shell id -u)
+-include .env
 
-.PHONY: install docker-up test hooks vendors db-seed db-migrations reset-db init
+CURRENT_UID ?= $(shell id -u)
+DOCKER_UP_OPTIONS ?=
+
+.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init
 
 install: vendors event/vendor
 
-docker-up: var/logs/.docker-build data docker-compose.override.yml
-	CURRENT_UID=$(CURRENT_UID) docker-compose up
+docker-up: .env var/logs/.docker-build data docker-compose.override.yml
+	CURRENT_UID=$(CURRENT_UID) docker-compose up $(DOCKER_UP_OPTIONS)
+
+docker-stop:
+	CURRENT_UID=$(CURRENT_UID) docker-compose stop
+
+docker-down:
+	CURRENT_UID=$(CURRENT_UID) docker-compose down
 
 var/logs/.docker-build: docker-compose.yml docker-compose.override.yml $(shell find docker -type f)
 	CURRENT_UID=$(CURRENT_UID) docker-compose build
 	touch var/logs/.docker-build
+
+.env:
+	cp .env-dist .env
 
 docker-compose.override.yml:
 	cp docker-compose.override.yml-dist docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ La base de test inclus un utilisateur administration avec les identifiants suiva
 
 Vous pouvez aussi y accéder directement via la commande: `docker/bin/mysql`
 
+### Autres commandes
+
+* `make docker-stop` : éteint les containers en fonctionnement.
+* `make docker-down` : détruit les containers existants.
+
+### Configuration avancée
+
+Plusieurs possibilités de configuration des containers sont disponibles, via l'utilisation de variables d'environnement.
+
+Pour faciliter leur configuration, un fichier `.env` est créé à la racine du projet à la première exécution de la commande `make docker-up`.
+Ce fichier contient la liste des options disponibles.
+
+#### `DOCKER_UP_OPTIONS`
+
+liste des options à passer à la commande `docker-composer up`. 
+
 ## Base de données
 
 Config par défaut:

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -40,7 +40,7 @@ ARG uid=1008
 ARG gid=1008
 
 RUN groupadd -g ${gid} localUser && \
-    useradd -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
+    useradd -l -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
     usermod -a -G www-data localUser && \
     sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apache2.conf && \
     sed --in-place  "s/Group \${APACHE_RUN_GROUP}/Group localUser/" /etc/apache2/apache2.conf

--- a/docker/dockerfiles/event/Dockerfile
+++ b/docker/dockerfiles/event/Dockerfile
@@ -31,7 +31,7 @@ ARG uid=1008
 ARG gid=1008
 
 RUN groupadd -g ${gid} localUser && \
-    useradd -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
+    useradd -l -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
     usermod -a -G www-data localUser && \
     sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apache2.conf && \
     sed --in-place  "s/Group \${APACHE_RUN_GROUP}/Group localUser/" /etc/apache2/apache2.conf

--- a/docker/dockerfiles/planete/Dockerfile
+++ b/docker/dockerfiles/planete/Dockerfile
@@ -31,7 +31,7 @@ ARG uid=1008
 ARG gid=1008
 
 RUN groupadd -g ${gid} localUser && \
-    useradd -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
+    useradd -l -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
     usermod -a -G www-data localUser && \
     sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apache2.conf && \
     sed --in-place  "s/Group \${APACHE_RUN_GROUP}/Group localUser/" /etc/apache2/apache2.conf


### PR DESCRIPTION
L'installation du projet en utilisant [Docker For Mac](https://docs.docker.com/docker-for-mac/) rencontre un petit soucis de dépassement de limite d'utilisation de disque.

Cette PR ajoute une petite option à l'instruction `useradd` permettant de ne pas générer de logs lors de son execution (`--no-log-init` https://linux.die.net/man/8/useradd).

Ajout également de la possibilité de configurer l'exécution de docker.

Replace #629