### PR TITLE
correction des erreurs de migration de la db

### DIFF
--- a/db/migrations/20190403055839_suppression_aperos_php.php
+++ b/db/migrations/20190403055839_suppression_aperos_php.php
@@ -7,8 +7,8 @@ class SuppressionAperosPhp extends AbstractMigration
 {
     public function change()
     {
-        $this->dropTable('afup_aperos');
-        $this->dropTable('afup_aperos_inscrits');
-        $this->dropTable('afup_aperos_villes');
+        $this->execute('DROP TABLE IF EXISTS afup_aperos');
+        $this->execute('DROP TABLE IF EXISTS afup_aperos_inscrits');
+        $this->execute('DROP TABLE IF EXISTS afup_aperos_villes');
     }
 }


### PR DESCRIPTION
Lors  de l'initialisation  de la base de donnés la migration de suppression des tables liées aux apéros PHP bloque les migrations.
Cette PR corrige la migration pour supprimer les tables uniquement si elles existent.