### PR TITLE
ajout de xdebug dans les images docker

### DIFF
--- a/.env-dist
+++ b/.env-dist
@@ -1,2 +1,3 @@
 ## Options to pass to `docker-compose up` command
 #DOCKER_UP_OPTIONS= -d # -d will launch container in detached mode
+#ENABLE_XDEBUG=true # enable the PHP xDebug extension

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docker-down:
 	CURRENT_UID=$(CURRENT_UID) docker-compose down
 
 var/logs/.docker-build: docker-compose.yml docker-compose.override.yml $(shell find docker -type f)
-	CURRENT_UID=$(CURRENT_UID) docker-compose build
+	CURRENT_UID=$(CURRENT_UID) ENABLE_XDEBUG=$(ENABLE_XDEBUG) docker-compose build
 	touch var/logs/.docker-build
 
 .env:

--- a/docker-compose.override.yml-dist
+++ b/docker-compose.override.yml-dist
@@ -6,6 +6,8 @@ services:
   apachephp:
     ports:
       - "9205:80"
+   # environment:
+   #   XDEBUG_CONFIG: "remote_connect_back=1 profiler_enable=1 remote_autostart=0 remote_enable=1"
   planete:
     ports:
       - "9215:80"
@@ -22,3 +24,5 @@ services:
   apachephp7:
     ports:
       - "9235:80"
+   # environment:
+   #   XDEBUG_CONFIG: "remote_connect_back=1 profiler_enable=1 remote_autostart=0 remote_enable=1"

--- a/docker-compose.override.yml-dist
+++ b/docker-compose.override.yml-dist
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.2"
 services:
   db:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2.1"
+version: "2.2"
 
 services:
   db:
@@ -17,6 +17,7 @@ services:
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"
+        ENABLE_XDEBUG: ${ENABLE_XDEBUG:-false}
     environment:
       SYMFONY_ENV: "dev"
     volumes:
@@ -31,6 +32,7 @@ services:
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"
+        ENABLE_XDEBUG: ${ENABLE_XDEBUG:-false}
     environment:
       SYMFONY_ENV: "dev"
     volumes:
@@ -96,6 +98,7 @@ services:
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"
+        ENABLE_XDEBUG: ${ENABLE_XDEBUG:-false}
     user: localUser
     volumes:
       - ./data/composer:/home/localUser/.composer

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
+    pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug && \
     apt-get remove -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -1,5 +1,10 @@
 FROM php:5.6-apache
 
+ARG ENABLE_XDEBUG=false
+
+RUN if [ "$ENABLE_XDEBUG" = "true" ]; then echo ************ XDEBUG ENABLED **********; \
+else echo ------------ XDEBUG DISABLED ==========; fi
+
 # Install required php extensions for afup website and other management package
 RUN apt-get update && \
     apt-get install -y \
@@ -12,7 +17,7 @@ RUN apt-get update && \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
-    pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug && \
+    if [ "$ENABLE_XDEBUG" = "true" ]; then pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug; fi && \
     apt-get remove -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
+    pecl install xdebug-2.6.1 && docker-php-ext-enable xdebug && \
     apt-get remove -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -1,5 +1,10 @@
 FROM php:7.0-apache
 
+ARG ENABLE_XDEBUG=false
+
+RUN if [ "$ENABLE_XDEBUG" = "true" ]; then echo ************ XDEBUG ENABLED **********; \
+else echo ------------ XDEBUG DISABLED ==========; fi
+
 # Install required php extensions for afup website and other management package
 RUN apt-get update && \
     apt-get install -y \
@@ -12,7 +17,7 @@ RUN apt-get update && \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
-    pecl install xdebug-2.6.1 && docker-php-ext-enable xdebug && \
+    if [ "$ENABLE_XDEBUG" = "true" ]; then pecl install xdebug-2.6.1 && docker-php-ext-enable xdebug; fi && \
     apt-get remove -y \
         libfreetype6-dev \
         libjpeg62-turbo-dev \


### PR DESCRIPTION
Afin d'aider au débug, les images docker build xdebug.
Il faut activer xdebug dans le `.env` puis dans le fichier `docker-compose.override.yml-dist` il y a la configuration par défaut pour Xdebug.