### PR TITLE
on fait fonctionner les anciens exports des badges

### DIFF
--- a/htdocs/templates/administration/forum_inscriptions.html
+++ b/htdocs/templates/administration/forum_inscriptions.html
@@ -75,7 +75,7 @@
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
     <a href="index.php?page=forum_badge&amp;action=export&amp;id_forum={$id_forum}" title="Exporter les inscriptions">Exporter les inscriptions</a><br />
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
-    <a href="/admin/event/badges" title="Exporter les inscriptions pour les badges">Exporter les inscriptions pour les badges</a> <i>(prends environ une minute)</i><br />
+    <a href="/admin/event/badges?id_forum={$id_forum}" title="Exporter les inscriptions pour les badges">Exporter les inscriptions pour les badges</a> <i>(prends environ une minute)</i><br />
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
     <a href="/admin/event/previous_registrations?event_count=4">Exporter des inscrits aux 4 derniers événements</a><br />
 


### PR DESCRIPTION
on ne passait pas l'id du forum. du coup les liens d'export des badges
exportaient à chaque fois ceux du dernier forum.