### PR TITLE
correction du lien vers les articles dans la liste des news de la home

### DIFF
--- a/app/Resources/views/site/home.html.twig
+++ b/app/Resources/views/site/home.html.twig
@@ -32,7 +32,7 @@
                     <ul class="home-list home-list__actualites">
                         {% for actualite in actualites %}
                             <li class="{% if loop.first %} home-list-item_first {% endif %}">
-                                <a href="{{ actualite.route }}">
+                                <a href="{{ path('news_display', {code: actualite.code}) }}">
                                     <span class="home-list-date">{{ actualite.date|date('d/m') }}</span>
                                     {% if loop.first  %}
                                         <h4 style="display: inline-block">{{ actualite.titre }}</h4>

--- a/sources/Afup/Corporate/Article.php
+++ b/sources/Afup/Corporate/Article.php
@@ -102,6 +102,11 @@ class Article
         return $this->titre;
     }
 
+    public function getCode()
+    {
+        return $this->id . '-' . $this->raccourci;
+    }
+
     function teaser()
     {
         switch (true) {


### PR DESCRIPTION
Quand le raccourci de l'article contenait un caractère urlencodé,
il été encodé deux fois : une première fois dans le lien, une seconde
lors de la redirection. On tombait donc sur des 404. Vu qu'on peux
difficilement modifier les raccourcis déjà existants, on met directement
le lien vers l'url de l'article (au passage, comme ça on évite la redirection).