### PR TITLE
bascule pages contact sur le nouveau layout

### DIFF
--- a/htdocs/pages/.htaccess
+++ b/htdocs/pages/.htaccess
@@ -273,6 +273,12 @@ RewriteRule ^site/$  "/?"  [L,R=302]
 RewriteCond %{QUERY_STRING}  ^route=divers/232/annuaire-de-prestataires$
 RewriteRule ^site/$  "/?"  [L,R=302]
 
+RewriteCond %{QUERY_STRING}  ^route=divers/53/comment-contacter-l-afup$
+RewriteRule ^(.*)$  "/p/53-comment-contacter-l-afup?"  [L,R=302]
+
+RewriteCond %{QUERY_STRING}  ^route=divers/645/mentions-legales$
+RewriteRule ^(.*)$  "/p/645-mentions-legales?"  [L,R=302]
+
 RewriteCond %{QUERY_STRING}  ^route=divers/22$
 RewriteRule ^site/$  "/?"  [L,R=302]
 

--- a/htdocs/pages/.htaccess
+++ b/htdocs/pages/.htaccess
@@ -267,4 +267,12 @@ RewriteRule ^site/$ "/news/%1-%2?"  [L,R=302]
 RewriteCond %{QUERY_STRING}  ^route=06-actualit/9$
 RewriteRule ^site/$  "/news?"  [L,R=302]
 
+RewriteCond %{QUERY_STRING}  ^route=divers/231/le-livre-blanc-php-en-entreprise$
+RewriteRule ^site/$  "/?"  [L,R=302]
+
+RewriteCond %{QUERY_STRING}  ^route=divers/232/annuaire-de-prestataires$
+RewriteRule ^site/$  "/?"  [L,R=302]
+
+RewriteCond %{QUERY_STRING}  ^route=divers/22$
+RewriteRule ^site/$  "/?"  [L,R=302]
 

--- a/sources/Afup/Corporate/Rubrique.php
+++ b/sources/Afup/Corporate/Rubrique.php
@@ -9,6 +9,7 @@ class Rubrique
     const ID_RUBRIQUE_ACTUALITES = 9;
     const ID_RUBRIQUE_ASSOCIATION = 85;
     const ID_RUBRIQUE_ANTENNES = 84;
+    const ID_RUBRIQUE_INFORMATIONS_PRATIQUES = 86;
 
     public $id;
     public $id_personne_physique;

--- a/sources/AppBundle/Controller/CmsPageController.php
+++ b/sources/AppBundle/Controller/CmsPageController.php
@@ -36,6 +36,6 @@ class CmsPageController extends SiteBaseController
 
     protected function isRubriqueAllowed($rubrique)
     {
-        return $rubrique['id'] == Rubrique::ID_RUBRIQUE_ASSOCIATION || $rubrique['id'] == Rubrique::ID_RUBRIQUE_ANTENNES;
+        return $rubrique['id'] == Rubrique::ID_RUBRIQUE_ASSOCIATION || $rubrique['id'] == Rubrique::ID_RUBRIQUE_ANTENNES || $rubrique['id'] == Rubrique::ID_RUBRIQUE_INFORMATIONS_PRATIQUES;
     }
 }


### PR DESCRIPTION
page contact avant:
![screen shot 2018-09-23 at 17 27 12-fullpage](https://user-images.githubusercontent.com/320372/45929843-aec4e780-bf57-11e8-9cd5-300024c7521d.png)

page contact après:
![screen shot 2018-09-23 at 17 26 59-fullpage](https://user-images.githubusercontent.com/320372/45929842-9fde3500-bf57-11e8-9bd6-c06e3f130ac4.png)



page mentions légales avant:
![screen shot 2018-09-23 at 17 26 33-fullpage](https://user-images.githubusercontent.com/320372/45929834-92c14600-bf57-11e8-9e4e-64206f3d27fa.png)

page mention légales après:
![screen shot 2018-09-23 at 17 26 47-fullpage](https://user-images.githubusercontent.com/320372/45929855-c0a68a80-bf57-11e8-8e08-936f2d64aa8c.png)



les pages annuaire des prestataires et livre blanc, ainsi que l'index de divers ont été redirigées vers la home.