### PR TITLE
billeterie : ajout d'une case pour valiser les CGV, CGP et le COC

### DIFF
--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -193,6 +193,13 @@
         <fieldset class="f{{ ticketForm.tickets|length +2 }} fieldset-divers">
             <legend>Divers <span class="fieldset--legend--title"></span><span class="fieldset--legend--price"></span></legend>        <div id="fieldset--optin" class="fieldset--inner">
                 <div>
+                    {{ form_errors(ticketForm.cgv) }}
+                    {{ form_widget(ticketForm.cgv) }}
+                    <label for="{{ ticketForm.cgv.vars.id }}">
+                        J'accepte les <a href="https://event.afup.org/conditions-generales-de-vente/">conditions générale de vente</a>, <a href="https://event.afup.org/condition-generales-de-participation/">de participation</a> et m'engage à respecter <a href="https://afup.org/p/986-code-de-conduite">le code de conduite</a>.
+                    </label>
+                </div>
+                <div>
                     {{ form_widget(ticketForm.companyCitation) }}
                     {{ form_label(ticketForm.companyCitation) }}
                 </div>
@@ -229,11 +236,6 @@
                 <div class="clearfix">
                     <div class="input">
                         Si vous rencontrez le moindre problème, n'hésitez pas à nous contacter à l'adresse bonjour [@] afup.org.
-                    </div>
-                </div>
-                <div class="clearfix">
-                    <div class="input">
-                        * En venant aux évènements de l'AFUP vous vous engagez à respecter le <a href="http://event.afup.org/code-de-conduite/">Code de conduite</a>.
                     </div>
                 </div>
 

--- a/sources/AppBundle/Event/Form/PurchaseType.php
+++ b/sources/AppBundle/Event/Form/PurchaseType.php
@@ -14,6 +14,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Validator\Constraints\IsTrue;
 
 class PurchaseType extends AbstractType
 {
@@ -84,6 +85,15 @@ class PurchaseType extends AbstractType
                 'label'    => 'J\'accepte que ma société soit citée comme participant à la conférence',
                 'required' => false,
                 'mapped' => false
+            ])
+            ->add('cgv', CheckboxType::class, [
+                'required' => true,
+                'mapped' => false,
+                'constraints' => [
+                    new IsTrue([
+                        'message' => 'Vous devez valider les conditions.',
+                    ]),
+                ],
             ])
             ->add('newsletterAfup', CheckboxType::class, [
                 'label' => 'Je souhaite être tenu au courant des rencontres de l\'AFUP sur des sujets afférents à PHP',


### PR DESCRIPTION
On ajoute une case à cocher pour valider l'acceptation des conditions
générales de vente, de participation et le code de conduite.
On a des liens vers les 3 documents en question.

![screenshot_2018-11-19 prenez votre place pour le forum 2](https://user-images.githubusercontent.com/320372/48860320-e4a01400-edc0-11e8-8124-8a1aa85fae37.png)
