### PR TITLE
On évite une erreur à la modification d'un user si les rôles sont vides

### DIFF
--- a/htdocs/pages/administration/personnes_physiques.php
+++ b/htdocs/pages/administration/personnes_physiques.php
@@ -101,6 +101,11 @@ if ($action == 'lister') {
         }
     } else {
         $champs = $personnes_physiques->obtenir($_GET['id']);
+
+        if (0 === strlen($champs['roles'])) {
+            $champs['roles'] = json_encode(array());
+        }
+
         unset($champs['mot_de_passe']);
 
         $formulaire->setDefaults($champs);


### PR DESCRIPTION
Si les rôles sont vides on évite une erreur à la soumission du formulaire
car le json est invalide en mettant une valeur par défaut.

fixes #845