### PR TITLE
gestion de l'environnement de production sur le lancement des migrati…

### DIFF
--- a/phinx.php
+++ b/phinx.php
@@ -2,26 +2,43 @@
 
 require 'vendor/autoload.php';
 
-$kernel = new AppKernel('dev', true);
-$kernel->boot();
-$container = $kernel->getContainer();
+$environments = [
+    'default_migration_table' => 'phinxlog',
+];
+
+if (is_file(__DIR__ . '/vendor/sensio/generator-bundle/composer.json')) {
+    $kernelDev = new AppKernel('dev', true);
+    $kernelDev->boot();
+    $containerDev = $kernelDev->getContainer();
+    $environments['development'] = [
+        'adapter' => 'mysql',
+        'host' => $containerDev->getParameter('database_host'),
+        'name' => $containerDev->getParameter('database_name'),
+        'user' => $containerDev->getParameter('database_user'),
+        'pass' => $containerDev->getParameter('database_password'),
+        'port' => $containerDev->getParameter('database_port'),
+        'charset' => 'utf8mb4',
+    ];
+}
+
+$kernelProd = new AppKernel('prod', true);
+$kernelProd->boot();
+$containerProd = $kernelProd->getContainer();
+
+$environments['production'] = [
+    'adapter' => 'mysql',
+    'host' => $containerProd->getParameter('database_host'),
+    'name' => $containerProd->getParameter('database_name'),
+    'user' => $containerProd->getParameter('database_user'),
+    'pass' => $containerProd->getParameter('database_password'),
+    'port' => $containerProd->getParameter('database_port'),
+    'charset' => 'utf8mb4',
+];
 
 return [
     'paths' => [
         'migrations' => __DIR__ . '/db/migrations',
         'seeds' => __DIR__ . '/db/seeds',
     ],
-    'environments' =>
-        [
-            'default_migration_table' => 'phinxlog',
-            'development' => [
-                'adapter' => 'mysql',
-                'host' => $container->getParameter('database_host'),
-                'name' => $container->getParameter('database_name'),
-                'user' => $container->getParameter('database_user'),
-                'pass' => $container->getParameter('database_password'),
-                'port' => $container->getParameter('database_port'),
-                'charset' => 'utf8mb4',
-            ]
-        ]
+    'environments' => $environments,
 ];


### PR DESCRIPTION
…ons phinx

Actuellement les migrations phinx sont lancées à la main.
Il y avait un problème, à chaque fois il fallait passer l'environnement à prod
dans le fichier de config, vu qu'il était lancé en dev pour récupérer les infos
de connexion à la base.

On évite donc cela en créant bien des configurations de production et de
développement (pour vérifier si on est en environnement de dev, le seul
moyen trouvé à été de vérifier si un fes fichiers lodés seulement en dev
est présent).

Comme cela la commande de migration pourra être lancée sans modification,
et on va pouvoir lancer automatiquement ces migrations lors du déploiement
automatisé (ça a tourné suffisament de fois à la main).