### PR TITLE
on affiche la langue de la vidéo ainsi que les sous titres présents sur la page d'un talk

### DIFF
--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -85,6 +85,16 @@
                                 <a class="talk-info-link" href="{{ talk.getJoindinUrl }}"><i class="fa fa-comments"></i> Fiche joind.in</a>
                             </li>
                         {% endif %}
+
+                        <li><i class="fa fa-headphones"></i> Audio : {{ talk.getLanguageLabel|lower }}</li>
+
+                        {% if talk.getVideoHasEnSubtitles %}
+                            <li><i class="fa fa-cc"></i> Sous titres : anglais</li>
+                        {% endif %}
+
+                        {% if talk.getVideoHasFrSubtitles %}
+                            <li><i class="fa fa-cc"></i> Sous titres : français</li>
+                        {% endif %}
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
fixes #707

![Screen Shot 2019-04-23 at 22 22 44](https://user-images.githubusercontent.com/320372/56613155-5998a380-6616-11e9-91b5-67e2ea7d8a11.png)
