### PR TITLE
correction auteur flux rss

### DIFF
--- a/htdocs/pages/site/rss.php
+++ b/htdocs/pages/site/rss.php
@@ -33,7 +33,7 @@ $feed = array(
 	'url'           => 'https://afup.org/',
 	'link'          => 'https://afup.org/rss.php',
 	'email'         => 'bonjour@afup.org',
-	'author'        => 'Nicolas Silberman / AFUP',
+	'author'        => 'AFUP',
 	'date'          => date(DATE_RSS),
 	'lastBuildDate' => 
         isset($derniersArticles[0]['maj']) ?


### PR DESCRIPTION
L'auteur du flux rss était `Nicolas Silberman / AFUP`.
On corrige cela pour que ça soit seulement `AFUP`.