### PR TITLE
correction de la gestion du Forum précédent sur la page des stats

### DIFF
--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -75,13 +75,13 @@ class Forum
         return $this->_bdd->obtenirUn($requete);
     }
 
-    function obtenirPrecedent($id_forum)
+    function obtenirForumPrecedent($id_forum)
     {
         $requete = 'SELECT MAX(id)';
         $requete .= 'FROM';
         $requete .= '  afup_forum ';
         $requete .= 'WHERE';
-        $requete .= '  id <  ' . (int)$id_forum;
+        $requete .= '  id <  ' . (int)$id_forum . ' AND titre like "%Forum%"';
         return $this->_bdd->obtenirUn($requete);
     }
 

--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -151,8 +151,7 @@ SQL;
     function obtenirSuivi($id_forum)
     {
         $forum = new Forum($this->_bdd);
-        $id_forum_precedent = $forum->obtenirPrecedent($id_forum);
-        $id_forum_precedent = $forum->obtenirPrecedent($id_forum_precedent);
+        $id_forum_precedent = $forum->obtenirForumPrecedent($id_forum);
 
         $now = new \DateTime();
         $dateForum = \DateTime::createFromFormat('U', $forum->obtenir($id_forum)['date_fin_vente']);


### PR DESCRIPTION
Avant avec le PHP Tour on appellait deux fois le la méthode
récupérant l'event précédent.

Maintenant avec l'AFUP Day on a plusieurs events à nombre variable.
On utilise donc le nom de l'événement pour trouver le précédent
et ainsi comparer le Forum à un Forum et non plus comparer le Forum
à un AFUP Day.

fixes #809