### PR TITLE
Export des inscrits aux derniers forums : on prends bien en compte l'autorisation d'envoi

### DIFF
--- a/htdocs/templates/administration/forum_inscriptions.html
+++ b/htdocs/templates/administration/forum_inscriptions.html
@@ -77,7 +77,7 @@
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
     <a href="/admin/event/badges?id_forum={$id_forum}" title="Exporter les inscriptions pour les badges">Exporter les inscriptions pour les badges</a> <i>(prends environ une minute)</i><br />
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" />
-    <a href="/admin/event/previous_registrations?event_count=4">Exporter des inscrits aux 4 derniers événements</a><br />
+    <a href="/admin/event/previous_registrations?event_count=4">Exporter les inscrits aux 4 derniers événements</a> <i>(ayant acceptés d'être contactés, et pour les événements passés)</i><br />
 
     <br/>
     <table>

--- a/sources/AppBundle/Controller/AdminEventController.php
+++ b/sources/AppBundle/Controller/AdminEventController.php
@@ -584,7 +584,7 @@ class AdminEventController extends Controller
 
         $events = $this->get('ting')->get(EventRepository::class)->getPreviousEvents($request->query->getInt('event_count', 4));
 
-        $registrations = $this->get('ting')->get(TicketRepository::class)->getRegistrationsForEvents($events);
+        $registrations = $this->get('ting')->get(TicketRepository::class)->getRegistrationsForEventsWithNewsletterAllowed($events);
 
         foreach ($registrations as $registration) {
             $file->fputcsv($registration);

--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -47,7 +47,7 @@ class TicketRepository extends Repository implements MetadataInitializer
      *
      * @return \CCMBenchmark\Ting\Repository\CollectionInterface
      */
-    public function getRegistrationsForEvents(\Traversable $events)
+    public function getRegistrationsForEventsWithNewsletterAllowed(\Traversable $events)
     {
         $params = [];
         $cpt = 0;
@@ -63,6 +63,7 @@ class TicketRepository extends Repository implements MetadataInitializer
                         afup_inscription_forum.email
                  FROM afup_inscription_forum
                  WHERE afup_inscription_forum.id_forum IN (%ids%)
+                   AND afup_inscription_forum.newsletter_afup = 1
                  GROUP BY afup_inscription_forum.nom, afup_inscription_forum.prenom, afup_inscription_forum.email
                  ORDER BY afup_inscription_forum.nom, afup_inscription_forum.prenom, afup_inscription_forum.email',
                 [


### PR DESCRIPTION
Lors de l'inscription au forum on a une case à cocher "Je souhaite être tenu au courant des rencontres de l'AFUP sur des sujets afférents à PHP".
On utilise ce flag dans l'export des inscriptions aux X derniers événements (qu'on utilise pour communiquer autour de la billeterie).