### PR TITLE
correction retour de l'hydrator si la requête ne renvoie aucun résultat

### DIFF
--- a/sources/AppBundle/Event/Model/HydratorAggregator.php
+++ b/sources/AppBundle/Event/Model/HydratorAggregator.php
@@ -124,7 +124,7 @@ class HydratorAggregator extends Hydrator
             }
         }
 
-        if ($previousId === $currentId) {
+        if ($previousId === $currentId && $previousId !== null) {
             yield $key => $this->finalizeAggregate($result, $aggregate);
         }
     }


### PR DESCRIPTION
si la requête ne renvoyait aucun résultat on yieldait tout de même
des tableaux vides/incomplets ce qui pouvait causer des erreurs 500.