### PR TITLE
on permet d'affichager la page sponsor après la fin de la billeterie

### DIFF
--- a/app/Resources/views/event/ticket/sponsor.html.twig
+++ b/app/Resources/views/event/ticket/sponsor.html.twig
@@ -12,70 +12,76 @@
 
             <h3>{% trans %}VOS PLACES GRATUITES{% endtrans %}</h3>
 
-            <p>
-                {% trans with { '%date%': "<b>" ~ event.dateEndSales|localizeddate('full', 'none') ~ "</b>" } %}
-                    Enregistrez vous-même vos invités avant le %date% dernier délai. Vos invités recevront leur convocation quelques jours avant l’événement.
-                {% endtrans %}
-            </p>
+            {% if sold_out %}
+                <p>Désolé, la billeterie n'est plus disponible pour cet événement.</p>
 
-            <p>{% trans %}Pour rappel, les personnes en charge de l’animation de votre stand doivent bénéficier en priorité de ces places.{% endtrans %}</p>
-
-            <h4>Tickets déjà enregistrés</h4>
-            <table>
-                <tr>
-                    <th>
-                        Prénom
-                    </th>
-                    <th>
-                        Nom
-                    </th>
-                    <th>
-                        Email
-                    </th>
-                    <th>
-                        ¤
-                    </th>
-                </tr>
-            {% for ticket in registeredTickets %}
-                <tr>
-                    <td>
-                        {{ ticket.firstName }}
-                    </td>
-                    <td>
-                        {{ ticket.lastName }}
-                    </td>
-                    <td>
-                        {{ ticket.email }}
-                    </td>
-                    <td>
-                        <form method="post" class="sponsor--ticket">
-                            <a href="{{ url('sponsor_ticket_form', {ticket: ticket.id, eventSlug: event.path}) }}" class="button">Modifier</a>
-                            <button type="submit" value="{{ ticket.id }}" name="delete">Supprimer</button>
-                        </form>
-                    </td>
-                </tr>
             {% else %}
-                <tr>
-                    <td colspan="4"><em>Aucun ticket enregistré pour le moment.</em></td>
-                </tr>
+                <p>
+                    {% trans with { '%date%': "<b>" ~ event.dateEndSales|localizeddate('full', 'none') ~ "</b>" } %}
+                        Enregistrez vous-même vos invités avant le %date% dernier délai. Vos invités recevront leur convocation quelques jours avant l’événement.
+                    {% endtrans %}
+                </p>
 
-            {% endfor %}
-            </table>
+                <p>{% trans %}Pour rappel, les personnes en charge de l’animation de votre stand doivent bénéficier en priorité de ces places.{% endtrans %}</p>
 
