### PR TITLE
on permet de saisir le contenu du mail d'inscription dans le bo

### DIFF
--- a/app/Resources/views/admin/event/mail_inscription.html.twig
+++ b/app/Resources/views/admin/event/mail_inscription.html.twig
@@ -5,9 +5,9 @@
 {{ content|markdown_email }}
 
 {% if logo_url %}
-<div style="text-align: center">
-    <img src="{{ logo_url }}" alt="AFUP" width="300" height="156" style="-ms-interpolation-mode: bicubic; border: none; outline: none; text-decoration: none;">
-</div>
+    <div style="text-align: center">
+        <img src="{{ logo_url }}" alt="AFUP" width="300" height="156" style="-ms-interpolation-mode: bicubic; border: none; outline: none; text-decoration: none;">
+    </div>
 {% endif %}
 
 {% endblock %}

--- a/app/Resources/views/admin/event/mail_inscription.html.twig
+++ b/app/Resources/views/admin/event/mail_inscription.html.twig
@@ -1,0 +1,13 @@
+{% extends ':mail:_base_mail.html.twig' %}
+
+{% block content %}
+
+{{ content|markdown_email }}
+
+{% if logo_url %}
+<div style="text-align: center">
+    <img src="{{ logo_url }}" alt="AFUP" width="300" height="156" style="-ms-interpolation-mode: bicubic; border: none; outline: none; text-decoration: none;">
+</div>
+{% endif %}
+
+{% endblock %}

--- a/app/Resources/views/mail/_base_mail.html.twig
+++ b/app/Resources/views/mail/_base_mail.html.twig
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style type="text/css">
+        .ExternalClass {
+            display:block !important;
+            width: 100%;
+        }
+        .ExternalClass,
+        .ExternalClass p,
+        .ExternalClass span,
+        .ExternalClass font,
+        .ExternalClass td,
+        .ExternalClass div {
+            line-height: 100%;
+        }
+        @media screen and (max-width:0) {
+            body {
+                margin: 0;
+            }
+        }
+        @media screen and (max-width:600px) {
+            .content img {
+                width: 100% !important;
+                max-width: 100% !important;
+                height: auto !important;
+            }
+            .container{
+                width: 95% !important;
+            }
+        }
+        @media screen and (max-width:480px) {
+            .content {
+                padding-left: 10px !important;
+                padding-right: 10px !important;
+                width:90% !important;;
+            }
+        }
+    </style>
+</head>
+<body style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #ebebeb; margin: 0; padding: 0; width: 100%;">
+<table width="100%" height="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="#ebebeb" class="wrapper" style="background-color: #ebebeb; border-spacing: 0;">
+    <tr>
+        <td align="center" valign="top" bgcolor="#ebebeb" class="center" style="background-color: #ebebeb; border-collapse: collapse; padding: 20px 0; vertical-align: top;">
+            <table width="600" cellpadding="0" cellspacing="0" border="0" class="container" style="border-spacing: 0; font-family: Arial, sans-serif;">
+                <tr>
+                    <td align="center" valign="top" class="test" style="border-collapse: collapse; vertical-align: top;">
+                        <table width="100%" border="0" cellpadding="0" cellspacing="0" class="top" style="border-spacing: 0;">
+                            <tr>
+                                <td class="top1" style="background-color: #718dc1; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                                <td class="top2" style="background-color: #607fba; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                                <td class="top3" style="background-color: #4e71b2; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                                <td class="top4" style="background-color: #4666a1; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                                <td class="top5" style="background-color: #3e5a8f; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                                <td class="top6" style="background-color: #364f7d; border-collapse: collapse; height: 4px; vertical-align: top;"></td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" valign="top" bgcolor="#ffffff" class="header" style="border-collapse: collapse; border-left: 1px solid #d6d6d0; border-right: 1px solid #d6d6d0; padding: 15px 0 0; vertical-align: top;">
+                        <a href="http://afup.org">
+                            <img src="http://afup.org/templates/site/img/afup_logo_h100.png" alt="" style="-ms-interpolation-mode: bicubic; outline: none; text-decoration: none; max-width:404px;">
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <td align="left" valign="top" style="border-collapse: collapse; vertical-align: top;">
+                        <table width="100%" border="0" cellpadding="0" cellspacing="0" bgcolor="#ffffff" class="inner" style="background-color: #fff; border-bottom: 1px solid #d6d6d0; border-left: 1px solid #d6d6d0; border-radius: 0 0 4px 4px; border-right: 1px solid #d6d6d0; border-spacing: 0;">
+                            <tr>
+                                <td align="left" valign="top" class="content" style="border-collapse: collapse; color: #333; font-size: 14px; line-height: 20px; padding: 20px 25px; vertical-align: top;">
+                                    <div>
+                                        {% block content %}
+                                        {% endblock %}
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+                <tr>
+                    <td align="center" valign="top" bgcolor="#ebebeb" class="footer" style="background-color: #ebebeb; border-collapse: collapse; color: #9f9f9f; font-size: 12px; line-height: 15px; padding: 10px 25px 0; text-align: center; vertical-align: top;">
+                        AFUP - Association fran&ccedil;aise des utilisateurs de PHP
+                        <br>
+                        <span style="color: #4b85bd; text-decoration: underline;"><a href="mailto:bonjour@afup.org">bonjour@afup.org</a></span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/app/config/routing/admin_event.yml
+++ b/app/config/routing/admin_event.yml
@@ -38,6 +38,10 @@ admin_event_speaker_infos:
   path: /speaker-infos
   defaults: {_controller: AppBundle:AdminEvent:speakerInfos}
 
