### PR TITLE
correction affichage des confs planifiées sur l'historique

### DIFF
--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -556,7 +556,7 @@ class Talk implements NotifyPropertyInterface
     {
         $type = $this->getType();
 
-        return $type != self::TYPE_CLINIC && $type != self::TYPE_SPEAKER_INTRODUCTIONS;
+        return $type != self::TYPE_CLINIC && $type != self::TYPE_SPEAKER_INTRODUCTIONS && true === $this->getScheduled();
     }
 
     /**


### PR DESCRIPTION
Si une conf avait été planifiée et se trouvait dans la table de planning,
puis qu'elle était annulée via la table des sessions, on l'affichait dans l'historique.
Il faut dans ces cas la masquer.