### PR TITLE
par défaut la date de la techletter est positionnée sur le prochain mercredi

### DIFF
--- a/sources/AppBundle/TechLetter/Form/SendingType.php
+++ b/sources/AppBundle/TechLetter/Form/SendingType.php
@@ -15,7 +15,7 @@ class SendingType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('sendingDate', DateType::class, ['label' => 'Date planifiée', 'data' => new \DateTime('+2 days')])
+            ->add('sendingDate', DateType::class, ['label' => 'Date planifiée', 'data' => new \DateTime('next wednesday')])
             ->add('save', SubmitType::class, ['label' => 'Créer cette techletter'])
         ;
     }


### PR DESCRIPTION
La newsletter de la veille est envoyé le mercredi toutes les deux semaines.

Il est alors intéressant de positionner par défaut la date d'envoi au prochain mercredi plutôt qu'une date arbitraire.