### PR TITLE
correction du lien vers les sessions sur la page de détail d'un confé…

### DIFF
--- a/htdocs/pages/administration/forum_conferenciers.php
+++ b/htdocs/pages/administration/forum_conferenciers.php
@@ -264,7 +264,7 @@ if ($action == 'inscrire_forum') {
 
     $formulaire->addElement('header', null, 'Sessions');
     foreach ($sessions as $session) {
-        $url = 'index.php?page=forum_sessions&action=commenter&id=' . $session['session_id'] . '&id_forum=' . $_GET['id_forum'];
+        $url = 'index.php?page=forum_sessions&action=modifier&id=' . $session['session_id'] . '&id_forum=' . $_GET['id_forum'];
         $formulaire->addElement('static', null, '<a href="' . $url . '">' . $session['titre'] . '</a>');
     }
 


### PR DESCRIPTION
…rencier

Le lien envoyait vers la page pour commenter une session, page qui ne
fonctionne plus et est ammenée à être supprimée.
Afin de naviger plus facilement entre les sessions/conférenciers, on corrige
ce lien pour l'ammener vers la page de modification au lieu de la page de
commentaire.