-            {% if edit %}
-                <h4>Modifier le ticket</h4>
-            {% else %}
-                <h4>Nouveau ticket</h4>
-            {% endif %}
-            <p>{{ 'Places disponibles'|trans }}: {{ sponsorTicket.pendingInvitations }} / {{ sponsorTicket.maxInvitations }} </p>
-            {% if sponsorTicket.pendingInvitations == 0 %}
-                <p>Vous avez utilisé toutes vos invitations. Nous avons hâte de vous retrouver lors de cet événement !</p>
-            {% else %}
-                {{ form_start(ticketForm, {attr: {class: 'sponsor--ticket-edit'}}) }}
-                {{ form_errors(ticketForm) }}
-                {{ form_widget(ticketForm) }}
-                <input type="submit" value="Enregistrer" />
-                {{ form_end(ticketForm) }}
+                <h4>Tickets déjà enregistrés</h4>
+                <table>
+                    <tr>
+                        <th>
+                            Prénom
+                        </th>
+                        <th>
+                            Nom
+                        </th>
+                        <th>
+                            Email
+                        </th>
+                        <th>
+                            ¤
+                        </th>
+                    </tr>
+                {% for ticket in registeredTickets %}
+                    <tr>
+                        <td>
+                            {{ ticket.firstName }}
+                        </td>
+                        <td>
+                            {{ ticket.lastName }}
+                        </td>
+                        <td>
+                            {{ ticket.email }}
+                        </td>
+                        <td>
+                            <form method="post" class="sponsor--ticket">
+                                <a href="{{ url('sponsor_ticket_form', {ticket: ticket.id, eventSlug: event.path}) }}" class="button">Modifier</a>
+                                <button type="submit" value="{{ ticket.id }}" name="delete">Supprimer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% else %}
+                    <tr>
+                        <td colspan="4"><em>Aucun ticket enregistré pour le moment.</em></td>
+                    </tr>
+
+                {% endfor %}
+                </table>
+
+                {% if edit %}
+                    <h4>Modifier le ticket</h4>
+                {% else %}
+                    <h4>Nouveau ticket</h4>
+                {% endif %}
+                <p>{{ 'Places disponibles'|trans }}: {{ sponsorTicket.pendingInvitations }} / {{ sponsorTicket.maxInvitations }} </p>
+                {% if sponsorTicket.pendingInvitations == 0 %}
+                    <p>Vous avez utilisé toutes vos invitations. Nous avons hâte de vous retrouver lors de cet événement !</p>
+                {% else %}
+                    {{ form_start(ticketForm, {attr: {class: 'sponsor--ticket-edit'}}) }}
+                    {{ form_errors(ticketForm) }}
+                    {{ form_widget(ticketForm) }}
+                    <input type="submit" value="Enregistrer" />
+                    {{ form_end(ticketForm) }}
+                {% endif %}
+
             {% endif %}
         </div>
         <div class="col-md-6">

--- a/sources/AppBundle/Controller/TicketController.php
+++ b/sources/AppBundle/Controller/TicketController.php
@@ -23,9 +23,6 @@ class TicketController extends EventBaseController
     {
         $event = $this->checkEventSlug($eventSlug);
 
-        if ($event->getDateEndSales() < new \DateTime()) {
-            return $this->render(':event/ticket:sold_out.html.twig', ['event' => $event]);
-        }
         if ($request->getSession()->has('sponsor_ticket_id') === true) {
             $request->getSession()->remove('sponsor_ticket_id');
         }
@@ -73,10 +70,6 @@ class TicketController extends EventBaseController
     {
         $event = $this->checkEventSlug($eventSlug);
 
-        if ($event->getDateEndSales() < new \DateTime()) {
-            return $this->render(':event/ticket:sold_out.html.twig', ['event' => $event]);
-        }
-
         if ($request->getSession()->has('sponsor_ticket_id') === false) {
             $this->addFlash('error', 'Merci de renseigner votre token');
             return $this->redirectToRoute('sponsor_ticket_home', ['eventSlug' => $eventSlug]);
@@ -112,6 +105,10 @@ class TicketController extends EventBaseController
         $ticketForm->handleRequest($request);
 
         if ($ticketForm->isSubmitted() && $ticketForm->isValid() && $sponsorTicket->getPendingInvitations() > 0) {
+            if ($event->getDateEndSales() < new \DateTime()) {
+                return $this->render(':event/ticket:sold_out.html.twig', ['event' => $event]);
+            }
+
             $sponsorTicketHelper->addTicketToSponsor($sponsorTicket, $ticket);
             $mailer = $this->get('app.mail');
             $logger = $this->get('logger');
@@ -156,7 +153,8 @@ class TicketController extends EventBaseController
             'sponsorTicket' => $sponsorTicket,
             'ticketForm' => $ticketForm->createView(),
             'registeredTickets' => $sponsorTicketHelper->getRegisteredTickets($sponsorTicket),
-            'edit' => $edit
+            'edit' => $edit,
+            'sold_out' => $event->getDateEndSales() < new \DateTime(),
         ]);
     }
 


### PR DESCRIPTION
Maintenant que sur la page sponsor on affiche des informations à propos
de l'événement, on permet toujours d'accéder la page des sponsors
via leur token, mais bloque la partie gauche de la page.

![screenshot_2018-10-21 billetterie - afup](https://user-images.githubusercontent.com/320372/47271368-ee8fe680-d578-11e8-9b04-3e317b0160be.png)
