### PR TITLE
augmentation de la longueur de titre autorisée pour les sessions sur …

### DIFF
--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -283,7 +283,7 @@ if ($action == 'lister') {
     $formulaire->addElement('header', null, 'Présentation');
 
     $formulaire->addElement('date'    , 'date_soumission', 'Soumission', array('language' => 'fr', 'minYear' => date('Y'), 'maxYear' => date('Y')));
-    $formulaire->addElement('text'    , 'titre'          , 'Titre' , array('size' => 40, 'maxlength' => 80));
+    $formulaire->addElement('text'    , 'titre'          , 'Titre' , array('size' => 40, 'maxlength' => 150));
 
     $abstractClass = 'simplemde';
     $useMarkdown = true;


### PR DESCRIPTION
…le BO

Sur le BO on avait une limite à 80 caractères sur le titre des sessions.
Cette limite n'était pas présente dans le CFP, où on avait par exemple
des propositions de session avec une longueur à 138 caractères.
Ces titres ne sont pas modifiables dans le BO à cause de la limite à 80 caractères.
Afin d'être plus cohérent entre le formulaire dans le CFP et le formulaire
dans le BO, on augmente la longueur autorisée dans le BO.