### PR TITLE
fix roles accès techletter

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -45,6 +45,8 @@ security:
     access_control:
         - { path: ^/event/vote/, roles: ROLE_GITHUB }
         - { path: ^/admin/(login|register|password), roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: ^/admin/techletter/members, roles: ROLE_ADMIN }
+        - { path: ^/admin/techletter, roles: ROLE_VEILLE }
         - { path: ^/admin/company, roles: ROLE_COMPANY_MANAGER }
         - { path: ^/admin/(members/reporting|association/relances|event), roles: ROLE_ADMIN}
         - { path: ^/admin/(members/reporting|association/relances|event), roles: ROLE_NO_ACCESS}


### PR DESCRIPTION
les roles sur https://github.com/afup/web/blob/bc396cfbf7442314f33ab3c7c8eaf9920f54e6c1/app/config/config.yml#L77
correspondent seulement à l'affichage dans le menu.
il faut aussi afficher rajouter la config dans le security.yml