### PR TITLE
event : page builder on permet d'avoir des profile (trois colonnes) en mode banner

### DIFF
--- a/event/resources/themes/basis_child/three_cols_section_banner.php
+++ b/event/resources/themes/basis_child/three_cols_section_banner.php
@@ -1,0 +1,29 @@
+<?php
+
+$default = 1;
+$min = 1;
+$max = 20;
+
+$nthChild = $default;
+
+if (isset($_GET['nth-child']) && $_GET['nth-child'] >= $min && $_GET['nth-child'] <= $max) {
+    //die('a');
+    $nthChild = $_GET['nth-child'];
+}
+
+$css = <<<CSS
+.product-content-wrapper > div > section:nth-child($nthChild) {
+    background-image: url('/wp-content/uploads/header_afup-1.svg');
+    padding: 1.2rem 3.7rem;
+    margin: 2rem auto;
+    background-size: cover;
+    max-width: 100%;
+}
+
+.product-content-wrapper > div > section:nth-child($nthChild) .banner-button-container {
+    text-align: center;
+}
+CSS;
+
+header("Content-type: text/css");
+echo $css;

--- a/event/resources/themes/basis_child/three_cols_section_banner.php
+++ b/event/resources/themes/basis_child/three_cols_section_banner.php
@@ -7,7 +7,6 @@ $max = 20;
 $nthChild = $default;
 
 if (isset($_GET['nth-child']) && $_GET['nth-child'] >= $min && $_GET['nth-child'] <= $max) {
-    //die('a');
     $nthChild = $_GET['nth-child'];
 }
 


### PR DESCRIPTION
Cela va permettre de créer des boutons en colonne sur toute la largeur
qu'on utilisera pour l'AFUP Day.

La façon de faire est moche, mais on doit faire avec Wordpress.

Il faudra dans la config de la page, ajouter dans le html_head (on avait pas la main sur la config du page builder pour faire mieux).
```
<link rel='stylesheet' href="https://localhost:9215/wp-content/themes/basis_child/three_cols_section_banner.php?nth-child=2" type='text/css' media='all' />
```

![screen shot 2018-09-27 at 23 03 28](https://user-images.githubusercontent.com/320372/46174516-903d5400-c2a9-11e8-89f4-b80ce5f90897.png)
