### PR TITLE
améliorations info notification cfp

### DIFF
--- a/sources/AppBundle/Controller/CFPController.php
+++ b/sources/AppBundle/Controller/CFPController.php
@@ -287,8 +287,8 @@ class CFPController extends EventBaseController
                 $this->get('ting')->get(SpeakerRepository::class)->save($this->get('app.speaker_factory')->getSpeaker($event));
 
                 if ($this->get('ting.unitofwork')->isManaged($talk) === false) {
-                    $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($talk) {
-                        $this->get('app.slack_notifier')->notifyTalk($talk);
+                    $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($talk, $event) {
+                        $this->get('app.slack_notifier')->notifyTalk($talk, $event);
                     });
                 }
 

--- a/sources/AppBundle/Notifier/SlackNotifier.php
+++ b/sources/AppBundle/Notifier/SlackNotifier.php
@@ -3,6 +3,7 @@
 
 namespace AppBundle\Notifier;
 
+use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Talk;
 use AppBundle\Event\Model\Vote;
 use AppBundle\Slack\Message;
@@ -55,11 +56,13 @@ class SlackNotifier
      * Send a message to slack for a new talk
      *
      * @param Talk $talk
+     * @param Event $event
+     *
      * @return bool
      */
-    public function notifyTalk(Talk $talk)
+    public function notifyTalk(Talk $talk, Event $event)
     {
-        $message = $this->messageFactory->createMessageForTalk($talk);
+        $message = $this->messageFactory->createMessageForTalk($talk, $event);
         return $this->sendMessage($message);
     }
 

--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -81,14 +81,16 @@ class MessageFactory
 
     /**
      * @param Talk $talk
+     * @param Event $event
+     *
      * @return Message $message
      */
-    public function createMessageForTalk(Talk $talk)
+    public function createMessageForTalk(Talk $talk, Event $event)
     {
         $attachment = new Attachment();
         $attachment
-            ->setTitle('Nouvelle proposition sur le CFP')
-            ->setTitleLink('https://afup.org/pages/administration/index.php?page=forum_sessions')
+            ->setTitle('Nouvelle proposition sur le CFP - ' . $event->getTitle())
+            ->setTitleLink('https://afup.org/pages/administration/index.php?' . http_build_query(['page' => 'forum_sessions', 'id_forum' => $event->getId()]))
             ->setFallback(sprintf(
                     'Nouvelle proposition intitulée "%s". Type %s - Public %s',
                     $talk->getTitle(),


### PR DESCRIPTION
Vu qu'on a 3 events en parallèle, il faut indiquer à quel event
correspond l'événement dans la notfif slack.
De plus on rajoute l'id de l'event dans le lien, afin d'arriver de
suite sur la bonne page.