### PR TITLE
correction des liens joindin sur migration site legacy

### DIFF
--- a/app/config/routing/talks.yml
+++ b/app/config/routing/talks.yml
@@ -9,3 +9,7 @@ talks_list:
 talks_show:
   path: /{id}-{slug}
   defaults: {_controller: AppBundle:Talks:show}
+
+talks_joindin:
+  path: /{id}-{slug}/joindin
+  defaults: {_controller: AppBundle:Talks:joindin}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -118,6 +118,9 @@ services:
     AppBundle\Joindin\JoindinComments:
         arguments: ["@cache.system"]
 
+    AppBundle\Joindin\JoindinTalk:
+        arguments: ["@cache.system"]
+
     TwitterAPIExchange:
         class: TwitterAPIExchange
         arguments: ["%twitter_api_settings%"]

--- a/sources/AppBundle/Controller/TalksController.php
+++ b/sources/AppBundle/Controller/TalksController.php
@@ -49,4 +49,21 @@ class TalksController extends SiteBaseController
             ]
         );
     }
+
+    public function joindinAction($id, $slug)
+    {
+        $talk = $this->get('ting')->get(TalkRepository::class)->get($id);
+
+        if (null === $talk || $talk->getSlug() != $slug || !$talk->isDisplayedOnHistory()) {
+            throw $this->createNotFoundException();
+        }
+
+        $stub = $this->get(\AppBundle\Joindin\JoindinTalk::class)->getStubFromTalk($talk);
+
+        if (null === $stub) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->redirect('https://joind.in/talk/' . $stub);
+    }
 }

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -462,7 +462,7 @@ class Talk implements NotifyPropertyInterface
             return null;
         }
 
-        return 'https://legacy.joind.in/talk/view/' . $this->getJoindinId();
+        return '/talks/' . $this->getUrlKey() . '/joindin';
     }
 
     /**

--- a/sources/AppBundle/Joindin/JoindinTalk.php
+++ b/sources/AppBundle/Joindin/JoindinTalk.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace AppBundle\Joindin;
+
+use AppBundle\Event\Model\Talk;
+use Psr\Cache\CacheItemPoolInterface;
+
+class JoindinTalk
+{
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param CacheItemPoolInterface $cache
+     */
+    public function __construct(CacheItemPoolInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+
+    public function getStubFromTalk(Talk $talk)
+    {
+        if (!$talk->hasJoindinId()) {
+            return null;
+        }
+
+        try {
+            return $this->prepareStubFromJoindinResponse($this->callJoindInApi($talk->getJoindinId()));
+        } catch (\RuntimeException $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param int $joindinId
+     *
+     * @return string
+     *
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    private function callJoindInApi($joindinId)
+    {
+        $joindInurl = 'http://api.joind.in/v2.1/talks/' . $joindinId . '';
+        $cacheItem = $this->cache->getItem(urlencode($joindInurl));
+        if (!$cacheItem->isHit()) {
+            $cacheItem->set(file_get_contents($joindInurl));
+            $this->cache->save($cacheItem);
+        }
+
+        return $cacheItem->get();
+    }
+
+    /**
+     * @param string $response
+     *
+     * @return string|null
+     *
+     * @throws \Exception
+     */
+    private function prepareStubFromJoindinResponse($response)
+    {
+        $decodedResponse = $this->readResponse($response);
+
+        if (!isset($decodedResponse['talks'][0]['stub'])) {
+            return null;
+        }
+
+        return $decodedResponse['talks'][0]['stub'];
+    }
+
+    /**
+     * @param string $response
+     *
+     * @return array
+     */
+    private function readResponse($response)
+    {
+        $decodedResponse = json_decode($response, true);
+        if (!is_array($decodedResponse) || !isset($decodedResponse['talks'])) {
+            throw new \RuntimeException('Error reading joindin response');
+        }
+
+        return $decodedResponse;
+    }
+}

--- a/tests/units/AppBundle/Indexation/Talks/Transformer.php
+++ b/tests/units/AppBundle/Indexation/Talks/Transformer.php
@@ -102,7 +102,7 @@ class Transformer extends \atoum
                         'has_slides' => true,
                         'slides_url' => 'http://tapoueh.org/images/confs/PHPTour_2014_PostgreSQL.pdf',
                         'has_joindin' => true,
-                        'joindin_url' => 'https://legacy.joind.in/talk/view/11214',
+                        'joindin_url' => '/talks/1007-utiliser-postgresql-en-2014/joindin',
                         'has_blog_post' => true,
                         'blog_post_url' => 'http://tapoueh.org/confs/2014/06/23-PHPTour-Lyon-2014',
                         'language' => [


### PR DESCRIPTION
Les liens de legacy.joind.in renvoient maintenant vers la home de joind.in

Vu qu'on a en base les id et non pas les slug, on passe par un controlleur pour récupérer le slug et faire la redirection.

fixes #792 