### PR TITLE
correction du widget des talks/speakers sur les pages d'interviews

### DIFF
--- a/event/resources/themes/basis_child/functions.php
+++ b/event/resources/themes/basis_child/functions.php
@@ -13,7 +13,7 @@ add_filter('upload_mimes', 'cc_mime_types');
 
 
 function afup_website_func($attrs) {
-    $url = getenv('AFUP_WEBSITE_URL') . $attrs['path'];
+    $url = getenv('AFUP_WEBSITE_URL') . html_entity_decode($attrs['path']);
     $ch = curl_init();
 
     if (defined('WP_DEBUG') && WP_DEBUG == true) {


### PR DESCRIPTION
Si l'interview était éditée en mode visuel et pas en mode texte l'url
était htmlencodée et l'esperluette n'était donc plus présente telle
quelle, on ne prennait donc plus en compte les derniers paramètres
de filtre qui permettent de choisir si on affiche le widget speaker
ou celui du talk. En décodant celui-ci on évite ce problème et permet
d'utiliser le mode visuel lors de la rédaction des interviews.