### PR TITLE
Ajout d'un target pour la console PHP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,3 +103,6 @@ db-migrations:
 
 db-seed:
 	php bin/phinx seed:run
+
+console:
+	CURRENT_UID=$(CURRENT_UID) docker-compose run --rm cliphp bash

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CURRENT_UID ?= $(shell id -u)
 DOCKER_UP_OPTIONS ?=
 
-.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init
+.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init console
 
 install: vendors event/vendor
 


### PR DESCRIPTION
Ajout d'un target make pour ouvrir une console dans un container `cliphp`.
C'est très utile que la version de PHP n'est pas installé sur le poste.