+admin_event_send_test_mail_inscription:
+  path: /send-test-mail-inscription
+  defaults: {_controller: AppBundle:AdminEvent:sendTestInscriptionEmail}
+
 admin_event_badges:
   path: /badges
   defaults: {_controller: AppBundle:AdminEvent:badgesGenerate}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -23,7 +23,7 @@ services:
 
     app_twig:
         class: AppBundle\Twig\TwigExtension
-        autowire: true
+        arguments: ["@app.legacy_router", "@app.html_to_markdown", "@app.html_to_markdown_email", "@service_container"]
         tags:
             -  { name: twig.extension }
 
@@ -160,6 +160,10 @@ services:
 
     app.mail:
         class: Afup\Site\Utils\Mail
+
+    app.emails:
+        class: AppBundle\Email\Emails
+        arguments: ["@twig", "@app.mail"]
 
     app.invitation_mail:
         class: AppBundle\Association\CompanyMembership\InvitationMail
@@ -349,6 +353,9 @@ services:
     app.html_to_markdown:
         class: Parsedown
         autowire: true
+
+    app.html_to_markdown_email:
+        class: AppBundle\Email\Parsedown
 
     app.event_json_ld:
         class: AppBundle\Event\JsonLd

--- a/htdocs/pages/administration/forum_gestion.php
+++ b/htdocs/pages/administration/forum_gestion.php
@@ -62,6 +62,7 @@ if ($action == 'lister') {
             $champs['speaker_management_en'] = $text['speaker_management_en'];
             $champs['sponsor_management_fr'] = $text['sponsor_management_fr'];
             $champs['sponsor_management_en'] = $text['sponsor_management_en'];
+            $champs['mail_inscription_content'] = $text['mail_inscription_content'];
         }
 
         $formulaire->setDefaults($champs);
