### PR TITLE
Migration email transactionnel

### DIFF
--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -129,8 +129,7 @@ SQL;
                 $inscrit,
                 array(
                     'bcc_address' => false // avoid blind copy… spam inside! ;)
-                ),
-                true
+                )
             );
             if ($sent) {
                 $listSent[] = "{$inscrit['prenom']} {$inscrit['nom']} : {$inscrit['email']}";

--- a/sources/AppBundle/Association/CompanyMembership/AbstractCompanyReminder.php
+++ b/sources/AppBundle/Association/CompanyMembership/AbstractCompanyReminder.php
@@ -62,11 +62,10 @@ abstract class AbstractCompanyReminder implements MembershipReminderInterface
                 'content' => $this->getText(),
                 'title' => $this->getSubject(),
             ],
-            ['subject' => $this->getSubject()],
-            false,
-            null,
-            null,
-            false
+            [
+                'subject' => $this->getSubject(),
+                'force_bcc' => true,
+            ]
         );
         $log->setMailSent($status);
         $this->subscriptionReminderLogRepository->save($log);

--- a/sources/AppBundle/Association/CompanyMembership/InvitationMail.php
+++ b/sources/AppBundle/Association/CompanyMembership/InvitationMail.php
@@ -62,11 +62,10 @@ class InvitationMail
                 'content' => $text,
                 'title' => sprintf("%s vous invite à profiter de son compte \"Membre AFUP\"", $companyMember->getCompanyName())
             ],
-            ['subject' => sprintf("%s vous invite à profiter de son compte \"Membre AFUP\"", $companyMember->getCompanyName())],
-            false,
-            null,
-            null,
-            false
+            [
+                'subject' => sprintf("%s vous invite à profiter de son compte \"Membre AFUP\"", $companyMember->getCompanyName()),
+                'force_bcc' => true,
+            ]
         );
     }
 }

--- a/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
+++ b/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
@@ -50,17 +50,17 @@ abstract class AbstractUserReminder implements MembershipReminderInterface
             ->setUserType(UserRepository::USER_TYPE_PHYSICAL)
         ;
 
-        $status = $this->mail->send('message-transactionnel-afup-org',
+        $status = $this->mail->send(
+            'message-transactionnel-afup-org',
             ['email' => $user->getEmail()],
             [
                 'content' => $this->getText(),
-                'title' => $this->getSubject()
+                'title' => $this->getSubject(),
             ],
-            ['subject' => $this->getSubject()],
-            false,
-            null,
-            null,
-            false
+            [
+                'subject' => $this->getSubject(),
+                'force_bcc' => true,
+            ]
         );
         $log->setMailSent($status);
         $this->subscriptionReminderLogRepository->save($log);

--- a/sources/AppBundle/Event/Sponsorship/SponsorshipLeadMail.php
+++ b/sources/AppBundle/Event/Sponsorship/SponsorshipLeadMail.php
@@ -65,19 +65,11 @@ class SponsorshipLeadMail
                     'content' => base64_encode(file_get_contents($filepath . $filename)),
                 ]
             ],
-            'subject' => $this->translator->trans('mail.sponsoringfile.title', ['%eventName%' => $lead->getEvent()->getTitle()])
+            'subject' => $this->translator->trans('mail.sponsoringfile.title', ['%eventName%' => $lead->getEvent()->getTitle()]),
+            'force_bcc' => true,
         ];
 
-        if (!$this->mail->send(
-            Mail::TEMPLATE_TRANSAC,
-            $receiver,
-            $data,
-            $parameters,
-            false,
-            null,
-            null,
-            false
-        )) {
+        if (!$this->mail->send(Mail::TEMPLATE_TRANSAC, $receiver, $data, $parameters)) {
             $this->logger->warning(sprintf('Mail not sent for sponsorship lead retrieval: "%s"', $lead->getEmail()));
         }
     }

--- a/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
+++ b/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
@@ -86,11 +86,10 @@ class SponsorTokenMail
                 'content' => $text,
                 'title' => $this->translator->trans($subjectLabel, ['%event%' => $event->getTitle()])
             ],
-            ['subject' => $this->translator->trans($subjectLabel, ['%event%' => $event->getTitle()])],
-            false,
-            null,
-            null,
-            false
+            [
+                'subject' => $this->translator->trans($subjectLabel, ['%event%' => $event->getTitle()]),
+                'force_bcc' => true,
+            ]
         );
     }
 }


### PR DESCRIPTION
Cette PR a pour but d'envoyer les emails transactionnels via PHPMailer afin de remplacer MailChimp 