### PR TITLE
amélioration des cartes twitter des événements pour l'AFUP Day

### DIFF
--- a/app/Resources/views/event/cfp/vote_only.html.twig
+++ b/app/Resources/views/event/cfp/vote_only.html.twig
@@ -10,7 +10,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@afup" />
     <meta name="twitter:title" content="AFUP - Votez pour les conférences du {{ event.title }}" />
-    <meta name="twitter:description" content="Votez pour les conférence du {{ event.title }} qui aura lieu les {{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
+    <meta name="twitter:description" content="Votez pour les conférence du {{ event.title }} qui aura lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
     {% if event.logoUrl %}
         <meta name="twitter:image" content="{{ event.logoUrl }}" />
     {% endif %}

--- a/app/Resources/views/event/home.html.twig
+++ b/app/Resources/views/event/home.html.twig
@@ -10,7 +10,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@afup" />
     <meta name="twitter:title" content="AFUP - Soumettez une conférence pour le {{ event.title }}" />
-    <meta name="twitter:description" content="Proposez une conférence pour le {{ event.title }} qui aura lieu les {{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
+    <meta name="twitter:description" content="Proposez une conférence pour le {{ event.title }} qui aura lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
     {% if event.logoUrl %}
         <meta name="twitter:image" content="{{ event.logoUrl }}" />
     {% endif %}

--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -21,7 +21,7 @@
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@afup" />
     <meta name="twitter:title" content="Prenez votre place pour le {{ event.title }}" />
-    <meta name="twitter:description" content="Ne manquez pas le grand rendez-vous de la communauté PHP, {{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
+    <meta name="twitter:description" content="Ne manquez pas le grand rendez-vous de la communauté PHP, {% if event.dateStart == event.dateEnd %}{{ event.dateStart|date('d') }}{% else %}{{ event.dateStart|date('d') }}-{{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM') }}." />
     {% if event.logoUrl %}
         <meta name="twitter:image" content="{{ event.logoUrl }}" />
     {% endif %}


### PR DESCRIPTION
on affichait dans la description :

```
Proposez une conférence pour le AFUP Day 2019 Lyon qui aura lieu les 17-17 mai
```

on affiche maintenant :

```
Proposez une conférence pour le AFUP Day 2019 Lyon qui aura lieu le 17 mai
```

(jusqu'à présent on avait pas d'event d'une journée).