@@ -98,6 +99,7 @@ if ($action == 'lister') {
     $formulaire->addElement('textarea', 'speaker_management_en'             , 'Infos speakers (eb)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
     $formulaire->addElement('textarea', 'sponsor_management_fr'             , 'Infos sponsors (fr)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
     $formulaire->addElement('textarea', 'sponsor_management_en'             , 'Infos sponsors (en)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
+    $formulaire->addElement('textarea', 'mail_inscription_content'             , 'Contenu mail inscription'                           , ['rows' => 5, 'cols' => 50, 'class' => 'simplemde']);
 
 
     $formulaire->addElement('header', ''                     , 'Coupons');
@@ -132,6 +134,7 @@ if ($action == 'lister') {
                     'speaker_management_en' => $formulaire->exportValue('speaker_management_en'),
                     'sponsor_management_fr' => $formulaire->exportValue('sponsor_management_fr'),
                     'sponsor_management_en' => $formulaire->exportValue('sponsor_management_en'),
+                    'mail_inscription_content' => $formulaire->exportValue('mail_inscription_content'),
                 ],
                 $formulaire->exportValue('trello_list_id'),
                 $formulaire->exportValue('logo_url'),
@@ -163,6 +166,7 @@ if ($action == 'lister') {
                     'speaker_management_en' => $formulaire->exportValue('speaker_management_en'),
                     'sponsor_management_fr' => $formulaire->exportValue('sponsor_management_fr'),
                     'sponsor_management_en' => $formulaire->exportValue('sponsor_management_en'),
+                    'mail_inscription_content' => $formulaire->exportValue('mail_inscription_content'),
                 ],
                 $formulaire->exportValue('trello_list_id'),
                 $formulaire->exportValue('logo_url'),
@@ -191,4 +195,5 @@ if ($action == 'lister') {
     }
 
     $smarty->assign('formulaire', genererFormulaire($formulaire));
+    $smarty->assign('id_forum', $_GET['id']);
 }

--- a/htdocs/pages/administration/forum_gestion.php
+++ b/htdocs/pages/administration/forum_gestion.php
@@ -99,7 +99,7 @@ if ($action == 'lister') {
     $formulaire->addElement('textarea', 'speaker_management_en'             , 'Infos speakers (eb)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
     $formulaire->addElement('textarea', 'sponsor_management_fr'             , 'Infos sponsors (fr)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
     $formulaire->addElement('textarea', 'sponsor_management_en'             , 'Infos sponsors (en)'                           , ['rows' => 5, 'cols' => 50, 'class' => 'tinymce']);
-    $formulaire->addElement('textarea', 'mail_inscription_content'             , 'Contenu mail inscription'                           , ['rows' => 5, 'cols' => 50, 'class' => 'simplemde']);
+    $formulaire->addElement('textarea', 'mail_inscription_content'          , 'Contenu mail inscription'                      , ['rows' => 5, 'cols' => 50, 'class' => 'simplemde']);
 
 
     $formulaire->addElement('header', ''                     , 'Coupons');

--- a/htdocs/templates/administration/forum_gestion.html
+++ b/htdocs/templates/administration/forum_gestion.html
@@ -56,7 +56,7 @@
     {/if}
 
     {if $action != 'ajouter'}
-    <a href="/admin/event/send-test-mail-inscription?id={$id_forum}" >Envoyer un test du mail d'inscription sur bureau@afup.org</a>
+        <a href="/admin/event/send-test-mail-inscription?id={$id_forum}" >Envoyer un test du mail d'inscription sur bureau@afup.org</a>
     {/if}
 
     {include file="formulaire.html"}

--- a/htdocs/templates/administration/forum_gestion.html
+++ b/htdocs/templates/administration/forum_gestion.html
@@ -54,5 +54,23 @@
     {else}
         <h2>Modifier un forum</h2>
     {/if}
+
+    {if $action != 'ajouter'}
+    <a href="/admin/event/send-test-mail-inscription?id={$id_forum}" >Envoyer un test du mail d'inscription sur bureau@afup.org</a>
+    {/if}
+
     {include file="formulaire.html"}
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+    {literal}
+    <script>
+        var simplemde = new SimpleMDE({
+            element: document.querySelector('.simplemde'),
+            spellChecker: false,
+            hideIcons: ['side-by-side', 'fullscreen']
+        });
+    </script>
+    {/literal}
+
 {/if}

--- a/sources/AppBundle/Controller/AdminEventController.php
+++ b/sources/AppBundle/Controller/AdminEventController.php
@@ -26,7 +26,6 @@ use CCMBenchmark\Ting\Repository\CollectionInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;

--- a/sources/AppBundle/Controller/AdminEventController.php
+++ b/sources/AppBundle/Controller/AdminEventController.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller;
 
 use Afup\Site\Forum\Facturation;
 use Afup\Site\Forum\Inscriptions;
+use AppBundle\Email\Emails;
 use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\RoomType;
 use AppBundle\Event\Form\SponsorTokenType;
@@ -627,7 +628,7 @@ class AdminEventController extends Controller
         $eventRepository = $ting->get(EventRepository::class);
         $event = $this->getEvent($eventRepository, $request);
 
-        $this->get('app.emails')->sendInscription($event, 'bureau@afup.org', 'Bureau AFUP');
+        $this->get('app.emails')->sendInscription($event, Emails::EMAIL_BUREAU_ADDRESS, Emails::EMAIL_BUREAU_LABEL);
         $this->addFlash('notice', 'Mail de test envoyé');
 
         $url = $this->get('app.legacy_router')->getAdminUrl('forum_gestion', ['action' => 'modifier', 'id' => $event->getId()]);

--- a/sources/AppBundle/Controller/TicketController.php
+++ b/sources/AppBundle/Controller/TicketController.php
@@ -116,14 +116,7 @@ class TicketController extends EventBaseController
             $mailer = $this->get('app.mail');
             $logger = $this->get('logger');
             $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($event, $ticket, $mailer, $logger) {
-                $receiver = [
-                    'email' => $ticket->getEmail(),
-                    'name'  => $ticket->getLabel(),
-                ];
-
-                if (!$mailer->send($event->getMailTemplate(), $receiver, [])) {
-                    $logger->addWarning(sprintf('Mail not sent for inscription %s', $ticket->getEmail()));
-                }
+                $this->get('app.emails')->sendInscription($event, $ticket->getEmail(), $ticket->getLabel());
                 return 1;
             });
 
@@ -342,14 +335,7 @@ class TicketController extends EventBaseController
 
             if ($paymentStatus === Ticket::STATUS_PAID) {
                 $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($event, $ticket, $mailer, $logger) {
-                    $receiver = [
-                        'email' => $ticket->getEmail(),
-                        'name'  => $ticket->getLabel(),
-                    ];
-
-                    if (!$mailer->send($event->getMailTemplate(), $receiver, [])) {
-                        $logger->addWarning(sprintf('Mail not sent for inscription %s', $ticket->getEmail()));
-                    }
+                    $this->get('app.emails')->sendInscription($event, $ticket->getEmail(), $ticket->getLabel());
                     return 1;
                 });
             }

--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AppBundle\Email;
+
+use Afup\Site\Utils\Mail;
+use AppBundle\Event\Model\Event;
+
+class Emails
+{
+    /**
+     * @var \Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * @var Mail
+     */
+    private $mail;
+
+    /**
+     * @param \Twig_Environment $twig
+     */
+    public function __construct(\Twig_Environment $twig, Mail $mail)
+    {
+        $this->twig = $twig;
+        $this->mail = $mail;
+    }
+
+    /**
+     * @param Event $event
+     * @param string $receiverEmail
+     * @param string $receiverLabel
+     *
+     * @throws \Twig_Error_Loader
+     * @throws \Twig_Error_Runtime
+     * @throws \Twig_Error_Syntax
+     */
+    public function sendInscription(Event $event, $receiverEmail, $receiverLabel)
+    {
+        $mailContent = $event->getMailInscriptionContent();
+
+        if (0 === strlen(trim($mailContent))) {
+            throw new \Exception("Contenu du mail d'inscription non trouvé pour le forum " . $event->getTitle());
+        }
+
+        $content = $this->twig->render( ':admin/event:mail_inscription.html.twig', ['content' => $mailContent, 'logo_url' => $event->getLogoUrl()]);
+
+        $subject = sprintf("[%s] Merci !", $event->getTitle());
+
+        $this->mail->getMandrill()->messages->send([
+            'from_email' => 'bonjour@afup.org',
+            'from_name' => 'AFUP',
+            'html' => $content,
+            'subject' => $subject,
+            'to' => [
+                [
+                    'email' => $receiverEmail,
+                    'name' => $receiverLabel,
+                ]
+            ]
+        ]);
+    }
+}

--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -43,7 +43,7 @@ class Emails
             throw new \Exception("Contenu du mail d'inscription non trouvé pour le forum " . $event->getTitle());
         }
 
-        $content = $this->twig->render( ':admin/event:mail_inscription.html.twig', ['content' => $mailContent, 'logo_url' => $event->getLogoUrl()]);
+        $content = $this->twig->render(':admin/event:mail_inscription.html.twig', ['content' => $mailContent, 'logo_url' => $event->getLogoUrl()]);
 
         $subject = sprintf("[%s] Merci !", $event->getTitle());
 

--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -50,6 +50,7 @@ class Emails
         $this->mail->getMandrill()->messages->send([
             'from_email' => 'bonjour@afup.org',
             'from_name' => 'AFUP',
+            'bcc_address' => 'tresorier@afup.org',
             'html' => $content,
             'subject' => $subject,
             'to' => [

--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -7,6 +7,12 @@ use AppBundle\Event\Model\Event;
 
 class Emails
 {
+    const EMAIL_BUREAU_ADDRESS = 'bureau@afup.org';
+    const EMAIL_BUREAU_LABEL = 'Bureau AFUP';
+    const EMAIL_BONJOUR_ADDRESS = 'bonjour@afup.org';
+    const EMAIL_BONJOUR_LABEL = 'AFUP';
+    const EMAIL_TRESORIER_ADDRESS = 'tresorier@afup.org';
+
     /**
      * @var \Twig_Environment
      */
@@ -48,9 +54,9 @@ class Emails
         $subject = sprintf("[%s] Merci !", $event->getTitle());
 
         $this->mail->getMandrill()->messages->send([
-            'from_email' => 'bonjour@afup.org',
-            'from_name' => 'AFUP',
-            'bcc_address' => 'tresorier@afup.org',
+            'from_email' => self::EMAIL_BONJOUR_ADDRESS,
+            'from_name' => self::EMAIL_BONJOUR_LABEL,
+            'bcc_address' => self::EMAIL_TRESORIER_ADDRESS,
             'html' => $content,
             'subject' => $subject,
             'to' => [

--- a/sources/AppBundle/Email/Parsedown.php
+++ b/sources/AppBundle/Email/Parsedown.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace AppBundle\Email;
+
+class Parsedown extends \Parsedown
+{
+    public function __construct()
+    {
+        $this->setBreaksEnabled(true);
+    }
+
+    protected function inlineLink($Excerpt)
+    {
+        $inlineLink = parent::inlineLink($Excerpt);
+
+        $inlineLink['element']['attributes']['style'] = 'color: #4582db; text-decoration: underline;';
+
+        return  $inlineLink;
+    }
+
+    protected function blockHeader($Line)
+    {
+        if (isset($Line['text'][1]))
+        {
+            $level = 1;
+
+            while (isset($Line['text'][$level]) and $Line['text'][$level] === '#')
+            {
+                $level ++;
+            }
+
+            if ($level > 6)
+            {
+                return;
+            }
+
+            $text = trim($Line['text'], '# ');
+
+
+            $min = min(6, $level);
+
+            if ($min == 1) {
+                $Block = $this->customHeaderBlock($text);
+            } else {
+                $Block = array(
+                    'element' => array(
+                        'name' => 'h' . min(6, $level),
+                        'text' => $text,
+                        'handler' => 'line',
+                    ),
+                );
+            }
+
+
+            return $Block;
+        }
+    }
+
+    private function customHeaderBlock($text)
+    {
+        return array(
+            'element' => array(
+                'name' => 'div',
+                'attributes' => [
+                    'class' => 'title',
+                    'style' => 'color: #4582db; font-size: 18px; font-weight: bold; line-height: 24px;',
+                ],
+                'text' => $text,
+                'handler' => 'line',
+            ),
+        );
+    }
+}

--- a/sources/AppBundle/Email/Parsedown.php
+++ b/sources/AppBundle/Email/Parsedown.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace AppBundle\Email;
 
 class Parsedown extends \Parsedown

--- a/sources/AppBundle/Email/Parsedown.php
+++ b/sources/AppBundle/Email/Parsedown.php
@@ -21,17 +21,14 @@ class Parsedown extends \Parsedown
 
     protected function blockHeader($Line)
     {
-        if (isset($Line['text'][1]))
-        {
+        if (isset($Line['text'][1])) {
             $level = 1;
 
-            while (isset($Line['text'][$level]) and $Line['text'][$level] === '#')
-            {
+            while (isset($Line['text'][$level]) and $Line['text'][$level] === '#') {
                 $level ++;
             }
 
-            if ($level > 6)
-            {
+            if ($level > 6) {
                 return;
             }
 
@@ -43,13 +40,13 @@ class Parsedown extends \Parsedown
             if ($min == 1) {
                 $Block = $this->customHeaderBlock($text);
             } else {
-                $Block = array(
-                    'element' => array(
+                $Block = [
+                    'element' => [
                         'name' => 'h' . min(6, $level),
                         'text' => $text,
                         'handler' => 'line',
-                    ),
-                );
+                    ],
+                ];
             }
 
 
@@ -59,8 +56,8 @@ class Parsedown extends \Parsedown
 
     private function customHeaderBlock($text)
     {
-        return array(
-            'element' => array(
+        return [
+            'element' => [
                 'name' => 'div',
                 'attributes' => [
                     'class' => 'title',
@@ -68,7 +65,7 @@ class Parsedown extends \Parsedown
                 ],
                 'text' => $text,
                 'handler' => 'line',
-            ),
-        );
+            ],
+        ];
     }
 }

--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -365,9 +365,16 @@ class Event implements NotifyPropertyInterface
         return $cfp[$key];
     }
 
-    public function getMailTemplate()
+    public function getMailInscriptionContent()
     {
-        return 'confirmation-inscription-' . $this->getPath();
+        $cfp = $this->getCFP();
+        $key = 'mail_inscription_content';
+
+        if (!isset($cfp[$key])) {
+            return null;
+        }
+
+        return $cfp[$key];
     }
 
     /**

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -24,11 +24,17 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
      */
     private $container;
 
-    public function __construct(LegacyRouter $legacyRouter, \Parsedown $parsedown, ContainerInterface $container)
+    /**
+     * @var \Parsedown
+     */
+    private $emailParsedown;
+
+    public function __construct(LegacyRouter $legacyRouter, \Parsedown $parsedown, \Parsedown $emailParsedown, ContainerInterface $container)
     {
         $this->legacyRouter = $legacyRouter;
         $this->parsedown = $parsedown;
         $this->container = $container;
+        $this->emailParsedown = $emailParsedown;
     }
 
     /**
@@ -56,7 +62,9 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
             new \Twig_SimpleFilter('markdown', function ($text) {
                 return $this->parsedown->text($text);
             }, ['is_safe' => ['html']]),
-
+            new \Twig_SimpleFilter('markdown_email', function ($text) {
+                return $this->emailParsedown->text($text);
+            }, ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
Jusqu'à présent il fallait créer un nouveau template dans mandrill.
Cette année celui-ci avait été oublié pendant une partie de l'ouverture de la billeterie,
ce qui a entrainé pas mal de support.
Afin d'éviter de l'oublier et de multipler les outils à la création d'un event,
on permet de saisir le contenu du mail dans le BO.
Le contenu est saisi en markdown.
Afin de pouvoir tester le rendu, on ajoute un controlleur pour envoyer un mail
de test.
De plus, cela permettra de limiter la dépendance à Mandrill pour pouvoir
utiliser juste la partie SMTP et plus l'api (ce qui permettra à termer de limiter
les coûts sur Mandrill/Mailchimp).

![screen shot 2018-10-21 at 20 47 56](https://user-images.githubusercontent.com/320372/47271156-1cbff700-d576-11e8-9639-dc53f450a822.png)

![capture du 2018-10-21 20-48-08](https://user-images.githubusercontent.com/320372/47271160-26495f00-d576-11e8-8ea3-2aad598517d3.png)

