### PR TITLE
correction de l'invitation de l'adhésion membre

### DIFF
--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -135,7 +135,7 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
     /**
      * @var int
      */
-    private $slackInviteStatus;
+    private $slackInviteStatus = self::SLACK_INVITE_STATUS_NONE;
 
     /**
      * @return int


### PR DESCRIPTION
suite à l'ajout de l'invitation slack on avait une erreur 500
à la soumission du formulaire de création de membre physique lié
à la personne morale.