### PR TITLE
AFUP sitemap

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -16,7 +16,8 @@ class AppKernel extends Kernel
             new \CCMBenchmark\TingBundle\TingBundle(),
             new \KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle(),
             new AppBundle\AppBundle(),
-            new \JMS\SerializerBundle\JMSSerializerBundle()
+            new \JMS\SerializerBundle\JMSSerializerBundle(),
+            new Presta\SitemapBundle\PrestaSitemapBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -42,5 +42,8 @@ techletter:
     resource: "routing/techletter.yml"
     prefix: /techno_watch
 
+presta_sitemap:
+    resource: "@PrestaSitemapBundle/Resources/config/routing.yml"
+
 global:
     resource: "routing/global.yml"

--- a/app/config/routing/blog.yml
+++ b/app/config/routing/blog.yml
@@ -17,3 +17,5 @@ planning:
 talk_widget:
   path: /talk_widget
   defaults: {_controller: AppBundle:Blog:talkWidget}
+  options:
+    sitemap: true

--- a/app/config/routing/blog.yml
+++ b/app/config/routing/blog.yml
@@ -17,5 +17,3 @@ planning:
 talk_widget:
   path: /talk_widget
   defaults: {_controller: AppBundle:Blog:talkWidget}
-  options:
-    sitemap: true

--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -1,10 +1,14 @@
 event_index:
   path: /
   defaults: {_controller: AppBundle:Event:index}
+  options:
+    sitemap: true
 
 event_index_speaker_infos:
   path: /speaker-infos
   defaults: {_controller: AppBundle:Event:speakerInfosIndex}
+  options:
+    sitemap: true
 
 event:
   path: /{eventSlug}

--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -7,8 +7,6 @@ event_index:
 event_index_speaker_infos:
   path: /speaker-infos
   defaults: {_controller: AppBundle:Event:speakerInfosIndex}
-  options:
-    sitemap: true
 
 event:
   path: /{eventSlug}

--- a/app/config/routing/global.yml
+++ b/app/config/routing/global.yml
@@ -1,3 +1,5 @@
 home:
   path: /home
   defaults: {_controller: AppBundle:Home:display}
+  options:
+    sitemap: true

--- a/app/config/routing/meetups.yml
+++ b/app/config/routing/meetups.yml
@@ -1,3 +1,5 @@
 meetups_list:
   path: /
   defaults: {_controller: AppBundle:Meetups:list}
+  options:
+    sitemap: true

--- a/app/config/routing/news.yml
+++ b/app/config/routing/news.yml
@@ -1,6 +1,8 @@
 news_list:
   path: /
   defaults: {_controller: AppBundle:News:list}
+  options:
+    sitemap: true
 
 news_display:
   path: /{code}

--- a/app/config/routing/site.yml
+++ b/app/config/routing/site.yml
@@ -50,8 +50,6 @@ void:
 newsletter_subscribe:
   path: /newsletter-subscribe
   defaults: {_controller: AppBundle:Newsletter:subscribe}
-  options:
-    sitemap: true
 
 membership_payment:
   path: /paybox-callback

--- a/app/config/routing/site.yml
+++ b/app/config/routing/site.yml
@@ -1,10 +1,14 @@
 become_member:
   path: /devenir-membre
   defaults: {_controller: AppBundle:MemberShip:becomeMember}
+  options:
+    sitemap: true
 
 company_membership:
   path: /adherer/entreprise
   defaults: {_controller: AppBundle:MemberShip:company}
+  options:
+    sitemap: true
 
 company_membership_payment:
   path: /adherer/entreprise/paiement-{invoiceNumber}-{token}
@@ -30,10 +34,14 @@ company_invitation:
 offices:
   path: /antennes
   defaults: {_controller: AppBundle:Static:offices}
+  options:
+    sitemap: true
 
 superapero:
   path: /super-apero-8-mars-2018
   defaults: {_controller: AppBundle:Static:superApero}
+  options:
+    sitemap: true
 
 void:
   path: /void-route
@@ -42,6 +50,8 @@ void:
 newsletter_subscribe:
   path: /newsletter-subscribe
   defaults: {_controller: AppBundle:Newsletter:subscribe}
+  options:
+    sitemap: true
 
 membership_payment:
   path: /paybox-callback
@@ -50,6 +60,8 @@ membership_payment:
 techletter:
   path: /techletter
   defaults: {_controller: AppBundle:Techletter:index}
+  options:
+    sitemap: true
 
 techletter_subscribe:
   path: /techletter/subscription

--- a/app/config/routing/talks.yml
+++ b/app/config/routing/talks.yml
@@ -1,6 +1,8 @@
 talks_list:
   path: /
   defaults: {_controller: AppBundle:Talks:list}
+  options:
+    sitemap: true
 
 talks_show:
   path: /{id}-{slug}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "erusev/parsedown": "^1.6",
     "dms/meetup-api-client": "^2.3",
     "google/apiclient": "^2.0",
-    "robmorgan/phinx": "^0.9.2"
+    "robmorgan/phinx": "^0.9.2",
+    "presta/sitemap-bundle": "^1.5"
   },
   "scripts": {
     "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "672d010344b82e2885705be986ffa742",
+    "content-hash": "9117b6fafe46eaaaa1982d19ae83c7d7",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2714,6 +2714,69 @@
                 "dependency injection"
             ],
             "time": "2015-09-11T15:10:35+00:00"
+        },
+        {
+            "name": "presta/sitemap-bundle",
+            "version": "v1.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/prestaconcept/PrestaSitemapBundle.git",
+                "reference": "16a2c0eae7320e3647013e48026a6a6bd14f75df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/prestaconcept/PrestaSitemapBundle/zipball/16a2c0eae7320e3647013e48026a6a6bd14f75df",
+                "reference": "16a2c0eae7320e3647013e48026a6a6bd14f75df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/console": "~2.2|~3.0|~4.0",
+                "symfony/framework-bundle": "~2.2|~3.0|~4.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "~1.0",
+                "phpunit/phpunit": "5.*",
+                "symfony/browser-kit": "~2.2|~3.0|~4.0",
+                "symfony/form": "~2.2|~3.0|~4.0",
+                "symfony/phpunit-bridge": "~2.7|~3.0|~4.0",
+                "symfony/security-bundle": "~2.2|~3.0|~4.0",
+                "symfony/translation": "~2.2|~3.0|~4.0",
+                "symfony/validator": "~2.2|~3.0|~4.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-cache-bundle": "Allows to store sitemaps in cache"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Presta\\SitemapBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Prestaconcept",
+                    "homepage": "http://www.prestaconcept.net/"
+                }
+            ],
+            "description": "A Symfony bundle that provides tools to build your application sitemap.",
+            "keywords": [
+                "Sitemap",
+                "bundle",
+                "prestaconcept",
+                "symfony",
+                "xml"
+            ],
+            "time": "2018-02-20T11:33:33+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Première partie du sitemap: les routes statiques !

L'idée est de release la première partie sur le sitemap contant tout ce qui est route statique pour laisser le SEO commencer à se faire et enchainer plus tard sur une seconde partie qui aura les routes dynamiques (sans doute petit à petit vu qu'il y a pas mal de taf de ce côté là)

J'utilise: https://github.com/prestaconcept/PrestaSitemapBundle pour la génération du sitemap.

Related: #386