### PR TITLE
on permet de clic sur l'item du menu courant

### DIFF
--- a/htdocs/templates/site/scss/components/subheader.scss
+++ b/htdocs/templates/site/scss/components/subheader.scss
@@ -19,6 +19,15 @@
       &:hover {
         background: rgba(255, 255, 255, .2);
       }
+
+      &.subheader-current,
+      &.subheader-current:hover {
+        background-color: #fff;
+
+        a {
+          color: #50a0dd;
+        }
+      }
     }
 
     a {
@@ -29,15 +38,6 @@
       line-height: 1.25;
       color: #fff;
       text-decoration: none;
-    }
-  }
-
-  .subheader-current {
-    background-color: #fff;
-    pointer-events: none;
-
-    a {
-      color: #50a0dd;
     }
   }
 }


### PR DESCRIPTION
Parfois c'est utile de pouvoir cliquer sur l'item du menu courant.
Par exemple quand on est sur la page de détail d'un talk.

On ne pouvait pas le faire, c'est maintenant le cas.

![Screenshot_2019-07-21 AFUP - PHP Pragmatic Development](https://user-images.githubusercontent.com/320372/61594370-86476180-abeb-11e9-9107-51360c8c2a48.png)
