### PR TITLE
correction affichage certains résultats

### DIFF
--- a/sources/AppBundle/Event/Model/HydratorAggregator.php
+++ b/sources/AppBundle/Event/Model/HydratorAggregator.php
@@ -1,0 +1,148 @@
+<?php
+/***********************************************************************
+ *
+ * Ting - PHP Datamapper
+ * ==========================================
+ *
+ * Copyright (C) 2014 CCM Benchmark Group. (http://www.ccmbenchmark.com)
+ *
+ ***********************************************************************
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you
+ * may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ **********************************************************************/
+
+namespace AppBundle\Event\Model;
+
+use CCMBenchmark\Ting\Repository\Hydrator;
+
+class HydratorAggregator extends Hydrator
+{
+    /**
+     * @var callable
+     */
+    protected $callableForId;
+
+    /**
+     * @var callable
+     */
+    protected $callableForData;
+
+    /**
+     * @var callable
+     */
+    protected $callableFinalizeAggregate;
+
+    /**
+     * @param callable $callableForId
+     * @return $this
+     */
+    public function callableIdIs(callable $callableForId)
+    {
+        $this->callableForId = $callableForId;
+        return $this;
+    }
+
+    /**
+     * @param callable $callableForData
+     * @return $this
+     */
+    public function callableDataIs(callable $callableForData)
+    {
+        $this->callableForData = $callableForData;
+        return $this;
+    }
+
+    /**
+     * @param callable $callableFinalizeAggregate
+     * @return $this
+     */
+    public function callableFinalizeAggregate(callable $callableFinalizeAggregate)
+    {
+        $this->callableFinalizeAggregate = $callableFinalizeAggregate;
+        return $this;
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function getIterator()
+    {
+        $knownIdentifiers = [];
+        $callableForId = $this->callableForId;
+        $callableForData = $this->callableForData;
+        $previousId = null;
+        $previousResult = null;
+        $previousKey = null;
+        $currentId = null;
+        $aggregate = [];
+        $key = null;
+        $result = null;
+
+        foreach ($this->result as $key => $columns) {
+            $result = $this->hydrateColumns(
+                $this->result->getConnectionName(),
+                $this->result->getDatabase(),
+                $columns
+            );
+
+            $currentId = $callableForId($result);
+
+            if (isset($knownIdentifiers[$currentId]) === true) {
+                continue;
+            }
+
+            if ($previousId === null) {
+                $previousId = $currentId;
+                $previousResult = $result;
+                $previousKey = $key;
+            }
+
+            if ($previousId === $currentId) {
+                $aggregate[] = $callableForData($result);
+            } else {
+                $previousResult = $this->finalizeAggregate($previousResult, $aggregate);
+
+                $knownIdentifiers[$previousId] = true;
+
+                yield $previousKey => $previousResult;
+
+                $aggregate = [$callableForData($result)];
+                $previousId = $currentId;
+                $previousResult = $result;
+                $previousKey = $key;
+            }
+        }
+
+        if ($previousId === $currentId) {
+            yield $key => $this->finalizeAggregate($result, $aggregate);
+        }
+    }
+
+    /**
+     * @param mixed $result
+     * @param mixed $aggregate
+     *
+     * @return mixed
+     */
+    private function finalizeAggregate($result, $aggregate)
+    {
+        if ($this->callableFinalizeAggregate === null) {
+            $result['aggregate'] = $aggregate;
+            return $result;
+        }
+
+        $callableFinalizeAggregate = $this->callableFinalizeAggregate;
+        return $callableFinalizeAggregate($result, $aggregate);
+    }
+}

--- a/sources/AppBundle/Event/Model/JoinHydrator.php
+++ b/sources/AppBundle/Event/Model/JoinHydrator.php
@@ -1,110 +1,23 @@
 <?php
 
-
 namespace AppBundle\Event\Model;
 
-use CCMBenchmark\Ting\Exception;
-use CCMBenchmark\Ting\Repository\Hydrator;
-
-class JoinHydrator extends Hydrator
+class JoinHydrator extends HydratorAggregator
 {
-    private $nextResultRow = null;
-
-    private $aggregation = [];
-
     public function aggregateOn($mainObjectAlias, $joinedObjectAlias, $mainObjectGetter)
     {
-        $this->aggregation = [
-            'mainObjectAlias' => $mainObjectAlias,
-            'joinedObjectAlias' => $joinedObjectAlias,
-            'mainObjectGetter' => $mainObjectGetter
-        ];
-
+        $this
+            ->callableDataIs(function ($result) use ($joinedObjectAlias) {
+                return $result[$joinedObjectAlias];
+            })
+            ->callableIdIs(function ($result) use ($mainObjectAlias, $mainObjectGetter) {
+                return $result[$mainObjectAlias]->$mainObjectGetter();
+            })
+            ->callableFinalizeAggregate(function ($result, $aggregate) use ($joinedObjectAlias) {
+                $result['.aggregation'][$joinedObjectAlias] = array_filter($aggregate);
+                return $result;
+            })
+        ;
         return $this;
-    }
-
-    public function count()
-    {
-        throw new \RuntimeException('You cannot count results for a JoinHydrator, as results are built on loop');
-    }
-
-    /**
-     * @return \Generator
-     * @throws Exception
-     */
-    public function getIterator()
-    {
-        $aggregationChecked = false;
-
-        foreach ($this->result as $key => $columns) {
-            $result = $this->hydrateColumns(
-                $this->result->getConnectionName(),
-                $this->result->getDatabase(),
-                $columns
-            );
-            if ($aggregationChecked === false) {
-                if (isset($result[$this->aggregation['mainObjectAlias']]) === false) {
-                    throw new Exception(sprintf(
-                            'Your resultset does not include the alias "%s" but an aggregation has been defined for it. ' .
-                            'Is there a typo ?',
-                            $this->aggregation['mainObjectAlias']
-                        )
-                    );
-                }
-                if (
-                    method_exists(
-                        $result[$this->aggregation['mainObjectAlias']],
-                        $this->aggregation['mainObjectGetter']
-                    ) === false
-                ) {
-                    throw new Exception(sprintf(
-                            'Your alias %s does not include the getter "%s" but an aggregation has been defined for it. ' .
-                            'Is there a typo ?',
-                            $this->aggregation['mainObjectAlias'],
-                            $this->aggregation['mainObjectGetter']
-                        )
-                    );
-                }
-                $aggregationChecked = true;
-            }
-
-            if ($this->nextResultRow !== null) {
-                if (isset($this->nextResultRow[$this->aggregation['mainObjectAlias']]) === true) {
-                    $nextResultId = $this->nextResultRow[$this->aggregation['mainObjectAlias']]->{$this->aggregation['mainObjectGetter']}();
-                    $resultId = $result[$this->aggregation['mainObjectAlias']]->{$this->aggregation['mainObjectGetter']}();
-
-                    if ($nextResultId === $resultId) {
-                        if (isset($this->nextResultRow['.aggregation'][$this->aggregation['joinedObjectAlias']]) === false) {
-                            $this->nextResultRow['.aggregation'][$this->aggregation['joinedObjectAlias']] = [$this->nextResultRow[$this->aggregation['joinedObjectAlias']]];
-                        }
-                        $this->nextResultRow['.aggregation'][$this->aggregation['joinedObjectAlias']][] = $result[$this->aggregation['joinedObjectAlias']];
-                        continue;
-                    } else {
-                        $toYield = $this->nextResultRow;
-
-                        $this->nextResultRow = $this->prepareNextResultRow($result);
-
-                        yield $key => $toYield;
-                    }
-                } else {
-                    throw new Exception(sprintf('Could not find alias "%s" on result', $this->aggregation['mainObjectAlias']));
-                }
-            }
-            $this->nextResultRow = $this->prepareNextResultRow($result);
-        }
-        if ($this->nextResultRow !== null && isset($key)) {
-            yield $key => $this->nextResultRow;
-        }
-    }
-
-    private function prepareNextResultRow($row)
-    {
-        $row['.aggregation'][$this->aggregation['joinedObjectAlias']] = [];
-        if ($row[$this->aggregation['joinedObjectAlias']] !== null) {
-            $row['.aggregation'][$this->aggregation['joinedObjectAlias']][] = $row[$this->aggregation['joinedObjectAlias']];
-        }
-        unset($row[$this->aggregation['joinedObjectAlias']]);
-
-        return $row;
     }
 }


### PR DESCRIPTION
Parfois le joinHydrator ne renvoyais pas tous les résultats (un speaker n'était pas affiché sur la liste des speakers de Rennes).
On utilise donc le HydratorAggregator présent dans une version plus récente de ting et le proxifie dans le JoinHydrator afin de corriger cela.