### PR TITLE
[PHP7] Mise à jour des librairies legacy non portée

### DIFF
--- a/dependencies/magpierss/extlib/Snoopy.class.inc
+++ b/dependencies/magpierss/extlib/Snoopy.class.inc
@@ -1,12 +1,11 @@
 <?php
 
 /*************************************************
-
-Snoopy - the PHP net client
-Author: Monte Ohrt <monte@ispi.net>
-Copyright (c): 1999-2000 ispi, all rights reserved
-Version: 1.0
-
+ *
+ * Snoopy - the PHP net client
+ * Author: Monte Ohrt <monte@ispi.net>
+ * Copyright (c): 1999-2000 ispi, all rights reserved
+ * Version: 1.0
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
@@ -20,881 +19,885 @@ Version: 1.0
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-
-You may contact the author of Snoopy by e-mail at:
-monte@ispi.net
-
-Or, write to:
-Monte Ohrt
-CTO, ispi
-237 S. 70th suite 220
-Lincoln, NE 68510
-
-The latest version of Snoopy can be obtained from:
-http://snoopy.sourceforge.com
-
-*************************************************/
+ *
+ * You may contact the author of Snoopy by e-mail at:
+ * monte@ispi.net
+ *
+ * Or, write to:
+ * Monte Ohrt
+ * CTO, ispi
+ * 237 S. 70th suite 220
+ * Lincoln, NE 68510
+ *
+ * The latest version of Snoopy can be obtained from:
+ * http://snoopy.sourceforge.com
+ *************************************************/
 
 class Snoopy
 {
-	/**** Public variables ****/
-	
-	/* user definable vars */
+    /**** Public variables ****/
 
-	var $host			=	"www.php.net";		// host name we are connecting to
-	var $port			=	80;					// port we are connecting to
-	var $proxy_host		=	"";					// proxy host to use
-	var $proxy_port		=	"";					// proxy port to use
-	var $agent			=	"Snoopy v1.0";		// agent we masquerade as
-	var	$referer		=	"";					// referer info to pass
-	var $cookies		=	array();			// array of cookies to pass
-												// $cookies["username"]="joe";
-	var	$rawheaders		=	array();			// array of raw headers to send
-												// $rawheaders["Content-type"]="text/html";
+    /* user definable vars */
 
-	var $maxredirs		=	5;					// http redirection depth maximum. 0 = disallow
-	var $lastredirectaddr	=	"";				// contains address of last redirected address
-	var	$offsiteok		=	true;				// allows redirection off-site
-	var $maxframes		=	0;					// frame content depth maximum. 0 = disallow
-	var $expandlinks	=	true;				// expand links to fully qualified URLs.
-												// this only applies to fetchlinks()
-												// or submitlinks()
-	var $passcookies	=	true;				// pass set cookies back through redirects
-												// NOTE: this currently does not respect
-												// dates, domains or paths.
-	
-	var	$user			=	"";					// user for http authentication
-	var	$pass			=	"";					// password for http authentication
-	
-	// http accept types
-	var $accept			=	"image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, */*";
-	
-	var $results		=	"";					// where the content is put
-		
-	var $error			=	"";					// error messages sent here
-	var	$response_code	=	"";					// response code returned from server
-	var	$headers		=	array();			// headers returned from server sent here
-	var	$maxlength		=	500000;				// max return data length (body)
-	var $read_timeout	=	0;					// timeout on read operations, in seconds
-												// supported only since PHP 4 Beta 4
-												// set to 0 to disallow timeouts
-	var $timed_out		=	false;				// if a read operation timed out
-	var	$status			=	0;					// http request status
-	
-	var	$curl_path		=	"/usr/bin/curl";
-												// Snoopy will use cURL for fetching
-												// SSL content if a full system path to
-												// the cURL binary is supplied here.
-												// set to false if you do not have
-												// cURL installed. See http://curl.haxx.se
-												// for details on installing cURL.
-												// Snoopy does *not* use the cURL
-												// library functions built into php,
-												// as these functions are not stable
-												// as of this Snoopy release.
-	
-	// send Accept-encoding: gzip?
-	var $use_gzip		= true;	
-	
-	/**** Private variables ****/	
-	
-	var	$_maxlinelen	=	4096;				// max line length (headers)
-	
-	var $_httpmethod	=	"GET";				// default http request method
-	var $_httpversion	=	"HTTP/1.0";			// default http request version
-	var $_submit_method	=	"POST";				// default submit method
-	var $_submit_type	=	"application/x-www-form-urlencoded";	// default submit type
-	var $_mime_boundary	=   "";					// MIME boundary for multipart/form-data submit type
-	var $_redirectaddr	=	false;				// will be set if page fetched is a redirect
-	var $_redirectdepth	=	0;					// increments on an http redirect
-	var $_frameurls		= 	array();			// frame src urls
-	var $_framedepth	=	0;					// increments on frame depth
-	
-	var $_isproxy		=	false;				// set if using a proxy server
-	var $_fp_timeout	=	30;					// timeout for socket connection
+    var $host = "www.php.net";        // host name we are connecting to
+    var $port = 80;                    // port we are connecting to
+    var $proxy_host = "";                    // proxy host to use
+    var $proxy_port = "";                    // proxy port to use
+    var $agent = "Snoopy v1.0";        // agent we masquerade as
+    var $referer = "";                    // referer info to pass
+    var $cookies = array();            // array of cookies to pass
+    // $cookies["username"]="joe";
+    var $rawheaders = array();            // array of raw headers to send
+    // $rawheaders["Content-type"]="text/html";
 
-/*======================================================================*\
-	Function:	fetch
-	Purpose:	fetch the contents of a web page
-				(and possibly other protocols in the
-				future like ftp, nntp, gopher, etc.)
-	Input:		$URI	the location of the page to fetch
-	Output:		$this->results	the output text from the fetch
-\*======================================================================*/
+    var $maxredirs = 5;                    // http redirection depth maximum. 0 = disallow
+    var $lastredirectaddr = "";                // contains address of last redirected address
+    var $offsiteok = true;                // allows redirection off-site
+    var $maxframes = 0;                    // frame content depth maximum. 0 = disallow
+    var $expandlinks = true;                // expand links to fully qualified URLs.
+    // this only applies to fetchlinks()
+    // or submitlinks()
+    var $passcookies = true;                // pass set cookies back through redirects
+    // NOTE: this currently does not respect
+    // dates, domains or paths.
 
-	function fetch($URI)
-	{
-	
-		//preg_match("|^([^:]+)://([^:/]+)(:[\d]+)*(.*)|",$URI,$URI_PARTS);
-		$URI_PARTS = parse_url($URI);
-		if (!empty($URI_PARTS["user"]))
-			$this->user = $URI_PARTS["user"];
-		if (!empty($URI_PARTS["pass"]))
-			$this->pass = $URI_PARTS["pass"];
-				
-		switch($URI_PARTS["scheme"])
-		{
-			case "http":
-				$this->host = $URI_PARTS["host"];
-				if(!empty($URI_PARTS["port"]))
-					$this->port = $URI_PARTS["port"];
-				if($this->_connect($fp))
-				{
-					if($this->_isproxy)
-					{
-						// using proxy, send entire URI
-						$this->_httprequest($URI,$fp,$URI,$this->_httpmethod);
-					}
-					else
-					{
-						$path = $URI_PARTS["path"].(isset($URI_PARTS["query"]) ? "?".$URI_PARTS["query"] : "");
-						// no proxy, send only the path
-						$this->_httprequest($path, $fp, $URI, $this->_httpmethod);
-					}
-					
-					$this->_disconnect($fp);
+    var $user = "";                    // user for http authentication
+    var $pass = "";                    // password for http authentication
 
-					if($this->_redirectaddr)
-					{
-						/* url was redirected, check if we've hit the max depth */
-						if($this->maxredirs > $this->_redirectdepth)
-						{
-							// only follow redirect if it's on this site, or offsiteok is true
-							if(preg_match("|^http://".preg_quote($this->host)."|i",$this->_redirectaddr) || $this->offsiteok)
-							{
-								/* follow the redirect */
-								$this->_redirectdepth++;
-								$this->lastredirectaddr=$this->_redirectaddr;
-								$this->fetch($this->_redirectaddr);
-							}
-						}
-					}
+    // http accept types
+    var $accept = "image/gif, image/x-xbitmap, image/jpeg, image/pjpeg, */*";
 
-					if($this->_framedepth < $this->maxframes && count($this->_frameurls) > 0)
-					{
-						$frameurls = $this->_frameurls;
-						$this->_frameurls = array();
-						
-						while(list(,$frameurl) = each($frameurls))
-						{
-							if($this->_framedepth < $this->maxframes)
-							{
-								$this->fetch($frameurl);
-								$this->_framedepth++;
-							}
-							else
-								break;
-						}
-					}					
-				}
-				else
-				{
-					return false;
-				}
-				return true;					
-				break;
-			case "https":
-				if(!$this->curl_path || (!is_executable($this->curl_path))) {
-					$this->error = "Bad curl ($this->curl_path), can't fetch HTTPS \n";
-					return false;
-				}
-				$this->host = $URI_PARTS["host"];
-				if(!empty($URI_PARTS["port"]))
-					$this->port = $URI_PARTS["port"];
-				if($this->_isproxy)
-				{
-					// using proxy, send entire URI
-					$this->_httpsrequest($URI,$URI,$this->_httpmethod);
-				}
-				else
-				{
-					$path = $URI_PARTS["path"].($URI_PARTS["query"] ? "?".$URI_PARTS["query"] : "");
-					// no proxy, send only the path
-					$this->_httpsrequest($path, $URI, $this->_httpmethod);
-				}
+    var $results = "";                    // where the content is put
 
-				if($this->_redirectaddr)
-				{
-					/* url was redirected, check if we've hit the max depth */
-					if($this->maxredirs > $this->_redirectdepth)
-					{
-						// only follow redirect if it's on this site, or offsiteok is true
-						if(preg_match("|^http://".preg_quote($this->host)."|i",$this->_redirectaddr) || $this->offsiteok)
-						{
-							/* follow the redirect */
-							$this->_redirectdepth++;
-							$this->lastredirectaddr=$this->_redirectaddr;
-							$this->fetch($this->_redirectaddr);
-						}
-					}
-				}
+    var $error = "";                    // error messages sent here
+    var $response_code = "";                    // response code returned from server
+    var $headers = array();            // headers returned from server sent here
+    var $maxlength = 500000;                // max return data length (body)
+    var $read_timeout = 0;                    // timeout on read operations, in seconds
+    // supported only since PHP 4 Beta 4
+    // set to 0 to disallow timeouts
+    var $timed_out = false;                // if a read operation timed out
+    var $status = 0;                    // http request status
 
-				if($this->_framedepth < $this->maxframes && count($this->_frameurls) > 0)
-				{
-					$frameurls = $this->_frameurls;
-					$this->_frameurls = array();
+    var $curl_path = "/usr/bin/curl";
+    // Snoopy will use cURL for fetching
+    // SSL content if a full system path to
+    // the cURL binary is supplied here.
+    // set to false if you do not have
+    // cURL installed. See http://curl.haxx.se
+    // for details on installing cURL.
+    // Snoopy does *not* use the cURL
+    // library functions built into php,
+    // as these functions are not stable
+    // as of this Snoopy release.
 
-					while(list(,$frameurl) = each($frameurls))
-					{
-						if($this->_framedepth < $this->maxframes)
-						{
-							$this->fetch($frameurl);
-							$this->_framedepth++;
-						}
-						else
-							break;
-					}
-				}					
-				return true;					
-				break;
-			default:
-				// not a valid protocol
-				$this->error	=	'Invalid protocol "'.$URI_PARTS["scheme"].'"\n';
-				return false;
-				break;
-		}		
-		return true;
-	}
+    // send Accept-encoding: gzip?
+    var $use_gzip = true;
+
+    /**** Private variables ****/
+
+    var $_maxlinelen = 4096;                // max line length (headers)
+
+    var $_httpmethod = "GET";                // default http request method
+    var $_httpversion = "HTTP/1.0";            // default http request version
+    var $_submit_method = "POST";                // default submit method
+    var $_submit_type = "application/x-www-form-urlencoded";    // default submit type
+    var $_mime_boundary = "";                    // MIME boundary for multipart/form-data submit type
+    var $_redirectaddr = false;                // will be set if page fetched is a redirect
+    var $_redirectdepth = 0;                    // increments on an http redirect
+    var $_frameurls = array();            // frame src urls
+    var $_framedepth = 0;                    // increments on frame depth
+
+    var $_isproxy = false;                // set if using a proxy server
+    var $_fp_timeout = 30;                    // timeout for socket connection
+
+    /*======================================================================*\
+        Function:	fetch
+        Purpose:	fetch the contents of a web page
+                    (and possibly other protocols in the
+                    future like ftp, nntp, gopher, etc.)
+        Input:		$URI	the location of the page to fetch
+        Output:		$this->results	the output text from the fetch
+    \*======================================================================*/
+
+    function fetch($URI)
+    {
+
+        //preg_match("|^([^:]+)://([^:/]+)(:[\d]+)*(.*)|",$URI,$URI_PARTS);
+        $URI_PARTS = parse_url($URI);
+        if (!empty($URI_PARTS["user"])) {
+            $this->user = $URI_PARTS["user"];
+        }
+        if (!empty($URI_PARTS["pass"])) {
+            $this->pass = $URI_PARTS["pass"];
+        }
+
+        switch ($URI_PARTS["scheme"]) {
+            case "http":
+                $this->host = $URI_PARTS["host"];
+                if (!empty($URI_PARTS["port"])) {
+                    $this->port = $URI_PARTS["port"];
+                }
+                if ($this->_connect($fp)) {
+                    if ($this->_isproxy) {
+                        // using proxy, send entire URI
+                        $this->_httprequest($URI, $fp, $URI, $this->_httpmethod);
+                    } else {
+                        $path = $URI_PARTS["path"] . (isset($URI_PARTS["query"]) ? "?" . $URI_PARTS["query"] : "");
+                        // no proxy, send only the path
+                        $this->_httprequest($path, $fp, $URI, $this->_httpmethod);
+                    }
+
+                    $this->_disconnect($fp);
+
+                    if ($this->_redirectaddr) {
+                        /* url was redirected, check if we've hit the max depth */
+                        if ($this->maxredirs > $this->_redirectdepth) {
+                            // only follow redirect if it's on this site, or offsiteok is true
+                            if (preg_match("|^http://" . preg_quote($this->host) . "|i",
+                                    $this->_redirectaddr) || $this->offsiteok) {
+                                /* follow the redirect */
+                                $this->_redirectdepth++;
+                                $this->lastredirectaddr = $this->_redirectaddr;
+                                $this->fetch($this->_redirectaddr);
+                            }
+                        }
+                    }
+
+                    if ($this->_framedepth < $this->maxframes && count($this->_frameurls) > 0) {
+                        $frameurls = $this->_frameurls;
+                        $this->_frameurls = array();
+
+                        foreach ($frameurls as $frameurl) {
+                            if ($this->_framedepth < $this->maxframes) {
+                                $this->fetch($frameurl);
+                                $this->_framedepth++;
+                            } else {
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    return false;
+                }
+                return true;
+                break;
+            case "https":
+                if (!$this->curl_path || (!is_executable($this->curl_path))) {
+                    $this->error = "Bad curl ($this->curl_path), can't fetch HTTPS \n";
+                    return false;
+                }
+                $this->host = $URI_PARTS["host"];
+                if (!empty($URI_PARTS["port"])) {
+                    $this->port = $URI_PARTS["port"];
+                }
+                if ($this->_isproxy) {
+                    // using proxy, send entire URI
+                    $this->_httpsrequest($URI, $URI, $this->_httpmethod);
+                } else {
+                    $path = $URI_PARTS["path"] . ($URI_PARTS["query"] ? "?" . $URI_PARTS["query"] : "");
+                    // no proxy, send only the path
+                    $this->_httpsrequest($path, $URI, $this->_httpmethod);
+                }
+
+                if ($this->_redirectaddr) {
+                    /* url was redirected, check if we've hit the max depth */
+                    if ($this->maxredirs > $this->_redirectdepth) {
+                        // only follow redirect if it's on this site, or offsiteok is true
+                        if (preg_match("|^http://" . preg_quote($this->host) . "|i",
+                                $this->_redirectaddr) || $this->offsiteok) {
+                            /* follow the redirect */
+                            $this->_redirectdepth++;
+                            $this->lastredirectaddr = $this->_redirectaddr;
+                            $this->fetch($this->_redirectaddr);
+                        }
+                    }
+                }
+
+                if ($this->_framedepth < $this->maxframes && count($this->_frameurls) > 0) {
+                    $frameurls = $this->_frameurls;
+                    $this->_frameurls = array();
+
+                    foreach ($frameurls as $frameurl) {
+                        if ($this->_framedepth < $this->maxframes) {
+                            $this->fetch($frameurl);
+                            $this->_framedepth++;
+                        } else {
+                            break;
+                        }
+                    }
+                }
+                return true;
+                break;
+            default:
+                // not a valid protocol
+                $this->error = 'Invalid protocol "' . $URI_PARTS["scheme"] . '"\n';
+                return false;
+                break;
+        }
+        return true;
+    }
 
 
 
-/*======================================================================*\
-	Private functions
-\*======================================================================*/
-	
-	
-/*======================================================================*\
-	Function:	_striplinks
-	Purpose:	strip the hyperlinks from an html document
-	Input:		$document	document to strip.
-	Output:		$match		an array of the links
-\*======================================================================*/
+    /*======================================================================*\
+        Private functions
+    \*======================================================================*/
 
-	function _striplinks($document)
-	{	
-		preg_match_all("'<\s*a\s+.*href\s*=\s*			# find <a href=
+
+    /*======================================================================*\
+        Function:	_striplinks
+        Purpose:	strip the hyperlinks from an html document
+        Input:		$document	document to strip.
+        Output:		$match		an array of the links
+    \*======================================================================*/
+
+    function _connect(&$fp)
+    {
+        if (!empty($this->proxy_host) && !empty($this->proxy_port)) {
+            $this->_isproxy = true;
+            $host = $this->proxy_host;
+            $port = $this->proxy_port;
+        } else {
+            $host = $this->host;
+            $port = $this->port;
+        }
+
+        $this->status = 0;
+
+        if ($fp = fsockopen(
+            $host,
+            $port,
+            $errno,
+            $errstr,
+            $this->_fp_timeout
+        )) {
+            // socket connection succeeded
+
+            return true;
+        } else {
+            // socket connection failed
+            $this->status = $errno;
+            switch ($errno) {
+                case -3:
+                    $this->error = "socket creation failed (-3)";
+                case -4:
+                    $this->error = "dns lookup failure (-4)";
+                case -5:
+                    $this->error = "connection refused or timed out (-5)";
+                default:
+                    $this->error = "connection failed (" . $errno . ")";
+            }
+            return false;
+        }
+    }
+
+    /*======================================================================*\
+        Function:	_stripform
+        Purpose:	strip the form elements from an html document
+        Input:		$document	document to strip.
+        Output:		$match		an array of the links
+    \*======================================================================*/
+
+    function _httprequest($url, $fp, $URI, $http_method, $content_type = "", $body = "")
+    {
+        if ($this->passcookies && $this->_redirectaddr) {
+            $this->setcookies();
+        }
+
+        $URI_PARTS = parse_url($URI);
+        if (empty($url)) {
+            $url = "/";
+        }
+        $headers = $http_method . " " . $url . " " . $this->_httpversion . "\r\n";
+        if (!empty($this->agent)) {
+            $headers .= "User-Agent: " . $this->agent . "\r\n";
+        }
+        if (!empty($this->host) && !isset($this->rawheaders['Host'])) {
+            $headers .= "Host: " . $this->host . "\r\n";
+        }
+        if (!empty($this->accept)) {
+            $headers .= "Accept: " . $this->accept . "\r\n";
+        }
+
+        if ($this->use_gzip) {
+            // make sure PHP was built with --with-zlib
+            // and we can handle gzipp'ed data
+            if (function_exists(gzinflate)) {
+                $headers .= "Accept-encoding: gzip\r\n";
+            } else {
+                trigger_error(
+                    "use_gzip is on, but PHP was built without zlib support." .
+                    "  Requesting file(s) without gzip encoding.",
+                    E_USER_NOTICE);
+            }
+        }
+
+        if (!empty($this->referer)) {
+            $headers .= "Referer: " . $this->referer . "\r\n";
+        }
+        if (!empty($this->cookies)) {
+            if (!is_array($this->cookies)) {
+                $this->cookies = (array)$this->cookies;
+            }
+
+            reset($this->cookies);
+            if (count($this->cookies) > 0) {
+                $cookie_headers = 'Cookie: ';
+                foreach ($this->cookies as $cookieKey => $cookieVal) {
+                    $cookie_headers .= $cookieKey . "=" . urlencode($cookieVal) . "; ";
+                }
+                $headers .= substr($cookie_headers, 0, -2) . "\r\n";
+            }
+        }
+        if (!empty($this->rawheaders)) {
+            if (!is_array($this->rawheaders)) {
+                $this->rawheaders = (array)$this->rawheaders;
+            }
+            foreach ($this->rawheaders as $headerKey => $headerVal) {
+                $headers .= $headerKey . ": " . $headerVal . "\r\n";
+            }
+        }
+        if (!empty($content_type)) {
+            $headers .= "Content-type: $content_type";
+            if ($content_type == "multipart/form-data") {
+                $headers .= "; boundary=" . $this->_mime_boundary;
+            }
+            $headers .= "\r\n";
+        }
+        if (!empty($body)) {
+            $headers .= "Content-length: " . strlen($body) . "\r\n";
+        }
+        if (!empty($this->user) || !empty($this->pass)) {
+            $headers .= "Authorization: BASIC " . base64_encode($this->user . ":" . $this->pass) . "\r\n";
+        }
+
+        $headers .= "\r\n";
+
+        // set the read timeout if needed
+        if ($this->read_timeout > 0) {
+            socket_set_timeout($fp, $this->read_timeout);
+        }
+        $this->timed_out = false;
+
+        fwrite($fp, $headers . $body, strlen($headers . $body));
+
+        $this->_redirectaddr = false;
+        unset($this->headers);
+
+        // content was returned gzip encoded?
+        $is_gzipped = false;
+
+        while ($currentHeader = fgets($fp, $this->_maxlinelen)) {
+            if ($this->read_timeout > 0 && $this->_check_timeout($fp)) {
+                $this->status = -100;
+                return false;
+            }
+
+            //	if($currentHeader == "\r\n")
+            if (preg_match("/^\r?\n$/", $currentHeader)) {
+                break;
+            }
+
+            // if a header begins with Location: or URI:, set the redirect
+            if (preg_match("/^(Location:|URI:)/i", $currentHeader)) {
+                // get URL portion of the redirect
+                preg_match("/^(Location:|URI:)\s+(.*)/", chop($currentHeader), $matches);
+                // look for :// in the Location header to see if hostname is included
+                if (!preg_match("|\:\/\/|", $matches[2])) {
+                    // no host in the path, so prepend
+                    $this->_redirectaddr = $URI_PARTS["scheme"] . "://" . $this->host . ":" . $this->port;
+                    // eliminate double slash
+                    if (!preg_match("|^/|", $matches[2])) {
+                        $this->_redirectaddr .= "/" . $matches[2];
+                    } else {
+                        $this->_redirectaddr .= $matches[2];
+                    }
+                } else {
+                    $this->_redirectaddr = $matches[2];
+                }
+            }
+
+            if (preg_match("|^HTTP/|", $currentHeader)) {
+                if (preg_match("|^HTTP/[^\s]*\s(.*?)\s|", $currentHeader, $status)) {
+                    $this->status = $status[1];
+                }
+                $this->response_code = $currentHeader;
+            }
+
+            if (preg_match("/Content-Encoding: gzip/", $currentHeader)) {
+                $is_gzipped = true;
+            }
+
+            $this->headers[] = $currentHeader;
+        }
+
+        # $results = fread($fp, $this->maxlength);
+        $results = "";
+        while ($data = fread($fp, $this->maxlength)) {
+            $results .= $data;
+            if (
+                strlen($results) > $this->maxlength) {
+                break;
+            }
+        }
+
+        // gunzip
+        if ($is_gzipped) {
+            // per http://www.php.net/manual/en/function.gzencode.php
+            $results = substr($results, 10);
+            $results = gzinflate($results);
+        }
+
+        if ($this->read_timeout > 0 && $this->_check_timeout($fp)) {
+            $this->status = -100;
+            return false;
+        }
+
+        // check if there is a a redirect meta tag
+
+        if (preg_match("'<meta[\s]*http-equiv[^>]*?content[\s]*=[\s]*[\"\']?\d+;[\s]+URL[\s]*=[\s]*([^\"\']*?)[\"\']?>'i",
+            $results, $match)) {
+            $this->_redirectaddr = $this->_expandlinks($match[1], $URI);
+        }
+
+        // have we hit our frame depth and is there frame src to fetch?
+        if (($this->_framedepth < $this->maxframes) && preg_match_all("'<frame\s+.*src[\s]*=[\'\"]?([^\'\"\>]+)'i",
+                $results, $match)) {
+            $this->results[] = $results;
+            for ($x = 0; $x < count($match[1]); $x++) {
+                $this->_frameurls[] = $this->_expandlinks($match[1][$x], $URI_PARTS["scheme"] . "://" . $this->host);
+            }
+        } // have we already fetched framed content?
+        elseif (is_array($this->results)) {
+            $this->results[] = $results;
+        } // no framed content
+        else {
+            $this->results = $results;
+        }
+
+        return true;
+    }
+
+
+    /*======================================================================*\
+        Function:	_striptext
+        Purpose:	strip the text from an html document
+        Input:		$document	document to strip.
+        Output:		$text		the resulting text
+    \*======================================================================*/
+
+    function setcookies()
+    {
+        for ($x = 0; $x < count($this->headers); $x++) {
+            if (preg_match("/^set-cookie:[\s]+([^=]+)=([^;]+)/i", $this->headers[$x], $match)) {
+                $this->cookies[$match[1]] = $match[2];
+            }
+        }
+    }
+
+    /*======================================================================*\
+        Function:	_expandlinks
+        Purpose:	expand each link into a fully qualified URL
+        Input:		$links			the links to qualify
+                    $URI			the full URI to get the base from
+        Output:		$expandedLinks	the expanded links
+    \*======================================================================*/
+
+    function _check_timeout($fp)
+    {
+        if ($this->read_timeout > 0) {
+            $fp_status = socket_get_status($fp);
+            if ($fp_status["timed_out"]) {
+                $this->timed_out = true;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*======================================================================*\
+        Function:	_httprequest
+        Purpose:	go get the http data from the server
+        Input:		$url		the url to fetch
+                    $fp			the current open file pointer
+                    $URI		the full URI
+                    $body		body contents to send if any (POST)
+        Output:
+    \*======================================================================*/
+
+    function _expandlinks($links, $URI)
+    {
+
+        preg_match("/^[^\?]+/", $URI, $match);
+
+        $match = preg_replace("|/[^\/\.]+\.[^\/\.]+$|", "", $match[0]);
+
+        $search = array(
+            "|^http://" . preg_quote($this->host) . "|i",
+            "|^(?!http://)(\/)?(?!mailto:)|i",
+            "|/\./|",
+            "|/[^\/]+/\.\./|"
+        );
+
+        $replace = array(
+            "",
+            $match . "/",
+            "/",
+            "/"
+        );
+
+        $expandedLinks = preg_replace($search, $replace, $links);
+
+        return $expandedLinks;
+    }
+
+    /*======================================================================*\
+        Function:	_httpsrequest
+        Purpose:	go get the https data from the server using curl
+        Input:		$url		the url to fetch
+                    $URI		the full URI
+                    $body		body contents to send if any (POST)
+        Output:
+    \*======================================================================*/
+
+    function _disconnect($fp)
+    {
+        return (fclose($fp));
+    }
+
+    /*======================================================================*\
+        Function:	setcookies()
+        Purpose:	set cookies for a redirection
+    \*======================================================================*/
+
+    function _httpsrequest($url, $URI, $http_method, $content_type = "", $body = "")
+    {
+        if ($this->passcookies && $this->_redirectaddr) {
+            $this->setcookies();
+        }
+
+        $headers = array();
+
+        $URI_PARTS = parse_url($URI);
+        if (empty($url)) {
+            $url = "/";
+        }
+        // GET ... header not needed for curl
+        //$headers[] = $http_method." ".$url." ".$this->_httpversion;
+        if (!empty($this->agent)) {
+            $headers[] = "User-Agent: " . $this->agent;
+        }
+        if (!empty($this->host)) {
+            $headers[] = "Host: " . $this->host;
+        }
+        if (!empty($this->accept)) {
+            $headers[] = "Accept: " . $this->accept;
+        }
+        if (!empty($this->referer)) {
+            $headers[] = "Referer: " . $this->referer;
+        }
+        if (!empty($this->cookies)) {
+            if (!is_array($this->cookies)) {
+                $this->cookies = (array)$this->cookies;
+            }
+
+            reset($this->cookies);
+            if (count($this->cookies) > 0) {
+                $cookie_str = 'Cookie: ';
+                foreach ($this->cookies as $cookieKey => $cookieVal) {
+                    $cookie_str .= $cookieKey . "=" . urlencode($cookieVal) . "; ";
+                }
+                $headers[] = substr($cookie_str, 0, -2);
+            }
+        }
+        if (!empty($this->rawheaders)) {
+            if (!is_array($this->rawheaders)) {
+                $this->rawheaders = (array)$this->rawheaders;
+            }
+            foreach ($this->rawheaders as $headerKey => $headerVal) {
+                $headers[] = $headerKey . ": " . $headerVal;
+            }
+        }
+        if (!empty($content_type)) {
+            if ($content_type == "multipart/form-data") {
+                $headers[] = "Content-type: $content_type; boundary=" . $this->_mime_boundary;
+            } else {
+                $headers[] = "Content-type: $content_type";
+            }
+        }
+        if (!empty($body)) {
+            $headers[] = "Content-length: " . strlen($body);
+        }
+        if (!empty($this->user) || !empty($this->pass)) {
+            $headers[] = "Authorization: BASIC " . base64_encode($this->user . ":" . $this->pass);
+        }
+
+        for ($curr_header = 0; $curr_header < count($headers); $curr_header++) {
+            $cmdline_params .= " -H \"" . $headers[$curr_header] . "\"";
+        }
+
+        if (!empty($body)) {
+            $cmdline_params .= " -d \"$body\"";
+        }
+
+        if ($this->read_timeout > 0) {
+            $cmdline_params .= " -m " . $this->read_timeout;
+        }
+
+        $headerfile = uniqid(time());
+
+        # accept self-signed certs
+        $cmdline_params .= " -k";
+        exec($this->curl_path . " -D \"/tmp/$headerfile\"" . escapeshellcmd($cmdline_params) . " " . escapeshellcmd($URI),
+            $results, $return);
+
+        if ($return) {
+            $this->error = "Error: cURL could not retrieve the document, error $return.";
+            return false;
+        }
+
+
+        $results = implode("\r\n", $results);
+
+        $result_headers = file("/tmp/$headerfile");
+
+        $this->_redirectaddr = false;
+        unset($this->headers);
+
+        for ($currentHeader = 0; $currentHeader < count($result_headers); $currentHeader++) {
+
+            // if a header begins with Location: or URI:, set the redirect
+            if (preg_match("/^(Location: |URI: )/i", $result_headers[$currentHeader])) {
+                // get URL portion of the redirect
+                preg_match("/^(Location: |URI:)(.*)/", chop($result_headers[$currentHeader]), $matches);
+                // look for :// in the Location header to see if hostname is included
+                if (!preg_match("|\:\/\/|", $matches[2])) {
+                    // no host in the path, so prepend
+                    $this->_redirectaddr = $URI_PARTS["scheme"] . "://" . $this->host . ":" . $this->port;
+                    // eliminate double slash
+                    if (!preg_match("|^/|", $matches[2])) {
+                        $this->_redirectaddr .= "/" . $matches[2];
+                    } else {
+                        $this->_redirectaddr .= $matches[2];
+                    }
+                } else {
+                    $this->_redirectaddr = $matches[2];
+                }
+            }
+
+            if (preg_match("|^HTTP/|", $result_headers[$currentHeader])) {
+                $this->response_code = $result_headers[$currentHeader];
+                if (preg_match("|^HTTP/[^\s]*\s(.*?)\s|", $this->response_code, $match)) {
+                    $this->status = $match[1];
+                }
+            }
+            $this->headers[] = $result_headers[$currentHeader];
+        }
+
+        // check if there is a a redirect meta tag
+
+        if (preg_match("'<meta[\s]*http-equiv[^>]*?content[\s]*=[\s]*[\"\']?\d+;[\s]+URL[\s]*=[\s]*([^\"\']*?)[\"\']?>'i",
+            $results, $match)) {
+            $this->_redirectaddr = $this->_expandlinks($match[1], $URI);
+        }
+
+        // have we hit our frame depth and is there frame src to fetch?
+        if (($this->_framedepth < $this->maxframes) && preg_match_all("'<frame\s+.*src[\s]*=[\'\"]?([^\'\"\>]+)'i",
+                $results, $match)) {
+            $this->results[] = $results;
+            for ($x = 0; $x < count($match[1]); $x++) {
+                $this->_frameurls[] = $this->_expandlinks($match[1][$x], $URI_PARTS["scheme"] . "://" . $this->host);
+            }
+        } // have we already fetched framed content?
+        elseif (is_array($this->results)) {
+            $this->results[] = $results;
+        } // no framed content
+        else {
+            $this->results = $results;
+        }
+
+        unlink("/tmp/$headerfile");
+
+        return true;
+    }
+
+
+    /*======================================================================*\
+        Function:	_check_timeout
+        Purpose:	checks whether timeout has occurred
+        Input:		$fp	file pointer
+    \*======================================================================*/
+
+    function _striplinks($document)
+    {
+        preg_match_all("'<\s*a\s+.*href\s*=\s*			# find <a href=
 						([\"\'])?					# find single or double quote
 						(?(1) (.*?)\\1 | ([^\s\>]+))		# if quote found, match up to next matching
 													# quote, otherwise match up to next space
-						'isx",$document,$links);
-						
+						'isx", $document, $links);
 
-		// catenate the non-empty matches from the conditional subpattern
 
-		while(list($key,$val) = each($links[2]))
-		{
-			if(!empty($val))
-				$match[] = $val;
-		}				
-		
-		while(list($key,$val) = each($links[3]))
-		{
-			if(!empty($val))
-				$match[] = $val;
-		}		
-		
-		// return the links
-		return $match;
-	}
+        // catenate the non-empty matches from the conditional subpattern
 
-/*======================================================================*\
-	Function:	_stripform
-	Purpose:	strip the form elements from an html document
-	Input:		$document	document to strip.
-	Output:		$match		an array of the links
-\*======================================================================*/
+        $match = [];
+        foreach ($links[2] as $val) {
+            if (!empty($val)) {
+                $match[] = $val;
+            }
+        }
 
-	function _stripform($document)
-	{	
-		preg_match_all("'<\/?(FORM|INPUT|SELECT|TEXTAREA|(OPTION))[^<>]*>(?(2)(.*(?=<\/?(option|select)[^<>]*>[\r\n]*)|(?=[\r\n]*))|(?=[\r\n]*))'Usi",$document,$elements);
-		
-		// catenate the matches
-		$match = implode("\r\n",$elements[0]);
-				
-		// return the links
-		return $match;
-	}
 
-	
-	
-/*======================================================================*\
-	Function:	_striptext
-	Purpose:	strip the text from an html document
-	Input:		$document	document to strip.
-	Output:		$text		the resulting text
-\*======================================================================*/
+        foreach ($links[3] as $val) {
+            if (!empty($val)) {
+                $match[] = $val;
+            }
+        }
 
-	function _striptext($document)
-	{
-		
-		// I didn't use preg eval (//e) since that is only available in PHP 4.0.
-		// so, list your entities one by one here. I included some of the
-		// more common ones.
-								
-		$search = array("'<script[^>]*?>.*?</script>'si",	// strip out javascript
-						"'<[\/\!]*?[^<>]*?>'si",			// strip out html tags
-						"'([\r\n])[\s]+'",					// strip out white space
-						"'&(quote|#34);'i",					// replace html entities
-						"'&(amp|#38);'i",
-						"'&(lt|#60);'i",
-						"'&(gt|#62);'i",
-						"'&(nbsp|#160);'i",
-						"'&(iexcl|#161);'i",
-						"'&(cent|#162);'i",
-						"'&(pound|#163);'i",
-						"'&(copy|#169);'i"
-						);				
-		$replace = array(	"",
-							"",
-							"\\1",
-							"\"",
-							"&",
-							"<",
-							">",
-							" ",
-							chr(161),
-							chr(162),
-							chr(163),
-							chr(169));
-					
-		$text = preg_replace($search,$replace,$document);
-								
-		return $text;
-	}
+        // return the links
+        return $match;
+    }
 
-/*======================================================================*\
-	Function:	_expandlinks
-	Purpose:	expand each link into a fully qualified URL
-	Input:		$links			the links to qualify
-				$URI			the full URI to get the base from
-	Output:		$expandedLinks	the expanded links
-\*======================================================================*/
+    /*======================================================================*\
+        Function:	_connect
+        Purpose:	make a socket connection
+        Input:		$fp	file pointer
+    \*======================================================================*/
 
-	function _expandlinks($links,$URI)
-	{
-		
-		preg_match("/^[^\?]+/",$URI,$match);
+    function _stripform($document)
+    {
+        preg_match_all("'<\/?(FORM|INPUT|SELECT|TEXTAREA|(OPTION))[^<>]*>(?(2)(.*(?=<\/?(option|select)[^<>]*>[\r\n]*)|(?=[\r\n]*))|(?=[\r\n]*))'Usi",
+            $document, $elements);
 
-		$match = preg_replace("|/[^\/\.]+\.[^\/\.]+$|","",$match[0]);
-				
-		$search = array( 	"|^http://".preg_quote($this->host)."|i",
-							"|^(?!http://)(\/)?(?!mailto:)|i",
-							"|/\./|",
-							"|/[^\/]+/\.\./|"
-						);
-						
-		$replace = array(	"",
-							$match."/",
-							"/",
-							"/"
-						);			
-				
-		$expandedLinks = preg_replace($search,$replace,$links);
+        // catenate the matches
+        $match = implode("\r\n", $elements[0]);
 
-		return $expandedLinks;
-	}
+        // return the links
+        return $match;
+    }
 
-/*======================================================================*\
-	Function:	_httprequest
-	Purpose:	go get the http data from the server
-	Input:		$url		the url to fetch
-				$fp			the current open file pointer
-				$URI		the full URI
-				$body		body contents to send if any (POST)
-	Output:		
-\*======================================================================*/
-	
-	function _httprequest($url,$fp,$URI,$http_method,$content_type="",$body="")
-	{
-		if($this->passcookies && $this->_redirectaddr)
-			$this->setcookies();
-			
-		$URI_PARTS = parse_url($URI);
-		if(empty($url))
-			$url = "/";
-		$headers = $http_method." ".$url." ".$this->_httpversion."\r\n";		
-		if(!empty($this->agent))
-			$headers .= "User-Agent: ".$this->agent."\r\n";
-		if(!empty($this->host) && !isset($this->rawheaders['Host']))
-			$headers .= "Host: ".$this->host."\r\n";
-		if(!empty($this->accept))
-			$headers .= "Accept: ".$this->accept."\r\n";
-		
-		if($this->use_gzip) {
-			// make sure PHP was built with --with-zlib
-			// and we can handle gzipp'ed data
-			if ( function_exists(gzinflate) ) {
-			   $headers .= "Accept-encoding: gzip\r\n";
-			}
-			else {
-			   trigger_error(
-			   	"use_gzip is on, but PHP was built without zlib support.".
-				"  Requesting file(s) without gzip encoding.", 
-				E_USER_NOTICE);
-			}
-		}
-		
-		if(!empty($this->referer))
-			$headers .= "Referer: ".$this->referer."\r\n";
-		if(!empty($this->cookies))
-		{			
-			if(!is_array($this->cookies))
-				$this->cookies = (array)$this->cookies;
-	
-			reset($this->cookies);
-			if ( count($this->cookies) > 0 ) {
-				$cookie_headers .= 'Cookie: ';
-				foreach ( $this->cookies as $cookieKey => $cookieVal ) {
-				$cookie_headers .= $cookieKey."=".urlencode($cookieVal)."; ";
-				}
-				$headers .= substr($cookie_headers,0,-2) . "\r\n";
-			} 
-		}
-		if(!empty($this->rawheaders))
-		{
-			if(!is_array($this->rawheaders))
-				$this->rawheaders = (array)$this->rawheaders;
-			while(list($headerKey,$headerVal) = each($this->rawheaders))
-				$headers .= $headerKey.": ".$headerVal."\r\n";
-		}
-		if(!empty($content_type)) {
-			$headers .= "Content-type: $content_type";
-			if ($content_type == "multipart/form-data")
-				$headers .= "; boundary=".$this->_mime_boundary;
-			$headers .= "\r\n";
-		}
-		if(!empty($body))	
-			$headers .= "Content-length: ".strlen($body)."\r\n";
-		if(!empty($this->user) || !empty($this->pass))	
-			$headers .= "Authorization: BASIC ".base64_encode($this->user.":".$this->pass)."\r\n";
+    /*======================================================================*\
+        Function:	_disconnect
+        Purpose:	disconnect a socket connection
+        Input:		$fp	file pointer
+    \*======================================================================*/
 
-		$headers .= "\r\n";
-		
-		// set the read timeout if needed
-		if ($this->read_timeout > 0)
-			socket_set_timeout($fp, $this->read_timeout);
-		$this->timed_out = false;
-		
-		fwrite($fp,$headers.$body,strlen($headers.$body));
-		
-		$this->_redirectaddr = false;
-		unset($this->headers);
-		
-		// content was returned gzip encoded?
-		$is_gzipped = false;
-						
-		while($currentHeader = fgets($fp,$this->_maxlinelen))
-		{
-			if ($this->read_timeout > 0 && $this->_check_timeout($fp))
-			{
-				$this->status=-100;
-				return false;
-			}
-				
-		//	if($currentHeader == "\r\n")
-			if(preg_match("/^\r?\n$/", $currentHeader) )
-			      break;
-						
-			// if a header begins with Location: or URI:, set the redirect
-			if(preg_match("/^(Location:|URI:)/i",$currentHeader))
-			{
-				// get URL portion of the redirect
-				preg_match("/^(Location:|URI:)\s+(.*)/",chop($currentHeader),$matches);
-				// look for :// in the Location header to see if hostname is included
-				if(!preg_match("|\:\/\/|",$matches[2]))
-				{
-					// no host in the path, so prepend
-					$this->_redirectaddr = $URI_PARTS["scheme"]."://".$this->host.":".$this->port;
-					// eliminate double slash
-					if(!preg_match("|^/|",$matches[2]))
-							$this->_redirectaddr .= "/".$matches[2];
-					else
-							$this->_redirectaddr .= $matches[2];
-				}
-				else
-					$this->_redirectaddr = $matches[2];
-			}
-		
-			if(preg_match("|^HTTP/|",$currentHeader))
-			{
-                if(preg_match("|^HTTP/[^\s]*\s(.*?)\s|",$currentHeader, $status))
-				{
-					$this->status= $status[1];
-                }				
-				$this->response_code = $currentHeader;
-			}
-			
-			if (preg_match("/Content-Encoding: gzip/", $currentHeader) ) {
-				$is_gzipped = true;
-			}
-			
-			$this->headers[] = $currentHeader;
-		}
+    function _striptext($document)
+    {
 
-		# $results = fread($fp, $this->maxlength);
-		$results = "";
-		while ( $data = fread($fp, $this->maxlength) ) {
-		    $results .= $data;
-		    if (
-		        strlen($results) > $this->maxlength ) {
-		        break;
-		    }
-		}
-		
-		// gunzip
-		if ( $is_gzipped ) {
-			// per http://www.php.net/manual/en/function.gzencode.php
-			$results = substr($results, 10);
-			$results = gzinflate($results);
-		}
-		
-		if ($this->read_timeout > 0 && $this->_check_timeout($fp))
-		{
-			$this->status=-100;
-			return false;
-		}
-		
-		// check if there is a a redirect meta tag
-		
-		if(preg_match("'<meta[\s]*http-equiv[^>]*?content[\s]*=[\s]*[\"\']?\d+;[\s]+URL[\s]*=[\s]*([^\"\']*?)[\"\']?>'i",$results,$match))
-		{
-			$this->_redirectaddr = $this->_expandlinks($match[1],$URI);	
-		}
+        // I didn't use preg eval (//e) since that is only available in PHP 4.0.
+        // so, list your entities one by one here. I included some of the
+        // more common ones.
 
-		// have we hit our frame depth and is there frame src to fetch?
-		if(($this->_framedepth < $this->maxframes) && preg_match_all("'<frame\s+.*src[\s]*=[\'\"]?([^\'\"\>]+)'i",$results,$match))
-		{
-			$this->results[] = $results;
-			for($x=0; $x<count($match[1]); $x++)
-				$this->_frameurls[] = $this->_expandlinks($match[1][$x],$URI_PARTS["scheme"]."://".$this->host);
-		}
-		// have we already fetched framed content?
-		elseif(is_array($this->results))
-			$this->results[] = $results;
-		// no framed content
-		else
-			$this->results = $results;
-		
-		return true;
-	}
+        $search = array(
+            "'<script[^>]*?>.*?</script>'si",    // strip out javascript
+            "'<[\/\!]*?[^<>]*?>'si",            // strip out html tags
+            "'([\r\n])[\s]+'",                    // strip out white space
+            "'&(quote|#34);'i",                    // replace html entities
+            "'&(amp|#38);'i",
+            "'&(lt|#60);'i",
+            "'&(gt|#62);'i",
+            "'&(nbsp|#160);'i",
+            "'&(iexcl|#161);'i",
+            "'&(cent|#162);'i",
+            "'&(pound|#163);'i",
+            "'&(copy|#169);'i"
+        );
+        $replace = array(
+            "",
+            "",
+            "\\1",
+            "\"",
+            "&",
+            "<",
+            ">",
+            " ",
+            chr(161),
+            chr(162),
+            chr(163),
+            chr(169)
+        );
 
-/*======================================================================*\
-	Function:	_httpsrequest
-	Purpose:	go get the https data from the server using curl
-	Input:		$url		the url to fetch
-				$URI		the full URI
-				$body		body contents to send if any (POST)
-	Output:		
-\*======================================================================*/
-	
-	function _httpsrequest($url,$URI,$http_method,$content_type="",$body="")
-	{
-		if($this->passcookies && $this->_redirectaddr)
-			$this->setcookies();
+        $text = preg_replace($search, $replace, $document);
 
-		$headers = array();		
-					
-		$URI_PARTS = parse_url($URI);
-		if(empty($url))
-			$url = "/";
-		// GET ... header not needed for curl
-		//$headers[] = $http_method." ".$url." ".$this->_httpversion;		
-		if(!empty($this->agent))
-			$headers[] = "User-Agent: ".$this->agent;
-		if(!empty($this->host))
-			$headers[] = "Host: ".$this->host;
-		if(!empty($this->accept))
-			$headers[] = "Accept: ".$this->accept;
-		if(!empty($this->referer))
-			$headers[] = "Referer: ".$this->referer;
-		if(!empty($this->cookies))
-		{			
-			if(!is_array($this->cookies))
-				$this->cookies = (array)$this->cookies;
-	
-			reset($this->cookies);
-			if ( count($this->cookies) > 0 ) {
-				$cookie_str = 'Cookie: ';
-				foreach ( $this->cookies as $cookieKey => $cookieVal ) {
-				$cookie_str .= $cookieKey."=".urlencode($cookieVal)."; ";
-				}
-				$headers[] = substr($cookie_str,0,-2);
-			}
-		}
-		if(!empty($this->rawheaders))
-		{
-			if(!is_array($this->rawheaders))
-				$this->rawheaders = (array)$this->rawheaders;
-			while(list($headerKey,$headerVal) = each($this->rawheaders))
-				$headers[] = $headerKey.": ".$headerVal;
-		}
-		if(!empty($content_type)) {
-			if ($content_type == "multipart/form-data")
-				$headers[] = "Content-type: $content_type; boundary=".$this->_mime_boundary;
-			else
-				$headers[] = "Content-type: $content_type";
-		}
-		if(!empty($body))	
-			$headers[] = "Content-length: ".strlen($body);
-		if(!empty($this->user) || !empty($this->pass))	
-			$headers[] = "Authorization: BASIC ".base64_encode($this->user.":".$this->pass);
-			
-		for($curr_header = 0; $curr_header < count($headers); $curr_header++) {
-			$cmdline_params .= " -H \"".$headers[$curr_header]."\"";
-		}
-			  	                         
-		if(!empty($body))
-			$cmdline_params .= " -d \"$body\"";
-		
-		if($this->read_timeout > 0)
-			$cmdline_params .= " -m ".$this->read_timeout;
-		
-		$headerfile = uniqid(time());
-		
-		# accept self-signed certs
-		$cmdline_params .= " -k"; 
-		exec($this->curl_path." -D \"/tmp/$headerfile\"".escapeshellcmd($cmdline_params)." ".escapeshellcmd($URI),$results,$return);
-		
-		if($return)
-		{
-			$this->error = "Error: cURL could not retrieve the document, error $return.";
-			return false;
-		}
-			
-			
-		$results = implode("\r\n",$results);
-		
-		$result_headers = file("/tmp/$headerfile");
-						
-		$this->_redirectaddr = false;
-		unset($this->headers);
-						
-		for($currentHeader = 0; $currentHeader < count($result_headers); $currentHeader++)
-		{
-			
-			// if a header begins with Location: or URI:, set the redirect
-			if(preg_match("/^(Location: |URI: )/i",$result_headers[$currentHeader]))
-			{
-				// get URL portion of the redirect
-				preg_match("/^(Location: |URI:)(.*)/",chop($result_headers[$currentHeader]),$matches);
-				// look for :// in the Location header to see if hostname is included
-				if(!preg_match("|\:\/\/|",$matches[2]))
-				{
-					// no host in the path, so prepend
-					$this->_redirectaddr = $URI_PARTS["scheme"]."://".$this->host.":".$this->port;
-					// eliminate double slash
-					if(!preg_match("|^/|",$matches[2]))
-							$this->_redirectaddr .= "/".$matches[2];
-					else
-							$this->_redirectaddr .= $matches[2];
-				}
-				else
-					$this->_redirectaddr = $matches[2];
-			}
-		
-			if(preg_match("|^HTTP/|",$result_headers[$currentHeader]))
-			{
-			    $this->response_code = $result_headers[$currentHeader];
-			    if(preg_match("|^HTTP/[^\s]*\s(.*?)\s|",$this->response_code, $match))
-			    {
-				$this->status= $match[1];
-                	    }
-			}
-			$this->headers[] = $result_headers[$currentHeader];
-		}
+        return $text;
+    }
 
-		// check if there is a a redirect meta tag
-		
-		if(preg_match("'<meta[\s]*http-equiv[^>]*?content[\s]*=[\s]*[\"\']?\d+;[\s]+URL[\s]*=[\s]*([^\"\']*?)[\"\']?>'i",$results,$match))
-		{
-			$this->_redirectaddr = $this->_expandlinks($match[1],$URI);	
-		}
 
-		// have we hit our frame depth and is there frame src to fetch?
-		if(($this->_framedepth < $this->maxframes) && preg_match_all("'<frame\s+.*src[\s]*=[\'\"]?([^\'\"\>]+)'i",$results,$match))
-		{
-			$this->results[] = $results;
-			for($x=0; $x<count($match[1]); $x++)
-				$this->_frameurls[] = $this->_expandlinks($match[1][$x],$URI_PARTS["scheme"]."://".$this->host);
-		}
-		// have we already fetched framed content?
-		elseif(is_array($this->results))
-			$this->results[] = $results;
-		// no framed content
-		else
-			$this->results = $results;
+    /*======================================================================*\
+        Function:	_prepare_post_body
+        Purpose:	Prepare post body according to encoding type
+        Input:		$formvars  - form variables
+                    $formfiles - form upload files
+        Output:		post body
+    \*======================================================================*/
 
-		unlink("/tmp/$headerfile");
-		
-		return true;
-	}
+    function _prepare_post_body($formvars, $formfiles)
+    {
+        settype($formvars, "array");
+        settype($formfiles, "array");
 
-/*======================================================================*\
-	Function:	setcookies()
-	Purpose:	set cookies for a redirection
-\*======================================================================*/
-	
-	function setcookies()
-	{
-		for($x=0; $x<count($this->headers); $x++)
-		{
-		if(preg_match("/^set-cookie:[\s]+([^=]+)=([^;]+)/i", $this->headers[$x],$match))
-			$this->cookies[$match[1]] = $match[2];
-		}
-	}
+        if (count($formvars) == 0 && count($formfiles) == 0) {
+            return;
+        }
+        $postdata = '';
+        switch ($this->_submit_type) {
+            case "application/x-www-form-urlencoded":
+                reset($formvars);
 
-	
-/*======================================================================*\
-	Function:	_check_timeout
-	Purpose:	checks whether timeout has occurred
-	Input:		$fp	file pointer
-\*======================================================================*/
+                foreach ($formvars as $key => $val) {
+                    if (is_array($val) || is_object($val)) {
+							foreach ($val as $cur_key => $cur_val) {
+                            $postdata .= urlencode($key) . "[]=" . urlencode($cur_val) . "&";
+                        }
+                    } else {
+                        $postdata .= urlencode($key) . "=" . urlencode($val) . "&";
+                    }
+                }
+                break;
 
-	function _check_timeout($fp)
-	{
-		if ($this->read_timeout > 0) {
-			$fp_status = socket_get_status($fp);
-			if ($fp_status["timed_out"]) {
-				$this->timed_out = true;
-				return true;
-			}
-		}
-		return false;
-	}
+            case "multipart/form-data":
+                $this->_mime_boundary = "Snoopy" . md5(uniqid(microtime()));
 
-/*======================================================================*\
-	Function:	_connect
-	Purpose:	make a socket connection
-	Input:		$fp	file pointer
-\*======================================================================*/
-	
-	function _connect(&$fp)
-	{
-		if(!empty($this->proxy_host) && !empty($this->proxy_port))
-			{
-				$this->_isproxy = true;
-				$host = $this->proxy_host;
-				$port = $this->proxy_port;
-			}
-		else
-		{
-			$host = $this->host;
-			$port = $this->port;
-		}
-	
-		$this->status = 0;
-		
-		if($fp = fsockopen(
-					$host,
-					$port,
-					$errno,
-					$errstr,
-					$this->_fp_timeout
-					))
-		{
-			// socket connection succeeded
+                reset($formvars);
 
-			return true;
-		}
-		else
-		{
-			// socket connection failed
-			$this->status = $errno;
-			switch($errno)
-			{
-				case -3:
-					$this->error="socket creation failed (-3)";
-				case -4:
-					$this->error="dns lookup failure (-4)";
-				case -5:
-					$this->error="connection refused or timed out (-5)";
-				default:
-					$this->error="connection failed (".$errno.")";
-			}
-			return false;
-		}
-	}
-/*======================================================================*\
-	Function:	_disconnect
-	Purpose:	disconnect a socket connection
-	Input:		$fp	file pointer
-\*======================================================================*/
-	
-	function _disconnect($fp)
-	{
-		return(fclose($fp));
-	}
+                foreach ($formvars as $key => $val) {
 
-	
-/*======================================================================*\
-	Function:	_prepare_post_body
-	Purpose:	Prepare post body according to encoding type
-	Input:		$formvars  - form variables
-				$formfiles - form upload files
-	Output:		post body
-\*======================================================================*/
-	
-	function _prepare_post_body($formvars, $formfiles)
-	{
-		settype($formvars, "array");
-		settype($formfiles, "array");
+                    if (is_array($val) || is_object($val)) {
+                        foreach ($val as $cur_key => $cur_val) {
+                            $postdata .= "--" . $this->_mime_boundary . "\r\n";
+                            $postdata .= "Content-Disposition: form-data; name=\"$key\[\]\"\r\n\r\n";
+                            $postdata .= "$cur_val\r\n";
+                        }
+                    } else {
+                        $postdata .= "--" . $this->_mime_boundary . "\r\n";
+                        $postdata .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
+                        $postdata .= "$val\r\n";
+                    }
+                }
 
-		if (count($formvars) == 0 && count($formfiles) == 0)
-			return;
-		
-		switch ($this->_submit_type) {
-			case "application/x-www-form-urlencoded":
-				reset($formvars);
-				while(list($key,$val) = each($formvars)) {
-					if (is_array($val) || is_object($val)) {
-						while (list($cur_key, $cur_val) = each($val)) {
-							$postdata .= urlencode($key)."[]=".urlencode($cur_val)."&";
-						}
-					} else
-						$postdata .= urlencode($key)."=".urlencode($val)."&";
-				}
-				break;
+                reset($formfiles);
+                foreach ($formfiles as $field_name => $file_names) {
+                    settype($file_names, "array");
+                    foreach ($file_names as $file_name) {
+                        if (!is_readable($file_name)) {
+                            continue;
+                        }
 
-			case "multipart/form-data":
-				$this->_mime_boundary = "Snoopy".md5(uniqid(microtime()));
-				
-				reset($formvars);
-				while(list($key,$val) = each($formvars)) {
-					if (is_array($val) || is_object($val)) {
-						while (list($cur_key, $cur_val) = each($val)) {
-							$postdata .= "--".$this->_mime_boundary."\r\n";
-							$postdata .= "Content-Disposition: form-data; name=\"$key\[\]\"\r\n\r\n";
-							$postdata .= "$cur_val\r\n";
-						}
-					} else {
-						$postdata .= "--".$this->_mime_boundary."\r\n";
-						$postdata .= "Content-Disposition: form-data; name=\"$key\"\r\n\r\n";
-						$postdata .= "$val\r\n";
-					}
-				}
-				
-				reset($formfiles);
-				while (list($field_name, $file_names) = each($formfiles)) {
-					settype($file_names, "array");
-					while (list(, $file_name) = each($file_names)) {
-						if (!is_readable($file_name)) continue;
+                        $fp = fopen($file_name, "r");
+                        $file_content = fread($fp, filesize($file_name));
+                        fclose($fp);
+                        $base_name = basename($file_name);
 
-						$fp = fopen($file_name, "r");
-						$file_content = fread($fp, filesize($file_name));
-						fclose($fp);
-						$base_name = basename($file_name);
+                        $postdata .= "--" . $this->_mime_boundary . "\r\n";
+                        $postdata .= "Content-Disposition: form-data; name=\"$field_name\"; filename=\"$base_name\"\r\n\r\n";
+                        $postdata .= "$file_content\r\n";
+                    }
+                }
+                $postdata .= "--" . $this->_mime_boundary . "--\r\n";
+                break;
+        }
 
-						$postdata .= "--".$this->_mime_boundary."\r\n";
-						$postdata .= "Content-Disposition: form-data; name=\"$field_name\"; filename=\"$base_name\"\r\n\r\n";
-						$postdata .= "$file_content\r\n";
-					}
-				}
-				$postdata .= "--".$this->_mime_boundary."--\r\n";
-				break;
-		}
-
-		return $postdata;
-	}
+        return $postdata;
+    }
 }
-
-?>

--- a/dependencies/magpierss/rss_cache.inc
+++ b/dependencies/magpierss/rss_cache.inc
@@ -16,185 +16,198 @@
  *
  */
 
-class RSSCache {
+class RSSCache
+{
     var $BASE_CACHE = './cache';    // where the cache files are stored
-    var $MAX_AGE    = 3600;         // when are files stale, default one hour
-    var $ERROR      = "";           // accumulate error messages
-    
-    function RSSCache ($base='', $age='') {
-        if ( $base ) {
+    var $MAX_AGE = 3600;         // when are files stale, default one hour
+    var $ERROR = "";           // accumulate error messages
+
+    function __construct($base = '', $age = '')
+    {
+        if ($base) {
             $this->BASE_CACHE = $base;
         }
-        if ( $age ) {
+        if ($age) {
             $this->MAX_AGE = $age;
         }
-        
+
         // attempt to make the cache directory
-        if ( ! file_exists( $this->BASE_CACHE ) ) {
-            $status = @mkdir( $this->BASE_CACHE, 0755 );
-            
+        if (!file_exists($this->BASE_CACHE)) {
+            $status = @mkdir($this->BASE_CACHE, 0755);
+
             // if make failed 
-            if ( ! $status ) {
+            if (!$status) {
                 $this->error(
                     "Cache couldn't make dir '" . $this->BASE_CACHE . "'."
                 );
             }
         }
     }
-    
-/*=======================================================================*\
-    Function:   set
-    Purpose:    add an item to the cache, keyed on url
-    Input:      url from wich the rss file was fetched
-    Output:     true on sucess  
-\*=======================================================================*/
-    function set ($url, $rss) {
+
+    /*=======================================================================*\
+        Function:   set
+        Purpose:    add an item to the cache, keyed on url
+        Input:      url from wich the rss file was fetched
+        Output:     true on sucess
+    \*=======================================================================*/
+
+    function error($errormsg, $lvl = E_USER_WARNING)
+    {
+        // append PHP's error message if track_errors enabled
+        $error = error_get_last();
+        if (is_array($error)) {
+            $errormsg .= " (" . $error['message'] . ")";
+        }
+        $this->ERROR = $errormsg;
+        if (MAGPIE_DEBUG) {
+            trigger_error($errormsg, $lvl);
+        } else {
+            error_log($errormsg, 0);
+        }
+    }
+
+    /*=======================================================================*\
+        Function:   get
+        Purpose:    fetch an item from the cache
+        Input:      url from wich the rss file was fetched
+        Output:     cached object on HIT, false on MISS
+    \*=======================================================================*/
+
+    function set($url, $rss)
+    {
         $this->ERROR = "";
-        $cache_file = $this->file_name( $url );
-        $fp = @fopen( $cache_file, 'w' );
-        
-        if ( ! $fp ) {
+        $cache_file = $this->file_name($url);
+        $fp = @fopen($cache_file, 'w');
+
+        if (!$fp) {
             $this->error(
                 "Cache unable to open file for writing: $cache_file"
             );
             return 0;
         }
-        
-        
-        $data = $this->serialize( $rss );
-        fwrite( $fp, $data );
-        fclose( $fp );
-        
+
+
+        $data = $this->serialize($rss);
+        fwrite($fp, $data);
+        fclose($fp);
+
         return $cache_file;
     }
-    
-/*=======================================================================*\
-    Function:   get
-    Purpose:    fetch an item from the cache
-    Input:      url from wich the rss file was fetched
-    Output:     cached object on HIT, false on MISS 
-\*=======================================================================*/ 
-    function get ($url) {
+
+    /*=======================================================================*\
+        Function:   check_cache
+        Purpose:    check a url for membership in the cache
+                    and whether the object is older then MAX_AGE (ie. STALE)
+        Input:      url from wich the rss file was fetched
+        Output:     cached object on HIT, false on MISS
+    \*=======================================================================*/
+
+    function file_name($url)
+    {
+        $filename = md5($url);
+        return join(DIRECTORY_SEPARATOR, array($this->BASE_CACHE, $filename));
+    }
+
+    function serialize($rss)
+    {
+        return serialize($rss);
+    }
+
+    /*=======================================================================*\
+        Function:   serialize
+    \*=======================================================================*/
+
+    function get($url)
+    {
         $this->ERROR = "";
-        $cache_file = $this->file_name( $url );
-        
-        if ( ! file_exists( $cache_file ) ) {
-            $this->debug( 
+        $cache_file = $this->file_name($url);
+
+        if (!file_exists($cache_file)) {
+            $this->debug(
                 "Cache doesn't contain: $url (cache file: $cache_file)"
             );
             return 0;
         }
-        
+
         $fp = @fopen($cache_file, 'r');
-        if ( ! $fp ) {
+        if (!$fp) {
             $this->error(
                 "Failed to open cache file for reading: $cache_file"
             );
             return 0;
         }
-        
-        if ($filesize = filesize($cache_file) ) {
-        	$data = fread( $fp, filesize($cache_file) );
-        	$rss = $this->unserialize( $data );
-        
-        	return $rss;
-    	}
-    	
-    	return 0;
+
+        if ($filesize = filesize($cache_file)) {
+            $data = fread($fp, filesize($cache_file));
+            $rss = $this->unserialize($data);
+
+            return $rss;
+        }
+
+        return 0;
     }
 
-/*=======================================================================*\
-    Function:   check_cache
-    Purpose:    check a url for membership in the cache
-                and whether the object is older then MAX_AGE (ie. STALE)
-    Input:      url from wich the rss file was fetched
-    Output:     cached object on HIT, false on MISS 
-\*=======================================================================*/     
-    function check_cache ( $url ) {
+    /*=======================================================================*\
+        Function:   unserialize
+    \*=======================================================================*/
+
+    function debug($debugmsg, $lvl = E_USER_NOTICE)
+    {
+        if (MAGPIE_DEBUG) {
+            $this->error("MagpieRSS [debug] $debugmsg", $lvl);
+        }
+    }
+
+    /*=======================================================================*\
+        Function:   file_name
+        Purpose:    map url to location in cache
+        Input:      url from wich the rss file was fetched
+        Output:     a file name
+    \*=======================================================================*/
+
+    function unserialize($data)
+    {
+        return unserialize($data);
+    }
+
+    /*=======================================================================*\
+        Function:   error
+        Purpose:    register error
+    \*=======================================================================*/
+
+    function check_cache($url)
+    {
         $this->ERROR = "";
-        $filename = $this->file_name( $url );
-        
-        if ( file_exists( $filename ) ) {
+        $filename = $this->file_name($url);
+
+        if (file_exists($filename)) {
             // find how long ago the file was added to the cache
             // and whether that is longer then MAX_AGE
-            $mtime = filemtime( $filename );
+            $mtime = filemtime($filename);
             $age = time() - $mtime;
-            if ( $this->MAX_AGE > $age ) {
+            if ($this->MAX_AGE > $age) {
                 // object exists and is current
                 return 'HIT';
-            }
-            else {
+            } else {
                 // object exists but is old
                 return 'STALE';
             }
-        }
-        else {
+        } else {
             // object does not exist
             return 'MISS';
         }
     }
 
-	function cache_age( $cache_key ) {
-		$filename = $this->file_name( $url );
-		if ( file_exists( $filename ) ) {
-			$mtime = filemtime( $filename );
+    function cache_age($cache_key)
+    {
+        $filename = $this->file_name($url);
+        if (file_exists($filename)) {
+            $mtime = filemtime($filename);
             $age = time() - $mtime;
-			return $age;
-		}
-		else {
-			return -1;	
-		}
-	}
-	
-/*=======================================================================*\
-    Function:   serialize
-\*=======================================================================*/     
-    function serialize ( $rss ) {
-        return serialize( $rss );
-    }
-
-/*=======================================================================*\
-    Function:   unserialize
-\*=======================================================================*/     
-    function unserialize ( $data ) {
-        return unserialize( $data );
-    }
-    
-/*=======================================================================*\
-    Function:   file_name
-    Purpose:    map url to location in cache
-    Input:      url from wich the rss file was fetched
-    Output:     a file name
-\*=======================================================================*/     
-    function file_name ($url) {
-        $filename = md5( $url );
-        return join( DIRECTORY_SEPARATOR, array( $this->BASE_CACHE, $filename ) );
-    }
-
-/*=======================================================================*\
-    Function:   error
-    Purpose:    register error
-\*=======================================================================*/         
-    function error ($errormsg, $lvl=E_USER_WARNING) {
-        // append PHP's error message if track_errors enabled
-        if ( isset($php_errormsg) ) { 
-            $errormsg .= " ($php_errormsg)";
-        }
-        $this->ERROR = $errormsg;
-        if ( MAGPIE_DEBUG ) {
-            trigger_error( $errormsg, $lvl);
-        }
-        else {
-            error_log( $errormsg, 0);
-        }
-    }
-    
-    function debug ($debugmsg, $lvl=E_USER_NOTICE) {
-        if ( MAGPIE_DEBUG ) {
-            $this->error("MagpieRSS [debug] $debugmsg", $lvl);
+            return $age;
+        } else {
+            return -1;
         }
     }
 
 }
-
-?>

--- a/dependencies/magpierss/rss_fetch.inc
+++ b/dependencies/magpierss/rss_fetch.inc
@@ -15,7 +15,7 @@
  * magpierss-general@lists.sourceforge.net
  *
  */
- 
+
 // Setup MAGPIE_DIR for use on hosts that don't include
 // the current path in include_path.
 // with thanks to rajiv and smarty
@@ -27,12 +27,12 @@ if (!defined('MAGPIE_DIR')) {
     define('MAGPIE_DIR', dirname(__FILE__) . DIR_SEP);
 }
 
-require_once( MAGPIE_DIR . 'rss_parse.inc' );
-require_once( MAGPIE_DIR . 'rss_cache.inc' );
+require_once(MAGPIE_DIR . 'rss_parse.inc');
+require_once(MAGPIE_DIR . 'rss_cache.inc');
 
 // for including 3rd party libraries
 define('MAGPIE_EXTLIB', MAGPIE_DIR . 'extlib' . DIR_SEP);
-require_once( MAGPIE_EXTLIB . 'Snoopy.class.inc');
+require_once(MAGPIE_EXTLIB . 'Snoopy.class.inc');
 
 
 /* 
@@ -85,138 +85,132 @@ define('MAGPIE_VERSION', '0.72');
 
 $MAGPIE_ERROR = "";
 
-function fetch_rss ($url) {
+function fetch_rss($url)
+{
     // initialize constants
     init();
-    
-    if ( !isset($url) ) {
+
+    if (!isset($url)) {
         error("fetch_rss called without a url");
         return false;
     }
-    
+
     // if cache is disabled
-    if ( !MAGPIE_CACHE_ON ) {
+    if (!MAGPIE_CACHE_ON) {
         // fetch file, and parse it
-        $resp = _fetch_remote_file( $url );
-        if ( is_success( $resp->status ) ) {
-            return _response_to_rss( $resp );
-        }
-        else {
+        $resp = _fetch_remote_file($url);
+        if (is_success($resp->status)) {
+            return _response_to_rss($resp);
+        } else {
             error("Failed to fetch $url and cache is off");
             return false;
         }
-    } 
-    // else cache is ON
+    } // else cache is ON
     else {
         // Flow
         // 1. check cache
         // 2. if there is a hit, make sure its fresh
         // 3. if cached obj fails freshness check, fetch remote
         // 4. if remote fails, return stale object, or error
-        
-        $cache = new RSSCache( MAGPIE_CACHE_DIR, MAGPIE_CACHE_AGE );
-        
+
+        $cache = new RSSCache(MAGPIE_CACHE_DIR, MAGPIE_CACHE_AGE);
+
         if (MAGPIE_DEBUG and $cache->ERROR) {
             debug($cache->ERROR, E_USER_WARNING);
         }
-        
-        
-        $cache_status    = 0;       // response of check_cache
+
+
+        $cache_status = 0;       // response of check_cache
         $request_headers = array(); // HTTP headers to send with fetch
-        $rss             = 0;       // parsed RSS object
-        $errormsg        = 0;       // errors, if any
-        
+        $rss = 0;       // parsed RSS object
+        $errormsg = 0;       // errors, if any
+
         // store parsed XML by desired output encoding
         // as character munging happens at parse time
-        $cache_key       = $url . MAGPIE_OUTPUT_ENCODING;
-        
+        $cache_key = $url . MAGPIE_OUTPUT_ENCODING;
+
         if (!$cache->ERROR) {
             // return cache HIT, MISS, or STALE
-            $cache_status = $cache->check_cache( $cache_key);
+            $cache_status = $cache->check_cache($cache_key);
         }
-                
+
         // if object cached, and cache is fresh, return cached obj
-        if ( $cache_status == 'HIT' ) {
-            $rss = $cache->get( $cache_key );
-            if ( isset($rss) and $rss ) {
+        if ($cache_status == 'HIT') {
+            $rss = $cache->get($cache_key);
+            if (isset($rss) and $rss) {
                 // should be cache age
                 $rss->from_cache = 1;
-                if ( MAGPIE_DEBUG > 1) {
+                if (MAGPIE_DEBUG > 1) {
                     debug("MagpieRSS: Cache HIT", E_USER_NOTICE);
                 }
                 return $rss;
             }
         }
-        
+
         // else attempt a conditional get
-        
+
         // setup headers
-        if ( $cache_status == 'STALE' ) {
-            $rss = $cache->get( $cache_key );
-            if ( $rss and $rss->etag and $rss->last_modified ) {
+        if ($cache_status == 'STALE') {
+            $rss = $cache->get($cache_key);
+            if ($rss and $rss->etag and $rss->last_modified) {
                 $request_headers['If-None-Match'] = $rss->etag;
                 $request_headers['If-Last-Modified'] = $rss->last_modified;
             }
         }
-        
-        $resp = _fetch_remote_file( $url, $request_headers );
-        
+
+        $resp = _fetch_remote_file($url, $request_headers);
+
         if (isset($resp) and $resp) {
-          if ($resp->status == '304' ) {
+            if ($resp->status == '304') {
                 // we have the most current copy
-                if ( MAGPIE_DEBUG > 1) {
+                if (MAGPIE_DEBUG > 1) {
                     debug("Got 304 for $url");
                 }
                 // reset cache on 304 (at minutillo insistent prodding)
                 $cache->set($cache_key, $rss);
                 return $rss;
-            }
-            elseif ( is_success( $resp->status ) ) {
-                $rss = _response_to_rss( $resp );
-                if ( $rss ) {
+            } elseif (is_success($resp->status)) {
+                $rss = _response_to_rss($resp);
+                if ($rss) {
                     if (MAGPIE_DEBUG > 1) {
                         debug("Fetch successful");
                     }
                     // add object to cache
-                    $cache->set( $cache_key, $rss );
+                    $cache->set($cache_key, $rss);
                     return $rss;
                 }
-            }
-            else {
+            } else {
                 $errormsg = "Failed to fetch $url ";
-                if ( $resp->status == '-100' ) {
+                if ($resp->status == '-100') {
                     $errormsg .= "(Request timed out after " . MAGPIE_FETCH_TIME_OUT . " seconds)";
-                }
-                elseif ( $resp->error ) {
+                } elseif ($resp->error) {
                     # compensate for Snoopy's annoying habbit to tacking
                     # on '\n'
-                    $http_error = substr($resp->error, 0, -2); 
+                    $http_error = substr($resp->error, 0, -2);
                     $errormsg .= "(HTTP Error: $http_error)";
-                }
-                else {
-                    $errormsg .=  "(HTTP Response: " . $resp->response_code .')';
+                } else {
+                    $errormsg .= "(HTTP Response: " . $resp->response_code . ')';
                 }
             }
-        }
-        else {
+        } else {
             $errormsg = "Unable to retrieve RSS file for unknown reasons.";
         }
-        
+
         // else fetch failed
-        
+
         // attempt to return cached object
         if ($rss) {
-            if ( MAGPIE_DEBUG ) {
+            if (MAGPIE_DEBUG) {
                 debug("Returning STALE object for $url");
             }
             return $rss;
         }
-        
+
         // else we totally failed
-        error( $errormsg ); 
-        
+        error($errormsg);
+
         return false;
-        
+
     } // end if ( !MAGPIE_CACHE_ON ) {
 } // end fetch_rss()
 
@@ -225,36 +219,39 @@ function fetch_rss ($url) {
     Purpose:    set MAGPIE_ERROR, and trigger error
 \*=======================================================================*/
 
-function error ($errormsg, $lvl=E_USER_WARNING) {
-        global $MAGPIE_ERROR;
-        
-        // append PHP's error message if track_errors enabled
-        if ( isset($php_errormsg) ) { 
-            $errormsg .= " ($php_errormsg)";
-        }
-        if ( $errormsg ) {
-            $errormsg = "MagpieRSS: $errormsg";
-            $MAGPIE_ERROR = $errormsg;
-            trigger_error( $errormsg, $lvl);                
-        }
+function error($errormsg, $lvl = E_USER_WARNING)
+{
+    global $MAGPIE_ERROR;
+    $error = error_get_last();
+    // append PHP's error message if track_errors enabled
+    if (is_array($error)) {
+        $errormsg .= " (" . $error['message'] . ")";
+    }
+    if ($errormsg) {
+        $errormsg = "MagpieRSS: $errormsg";
+        $MAGPIE_ERROR = $errormsg;
+        trigger_error($errormsg, $lvl);
+    }
 }
 
-function debug ($debugmsg, $lvl=E_USER_NOTICE) {
+function debug($debugmsg, $lvl = E_USER_NOTICE)
+{
     trigger_error("MagpieRSS [debug] $debugmsg", $lvl);
 }
-            
+
 /*=======================================================================*\
     Function:   magpie_error
     Purpose:    accessor for the magpie error variable
 \*=======================================================================*/
-function magpie_error ($errormsg="") {
+function magpie_error($errormsg = "")
+{
     global $MAGPIE_ERROR;
-    
-    if ( isset($errormsg) and $errormsg ) { 
+
+    if (isset($errormsg) and $errormsg) {
         $MAGPIE_ERROR = $errormsg;
     }
-    
-    return $MAGPIE_ERROR;   
+
+    return $MAGPIE_ERROR;
 }
 
 /*=======================================================================*\
@@ -264,16 +261,17 @@ function magpie_error ($errormsg="") {
                 headers to send along with the request (optional)
     Output:     an HTTP response object (see Snoopy.class.inc)  
 \*=======================================================================*/
-function _fetch_remote_file ($url, $headers = "" ) {
+function _fetch_remote_file($url, $headers = "")
+{
     // Snoopy is an HTTP client in PHP
     $client = new Snoopy();
     $client->agent = MAGPIE_USER_AGENT;
     $client->read_timeout = MAGPIE_FETCH_TIME_OUT;
     $client->use_gzip = MAGPIE_USE_GZIP;
-    if (is_array($headers) ) {
+    if (is_array($headers)) {
         $client->rawheaders = $headers;
     }
-    
+
     @$client->fetch($url);
     return $client;
 
@@ -285,42 +283,42 @@ function _fetch_remote_file ($url, $headers = "" ) {
     Input:      an HTTP response object (see Snoopy)
     Output:     parsed RSS object (see rss_parse)
 \*=======================================================================*/
-function _response_to_rss ($resp) {
-    $rss = new MagpieRSS( $resp->results, MAGPIE_OUTPUT_ENCODING, MAGPIE_INPUT_ENCODING, MAGPIE_DETECT_ENCODING );
-    
+function _response_to_rss($resp)
+{
+    $rss = new MagpieRSS($resp->results, MAGPIE_OUTPUT_ENCODING, MAGPIE_INPUT_ENCODING, MAGPIE_DETECT_ENCODING);
+
     // if RSS parsed successfully       
-    if ( $rss and !$rss->ERROR) {
-        
+    if ($rss and !$rss->ERROR) {
+
         // find Etag, and Last-Modified
-        foreach($resp->headers as $h) {
+        foreach ($resp->headers as $h) {
             // 2003-03-02 - Nicola Asuni (www.tecnick.com) - fixed bug "Undefined offset: 1"
             if (strpos($h, ": ")) {
                 list($field, $val) = explode(": ", $h, 2);
-            }
-            else {
+            } else {
                 $field = $h;
                 $val = "";
             }
-            
-            if ( $field == 'ETag' ) {
+
+            if ($field == 'ETag') {
                 $rss->etag = $val;
             }
-            
-            if ( $field == 'Last-Modified' ) {
+
+            if ($field == 'Last-Modified') {
                 $rss->last_modified = $val;
             }
         }
-        
-        return $rss;    
+
+        return $rss;
     } // else construct error message
     else {
         $errormsg = "Failed to parse RSS file.";
-        
+
         if ($rss) {
             $errormsg .= " (" . $rss->ERROR . ")";
         }
         error($errormsg);
-        
+
         return false;
     } // end if ($rss and !$rss->error)
 }
@@ -330,66 +328,65 @@ function _response_to_rss ($resp) {
     Purpose:    setup constants with default values
                 check for user overrides
 \*=======================================================================*/
-function init () {
-    if ( defined('MAGPIE_INITALIZED') ) {
+function init()
+{
+    if (defined('MAGPIE_INITALIZED')) {
         return;
-    }
-    else {
+    } else {
         define('MAGPIE_INITALIZED', true);
     }
-    
-    if ( !defined('MAGPIE_CACHE_ON') ) {
+
+    if (!defined('MAGPIE_CACHE_ON')) {
         define('MAGPIE_CACHE_ON', true);
     }
 
-    if ( !defined('MAGPIE_CACHE_DIR') ) {
+    if (!defined('MAGPIE_CACHE_DIR')) {
         define('MAGPIE_CACHE_DIR', './cache');
     }
 
-    if ( !defined('MAGPIE_CACHE_AGE') ) {
-        define('MAGPIE_CACHE_AGE', 60*60); // one hour
+    if (!defined('MAGPIE_CACHE_AGE')) {
+        define('MAGPIE_CACHE_AGE', 60 * 60); // one hour
     }
 
-    if ( !defined('MAGPIE_CACHE_FRESH_ONLY') ) {
+    if (!defined('MAGPIE_CACHE_FRESH_ONLY')) {
         define('MAGPIE_CACHE_FRESH_ONLY', false);
     }
 
-    if ( !defined('MAGPIE_OUTPUT_ENCODING') ) {
+    if (!defined('MAGPIE_OUTPUT_ENCODING')) {
         define('MAGPIE_OUTPUT_ENCODING', 'ISO-8859-1');
     }
-    
-    if ( !defined('MAGPIE_INPUT_ENCODING') ) {
+
+    if (!defined('MAGPIE_INPUT_ENCODING')) {
         define('MAGPIE_INPUT_ENCODING', null);
     }
-    
-    if ( !defined('MAGPIE_DETECT_ENCODING') ) {
+
+    if (!defined('MAGPIE_DETECT_ENCODING')) {
         define('MAGPIE_DETECT_ENCODING', true);
     }
-    
-    if ( !defined('MAGPIE_DEBUG') ) {
+
+    if (!defined('MAGPIE_DEBUG')) {
         define('MAGPIE_DEBUG', 0);
     }
-    
-    if ( !defined('MAGPIE_USER_AGENT') ) {
-        $ua = 'MagpieRSS/'. MAGPIE_VERSION . ' (+http://magpierss.sf.net';
-        
-        if ( MAGPIE_CACHE_ON ) {
+
+    if (!defined('MAGPIE_USER_AGENT')) {
+        $ua = 'MagpieRSS/' . MAGPIE_VERSION . ' (+http://magpierss.sf.net';
+
+        if (MAGPIE_CACHE_ON) {
             $ua = $ua . ')';
-        }
-        else {
+        } else {
             $ua = $ua . '; No cache)';
         }
-        
+
         define('MAGPIE_USER_AGENT', $ua);
     }
-    
-    if ( !defined('MAGPIE_FETCH_TIME_OUT') ) {
+
+    if (!defined('MAGPIE_FETCH_TIME_OUT')) {
         define('MAGPIE_FETCH_TIME_OUT', 5); // 5 second timeout
     }
-    
+
     // use gzip encoding to fetch rss files if supported?
-    if ( !defined('MAGPIE_USE_GZIP') ) {
-        define('MAGPIE_USE_GZIP', true);    
+    if (!defined('MAGPIE_USE_GZIP')) {
+        define('MAGPIE_USE_GZIP', true);
     }
 }
 
@@ -411,48 +408,52 @@ function init () {
     Function:   is_info
     Purpose:    return true if Informational status code
 \*=======================================================================*/
-function is_info ($sc) { 
-    return $sc >= 100 && $sc < 200; 
+function is_info($sc)
+{
+    return $sc >= 100 && $sc < 200;
 }
 
 /*=======================================================================*\
     Function:   is_success
     Purpose:    return true if Successful status code
 \*=======================================================================*/
-function is_success ($sc) { 
-    return $sc >= 200 && $sc < 300; 
+function is_success($sc)
+{
+    return $sc >= 200 && $sc < 300;
 }
 
 /*=======================================================================*\
     Function:   is_redirect
     Purpose:    return true if Redirection status code
 \*=======================================================================*/
-function is_redirect ($sc) { 
-    return $sc >= 300 && $sc < 400; 
+function is_redirect($sc)
+{
+    return $sc >= 300 && $sc < 400;
 }
 
 /*=======================================================================*\
     Function:   is_error
     Purpose:    return true if Error status code
 \*=======================================================================*/
-function is_error ($sc) { 
-    return $sc >= 400 && $sc < 600; 
+function is_error($sc)
+{
+    return $sc >= 400 && $sc < 600;
 }
 
 /*=======================================================================*\
     Function:   is_client_error
     Purpose:    return true if Error status code, and its a client error
 \*=======================================================================*/
-function is_client_error ($sc) { 
-    return $sc >= 400 && $sc < 500; 
+function is_client_error($sc)
+{
+    return $sc >= 400 && $sc < 500;
 }
 
 /*=======================================================================*\
     Function:   is_client_error
     Purpose:    return true if Error status code, and its a server error
 \*=======================================================================*/
-function is_server_error ($sc) { 
-    return $sc >= 500 && $sc < 600; 
+function is_server_error($sc)
+{
+    return $sc >= 500 && $sc < 600;
 }
-
-?>

--- a/dependencies/magpierss/rss_parse.inc
+++ b/dependencies/magpierss/rss_parse.inc
@@ -1,585 +1,553 @@
 <?php
 
 /**
-* Project:     MagpieRSS: a simple RSS integration tool
-* File:        rss_parse.inc  - parse an RSS or Atom feed
-*               return as a simple object.
-*
-* Handles RSS 0.9x, RSS 2.0, RSS 1.0, and Atom 0.3
-*
-* The lastest version of MagpieRSS can be obtained from:
-* http://magpierss.sourceforge.net
-*
-* For questions, help, comments, discussion, etc., please join the
-* Magpie mailing list:
-* magpierss-general@lists.sourceforge.net
-*
-* @author           Kellan Elliott-McCrea <kellan@protest.net>
-* @version          0.7a
-* @license          GPL
-*
-*/
+ * Project:     MagpieRSS: a simple RSS integration tool
+ * File:        rss_parse.inc  - parse an RSS or Atom feed
+ *               return as a simple object.
+ *
+ * Handles RSS 0.9x, RSS 2.0, RSS 1.0, and Atom 0.3
+ *
+ * The lastest version of MagpieRSS can be obtained from:
+ * http://magpierss.sourceforge.net
+ *
+ * For questions, help, comments, discussion, etc., please join the
+ * Magpie mailing list:
+ * magpierss-general@lists.sourceforge.net
+ *
+ * @author           Kellan Elliott-McCrea <kellan@protest.net>
+ * @version          0.7a
+ * @license          GPL
+ *
+ */
 
 define('RSS', 'RSS');
 define('ATOM', 'Atom');
 
-require_once (MAGPIE_DIR . 'rss_utils.inc');
+require_once(MAGPIE_DIR . 'rss_utils.inc');
 
 /**
-* Hybrid parser, and object, takes RSS as a string and returns a simple object.
-*
-* see: rss_fetch.inc for a simpler interface with integrated caching support
-*
-*/
-class MagpieRSS {
+ * Hybrid parser, and object, takes RSS as a string and returns a simple object.
+ *
+ * see: rss_fetch.inc for a simpler interface with integrated caching support
+ *
+ */
+class MagpieRSS
+{
     var $parser;
-    
-    var $current_item   = array();  // item currently being parsed
-    var $items          = array();  // collection of parsed items
-    var $channel        = array();  // hash of channel fields
-    var $textinput      = array();
-    var $image          = array();
+
+    var $current_item = array();  // item currently being parsed
+    var $items = array();  // collection of parsed items
+    var $channel = array();  // hash of channel fields
+    var $textinput = array();
+    var $image = array();
     var $feed_type;
     var $feed_version;
-    var $encoding       = '';       // output encoding of parsed rss
-    
+    var $encoding = '';       // output encoding of parsed rss
+
     var $_source_encoding = '';     // only set if we have to parse xml prolog
-    
+
     var $ERROR = "";
     var $WARNING = "";
-    
+
     // define some constants
-    
+
     var $_CONTENT_CONSTRUCTS = array('content', 'summary', 'info', 'title', 'tagline', 'copyright');
-    var $_KNOWN_ENCODINGS    = array('UTF-8', 'US-ASCII', 'ISO-8859-1');
+    var $_KNOWN_ENCODINGS = array('UTF-8', 'US-ASCII', 'ISO-8859-1');
 
     // parser variables, useless if you're not a parser, treat as private
-    var $stack              = array(); // parser stack
-    var $inchannel          = false;
-    var $initem             = false;
-    var $incontent          = false; // if in Atom <content mode="xml"> field 
-    var $intextinput        = false;
-    var $inimage            = false;
-    var $current_namespace  = false;
-    
+    var $stack = array(); // parser stack
+    var $inchannel = false;
+    var $initem = false;
+    var $incontent = false; // if in Atom <content mode="xml"> field
+    var $intextinput = false;
+    var $inimage = false;
+    var $current_namespace = false;
+
 
     /**
      *  Set up XML parser, parse source, and return populated RSS object..
-     *   
-     *  @param string $source           string containing the RSS to be parsed
+     *
+     * @param string $source string containing the RSS to be parsed
      *
      *  NOTE:  Probably a good idea to leave the encoding options alone unless
      *         you know what you're doing as PHP's character set support is
      *         a little weird.
      *
-     *  NOTE:  A lot of this is unnecessary but harmless with PHP5 
+     *  NOTE:  A lot of this is unnecessary but harmless with PHP5
      *
      *
-     *  @param string $output_encoding  output the parsed RSS in this character 
+     * @param string $output_encoding output the parsed RSS in this character
      *                                  set defaults to ISO-8859-1 as this is PHP's
      *                                  default.
      *
      *                                  NOTE: might be changed to UTF-8 in future
      *                                  versions.
-     *                               
-     *  @param string $input_encoding   the character set of the incoming RSS source. 
+     *
+     * @param string $input_encoding the character set of the incoming RSS source.
      *                                  Leave blank and Magpie will try to figure it
      *                                  out.
-     *                                  
-     *                                   
-     *  @param bool   $detect_encoding  if false Magpie won't attempt to detect
+     *
+     *
+     * @param bool $detect_encoding if false Magpie won't attempt to detect
      *                                  source encoding. (caveat emptor)
      *
      */
-    function MagpieRSS ($source, $output_encoding='ISO-8859-1', 
-                        $input_encoding=null, $detect_encoding=true) 
-    {   
+    function __construct(
+        $source,
+        $output_encoding = 'ISO-8859-1',
+        $input_encoding = null,
+        $detect_encoding = true
+    ) {
         # if PHP xml isn't compiled in, die
         #
         if (!function_exists('xml_parser_create')) {
-            $this->error( "Failed to load PHP's XML Extension. " . 
-                          "http://www.php.net/manual/en/ref.xml.php",
-                           E_USER_ERROR );
-        }
-        
-        list($parser, $source) = $this->create_parser($source, 
-                $output_encoding, $input_encoding, $detect_encoding);
-        
-        
-        if (!is_resource($parser)) {
-            $this->error( "Failed to create an instance of PHP's XML parser. " .
-                          "http://www.php.net/manual/en/ref.xml.php",
-                          E_USER_ERROR );
+            $this->error("Failed to load PHP's XML Extension. " .
+                "http://www.php.net/manual/en/ref.xml.php",
+                E_USER_ERROR);
         }
 
-        
+        list($parser, $source) = $this->create_parser($source,
+            $output_encoding, $input_encoding, $detect_encoding);
+
+
+        if (!is_resource($parser)) {
+            $this->error("Failed to create an instance of PHP's XML parser. " .
+                "http://www.php.net/manual/en/ref.xml.php",
+                E_USER_ERROR);
+        }
+
+
         $this->parser = $parser;
-        
+
         # pass in parser, and a reference to this object
         # setup handlers
         #
-        xml_set_object( $this->parser, $this );
-        xml_set_element_handler($this->parser, 
-                'feed_start_element', 'feed_end_element' );
-                        
-        xml_set_character_data_handler( $this->parser, 'feed_cdata' ); 
-    
-        $status = xml_parse( $this->parser, $source );
-        
-        if (! $status ) {
-            $errorcode = xml_get_error_code( $this->parser );
-            if ( $errorcode != XML_ERROR_NONE ) {
-                $xml_error = xml_error_string( $errorcode );
+        xml_set_object($this->parser, $this);
+        xml_set_element_handler($this->parser,
+            'feed_start_element', 'feed_end_element');
+
+        xml_set_character_data_handler($this->parser, 'feed_cdata');
+
+        $status = xml_parse($this->parser, $source);
+
+        if (!$status) {
+            $errorcode = xml_get_error_code($this->parser);
+            if ($errorcode != XML_ERROR_NONE) {
+                $xml_error = xml_error_string($errorcode);
                 $error_line = xml_get_current_line_number($this->parser);
                 $error_col = xml_get_current_column_number($this->parser);
                 $errormsg = "$xml_error at line $error_line, column $error_col";
 
-                $this->error( $errormsg );
+                $this->error($errormsg);
             }
         }
-        
-        xml_parser_free( $this->parser );
+
+        xml_parser_free($this->parser);
 
         $this->normalize();
     }
-    
-    function feed_start_element($p, $element, &$attrs) {
-        $el = $element = strtolower($element);
-        $attrs = array_change_key_case($attrs, CASE_LOWER);
-        
-        // check for a namespace, and split if found
-        $ns = false;
-        if ( strpos( $element, ':' ) ) {
-            list($ns, $el) = split( ':', $element, 2); 
-        }
-        if ( $ns and $ns != 'rdf' ) {
-            $this->current_namespace = $ns;
-        }
-            
-        # if feed type isn't set, then this is first element of feed
-        # identify feed from root element
-        #
-        if (!isset($this->feed_type) ) {
-            if ( $el == 'rdf' ) {
-                $this->feed_type = RSS;
-                $this->feed_version = '1.0';
-            }
-            elseif ( $el == 'rss' ) {
-                $this->feed_type = RSS;
-                $this->feed_version = $attrs['version'];
-            }
-            elseif ( $el == 'feed' ) {
-                $this->feed_type = ATOM;
-                $this->feed_version = $attrs['version'];
-                $this->inchannel = true;
-            }
-            return;
-        }
-    
-        if ( $el == 'channel' ) 
-        {
-            $this->inchannel = true;
-        }
-        elseif ($el == 'item' or $el == 'entry' ) 
-        {
-            $this->initem = true;
-            if ( isset($attrs['rdf:about']) ) {
-                $this->current_item['about'] = $attrs['rdf:about']; 
-            }
-        }
-        
-        // if we're in the default namespace of an RSS feed,
-        //  record textinput or image fields
-        elseif ( 
-            $this->feed_type == RSS and 
-            $this->current_namespace == '' and 
-            $el == 'textinput' ) 
-        {
-            $this->intextinput = true;
-        }
-        
-        elseif (
-            $this->feed_type == RSS and 
-            $this->current_namespace == '' and 
-            $el == 'image' ) 
-        {
-            $this->inimage = true;
-        }
-        
-        # handle atom content constructs
-        elseif ( $this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS) )
-        {
-            // avoid clashing w/ RSS mod_content
-            if ($el == 'content' ) {
-                $el = 'atom_content';
-            }
-            
-            $this->incontent = $el;
-            
-            
-        }
-        
-        // if inside an Atom content construct (e.g. content or summary) field treat tags as text
-        elseif ($this->feed_type == ATOM and $this->incontent ) 
-        {
-            // if tags are inlined, then flatten
-            $attrs_str = join(' ', 
-                    array_map('map_attrs', 
-                    array_keys($attrs), 
-                    array_values($attrs) ) );
-            
-            $this->append_content( "<$element $attrs_str>"  );
-                    
-            array_unshift( $this->stack, $el );
-        }
-        
-        // Atom support many links per containging element.
-        // Magpie treats link elements of type rel='alternate'
-        // as being equivalent to RSS's simple link element.
-        //
-        elseif ($this->feed_type == ATOM and $el == 'link' ) 
-        {
-            if ( isset($attrs['rel']) and $attrs['rel'] == 'alternate' ) 
-            {
-                $link_el = 'link';
-            }
-            else {
-                $link_el = 'link_' . $attrs['rel'];
-            }
-            
-            $this->append($link_el, $attrs['href']);
-        }
-        // set stack[0] to current element
-        else {
-            array_unshift($this->stack, $el);
-        }
-    }
-    
 
-    
-    function feed_cdata ($p, $text) {
-        if ($this->feed_type == ATOM and $this->incontent) 
-        {
-            $this->append_content( $text );
+    function error($errormsg, $lvl = E_USER_WARNING)
+    {
+        $error = error_get_last();
+        // append PHP's error message if track_errors enabled
+        if (is_array($error)) {
+            $errormsg .= " (" . $error['message'] . ")";
         }
-        else {
-            $current_el = join('_', array_reverse($this->stack));
-            $this->append($current_el, $text);
+        if (MAGPIE_DEBUG) {
+            trigger_error($errormsg, $lvl);
+        } else {
+            error_log($errormsg, 0);
         }
-    }
-    
-    function feed_end_element ($p, $el) {
-        $el = strtolower($el);
-        
-        if ( $el == 'item' or $el == 'entry' ) 
-        {
-            $this->items[] = $this->current_item;
-            $this->current_item = array();
-            $this->initem = false;
-        }
-        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'textinput' ) 
-        {
-            $this->intextinput = false;
-        }
-        elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'image' ) 
-        {
-            $this->inimage = false;
-        }
-        elseif ($this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS) )
-        {   
-            $this->incontent = false;
-        }
-        elseif ($el == 'channel' or $el == 'feed' ) 
-        {
-            $this->inchannel = false;
-        }
-        elseif ($this->feed_type == ATOM and $this->incontent  ) {
-            // balance tags properly
-            // note:  i don't think this is actually neccessary
-            if ( $this->stack[0] == $el ) 
-            {
-                $this->append_content("</$el>");
-            }
-            else {
-                $this->append_content("<$el />");
-            }
 
-            array_shift( $this->stack );
-        }
-        else {
-            array_shift( $this->stack );
-        }
-        
-        $this->current_namespace = false;
-    }
-    
-    function concat (&$str1, $str2="") {
-        if (!isset($str1) ) {
-            $str1="";
-        }
-        $str1 .= $str2;
-    }
-    
-    
-    
-    function append_content($text) {
-        if ( $this->initem ) {
-            $this->concat( $this->current_item[ $this->incontent ], $text );
-        }
-        elseif ( $this->inchannel ) {
-            $this->concat( $this->channel[ $this->incontent ], $text );
-        }
-    }
-    
-    // smart append - field and namespace aware
-    function append($el, $text) {
-        if (!$el) {
-            return;
-        }
-        if ( $this->current_namespace ) 
-        {
-            if ( $this->initem ) {
-                $this->concat(
-                    $this->current_item[ $this->current_namespace ][ $el ], $text);
-            }
-            elseif ($this->inchannel) {
-                $this->concat(
-                    $this->channel[ $this->current_namespace][ $el ], $text );
-            }
-            elseif ($this->intextinput) {
-                $this->concat(
-                    $this->textinput[ $this->current_namespace][ $el ], $text );
-            }
-            elseif ($this->inimage) {
-                $this->concat(
-                    $this->image[ $this->current_namespace ][ $el ], $text );
-            }
-        }
-        else {
-            if ( $this->initem ) {
-                $this->concat(
-                    $this->current_item[ $el ], $text);
-            }
-            elseif ($this->intextinput) {
-                $this->concat(
-                    $this->textinput[ $el ], $text );
-            }
-            elseif ($this->inimage) {
-                $this->concat(
-                    $this->image[ $el ], $text );
-            }
-            elseif ($this->inchannel) {
-                $this->concat(
-                    $this->channel[ $el ], $text );
-            }
-            
-        }
-    }
-    
-    function normalize () {
-        // if atom populate rss fields
-        if ( $this->is_atom() ) {
-            $this->channel['description'] = $this->channel['tagline'];
-            for ( $i = 0; $i < count($this->items); $i++) {
-                $item = $this->items[$i];
-                if ( isset($item['summary']) )
-                    $item['description'] = $item['summary'];
-                if ( isset($item['atom_content']))
-                    $item['content']['encoded'] = $item['atom_content'];
-                
-                $atom_date = (isset($item['issued']) ) ? $item['issued'] : $item['modified'];
-                if ( $atom_date ) {
-                    $epoch = @parse_w3cdtf($atom_date);
-                    if ($epoch and $epoch > 0) {
-                        $item['date_timestamp'] = $epoch;
-                    }
-                }
-                
-                $this->items[$i] = $item;
-            }       
-        }
-        elseif ( $this->is_rss() ) {
-            $this->channel['tagline'] = $this->channel['description'];
-            for ( $i = 0; $i < count($this->items); $i++) {
-                $item = $this->items[$i];
-                if ( isset($item['description']))
-                    $item['summary'] = $item['description'];
-                if ( isset($item['content']['encoded'] ) )
-                    $item['atom_content'] = $item['content']['encoded'];
-                
-                if ( $this->is_rss() == '1.0' and isset($item['dc']['date']) ) {
-                    $epoch = @parse_w3cdtf($item['dc']['date']);
-                    if ($epoch and $epoch > 0) {
-                        $item['date_timestamp'] = $epoch;
-                    }
-                }
-                elseif ( isset($item['pubdate']) ) {
-                    $epoch = @strtotime($item['pubdate']);
-                    if ($epoch > 0) {
-                        $item['date_timestamp'] = $epoch;
-                    }
-                }
-                
-                $this->items[$i] = $item;
-            }
-        }
-    }
-    
-    
-    function is_rss () {
-        if ( $this->feed_type == RSS ) {
-            return $this->feed_version; 
-        }
-        else {
-            return false;
-        }
-    }
-    
-    function is_atom() {
-        if ( $this->feed_type == ATOM ) {
-            return $this->feed_version;
-        }
-        else {
-            return false;
+        $notices = E_USER_NOTICE | E_NOTICE;
+        if ($lvl & $notices) {
+            $this->WARNING = $errormsg;
+        } else {
+            $this->ERROR = $errormsg;
         }
     }
 
     /**
-    * return XML parser, and possibly re-encoded source
-    *
-    */
-    function create_parser($source, $out_enc, $in_enc, $detect) {
-        if ( substr(phpversion(),0,1) == 5) {
+     * return XML parser, and possibly re-encoded source
+     *
+     */
+    function create_parser($source, $out_enc, $in_enc, $detect)
+    {
+        if (substr(phpversion(), 0, 1) == 5) {
             $parser = $this->php5_create_parser($in_enc, $detect);
-        }
-        else {
+        } else {
             list($parser, $source) = $this->php4_create_parser($source, $in_enc, $detect);
         }
         if ($out_enc) {
             $this->encoding = $out_enc;
             xml_parser_set_option($parser, XML_OPTION_TARGET_ENCODING, $out_enc);
         }
-        
+
         return array($parser, $source);
     }
-    
+
     /**
-    * Instantiate an XML parser under PHP5
-    *
-    * PHP5 will do a fine job of detecting input encoding
-    * if passed an empty string as the encoding. 
-    *
-    * All hail libxml2!
-    *
-    */
-    function php5_create_parser($in_enc, $detect) {
+     * Instantiate an XML parser under PHP5
+     *
+     * PHP5 will do a fine job of detecting input encoding
+     * if passed an empty string as the encoding.
+     *
+     * All hail libxml2!
+     *
+     */
+    function php5_create_parser($in_enc, $detect)
+    {
         // by default php5 does a fine job of detecting input encodings
-        if(!$detect && $in_enc) {
+        if (!$detect && $in_enc) {
             return xml_parser_create($in_enc);
-        }
-        else {
+        } else {
             return xml_parser_create('');
         }
     }
-    
+
     /**
-    * Instaniate an XML parser under PHP4
-    *
-    * Unfortunately PHP4's support for character encodings
-    * and especially XML and character encodings sucks.  As
-    * long as the documents you parse only contain characters
-    * from the ISO-8859-1 character set (a superset of ASCII,
-    * and a subset of UTF-8) you're fine.  However once you
-    * step out of that comfy little world things get mad, bad,
-    * and dangerous to know.
-    *
-    * The following code is based on SJM's work with FoF
-    * @see http://minutillo.com/steve/weblog/2004/6/17/php-xml-and-character-encodings-a-tale-of-sadness-rage-and-data-loss
-    *
-    */
-    function php4_create_parser($source, $in_enc, $detect) {
-        if ( !$detect ) {
+     * Instaniate an XML parser under PHP4
+     *
+     * Unfortunately PHP4's support for character encodings
+     * and especially XML and character encodings sucks.  As
+     * long as the documents you parse only contain characters
+     * from the ISO-8859-1 character set (a superset of ASCII,
+     * and a subset of UTF-8) you're fine.  However once you
+     * step out of that comfy little world things get mad, bad,
+     * and dangerous to know.
+     *
+     * The following code is based on SJM's work with FoF
+     * @see http://minutillo.com/steve/weblog/2004/6/17/php-xml-and-character-encodings-a-tale-of-sadness-rage-and-data-loss
+     *
+     */
+    function php4_create_parser($source, $in_enc, $detect)
+    {
+        if (!$detect) {
             return array(xml_parser_create($in_enc), $source);
         }
-        
+
         if (!$in_enc) {
             if (preg_match('/<?xml.*encoding=[\'"](.*?)[\'"].*?>/m', $source, $m)) {
                 $in_enc = strtoupper($m[1]);
                 $this->source_encoding = $in_enc;
-            }
-            else {
+            } else {
                 $in_enc = 'UTF-8';
             }
         }
-        
+
         if ($this->known_encoding($in_enc)) {
             return array(xml_parser_create($in_enc), $source);
         }
-        
+
         // the dectected encoding is not one of the simple encodings PHP knows
-        
+
         // attempt to use the iconv extension to
         // cast the XML to a known encoding
         // @see http://php.net/iconv
-       
-        if (function_exists('iconv'))  {
-            $encoded_source = iconv($in_enc,'UTF-8', $source);
+
+        if (function_exists('iconv')) {
+            $encoded_source = iconv($in_enc, 'UTF-8', $source);
             if ($encoded_source) {
                 return array(xml_parser_create('UTF-8'), $encoded_source);
             }
         }
-        
+
         // iconv didn't work, try mb_convert_encoding
         // @see http://php.net/mbstring
-        if(function_exists('mb_convert_encoding')) {
-            $encoded_source = mb_convert_encoding($source, 'UTF-8', $in_enc );
+        if (function_exists('mb_convert_encoding')) {
+            $encoded_source = mb_convert_encoding($source, 'UTF-8', $in_enc);
             if ($encoded_source) {
                 return array(xml_parser_create('UTF-8'), $encoded_source);
             }
         }
-        
-        // else 
+
+        // else
         $this->error("Feed is in an unsupported character encoding. ($in_enc) " .
-                     "You may see strange artifacts, and mangled characters.",
-                     E_USER_NOTICE);
-            
+            "You may see strange artifacts, and mangled characters.",
+            E_USER_NOTICE);
+
         return array(xml_parser_create(), $source);
     }
-    
-    function known_encoding($enc) {
+
+    function known_encoding($enc)
+    {
         $enc = strtoupper($enc);
-        if ( in_array($enc, $this->_KNOWN_ENCODINGS) ) {
+        if (in_array($enc, $this->_KNOWN_ENCODINGS)) {
             return $enc;
-        }
-        else {
+        } else {
             return false;
         }
     }
 
-    function error ($errormsg, $lvl=E_USER_WARNING) {
-        // append PHP's error message if track_errors enabled
-        if ( isset($php_errormsg) ) { 
-            $errormsg .= " ($php_errormsg)";
-        }
-        if ( MAGPIE_DEBUG ) {
-            trigger_error( $errormsg, $lvl);        
-        }
-        else {
-            error_log( $errormsg, 0);
-        }
-        
-        $notices = E_USER_NOTICE|E_NOTICE;
-        if ( $lvl&$notices ) {
-            $this->WARNING = $errormsg;
-        } else {
-            $this->ERROR = $errormsg;
+    // smart append - field and namespace aware
+
+    function normalize()
+    {
+        // if atom populate rss fields
+        if ($this->is_atom()) {
+            $this->channel['description'] = $this->channel['tagline'];
+            for ($i = 0; $i < count($this->items); $i++) {
+                $item = $this->items[$i];
+                if (isset($item['summary'])) {
+                    $item['description'] = $item['summary'];
+                }
+                if (isset($item['atom_content'])) {
+                    $item['content']['encoded'] = $item['atom_content'];
+                }
+
+                $atom_date = (isset($item['issued'])) ? $item['issued'] : $item['modified'];
+                if ($atom_date) {
+                    $epoch = @parse_w3cdtf($atom_date);
+                    if ($epoch and $epoch > 0) {
+                        $item['date_timestamp'] = $epoch;
+                    }
+                }
+
+                $this->items[$i] = $item;
+            }
+        } elseif ($this->is_rss()) {
+            $this->channel['tagline'] = $this->channel['description'];
+            for ($i = 0; $i < count($this->items); $i++) {
+                $item = $this->items[$i];
+                if (isset($item['description'])) {
+                    $item['summary'] = $item['description'];
+                }
+                if (isset($item['content']['encoded'])) {
+                    $item['atom_content'] = $item['content']['encoded'];
+                }
+
+                if ($this->is_rss() == '1.0' and isset($item['dc']['date'])) {
+                    $epoch = @parse_w3cdtf($item['dc']['date']);
+                    if ($epoch and $epoch > 0) {
+                        $item['date_timestamp'] = $epoch;
+                    }
+                } elseif (isset($item['pubdate'])) {
+                    $epoch = @strtotime($item['pubdate']);
+                    if ($epoch > 0) {
+                        $item['date_timestamp'] = $epoch;
+                    }
+                }
+
+                $this->items[$i] = $item;
+            }
         }
     }
-    
-    
+
+    function is_atom()
+    {
+        if ($this->feed_type == ATOM) {
+            return $this->feed_version;
+        } else {
+            return false;
+        }
+    }
+
+    function is_rss()
+    {
+        if ($this->feed_type == RSS) {
+            return $this->feed_version;
+        } else {
+            return false;
+        }
+    }
+
+    function feed_start_element($p, $element, &$attrs)
+    {
+        $el = $element = strtolower($element);
+        $attrs = array_change_key_case($attrs, CASE_LOWER);
+
+        // check for a namespace, and split if found
+        $ns = false;
+        if (strpos($element, ':')) {
+            list($ns, $el) = explode(':', $element, 2);
+        }
+        if ($ns and $ns != 'rdf') {
+            $this->current_namespace = $ns;
+        }
+
+        # if feed type isn't set, then this is first element of feed
+        # identify feed from root element
+        #
+        if (!isset($this->feed_type)) {
+            if ($el == 'rdf') {
+                $this->feed_type = RSS;
+                $this->feed_version = '1.0';
+            } elseif ($el == 'rss') {
+                $this->feed_type = RSS;
+                $this->feed_version = $attrs['version'];
+            } elseif ($el == 'feed') {
+                $this->feed_type = ATOM;
+                $this->feed_version = $attrs['version'];
+                $this->inchannel = true;
+            }
+            return;
+        }
+
+        if ($el == 'channel') {
+            $this->inchannel = true;
+        } elseif ($el == 'item' or $el == 'entry') {
+            $this->initem = true;
+            if (isset($attrs['rdf:about'])) {
+                $this->current_item['about'] = $attrs['rdf:about'];
+            }
+        }
+
+        // if we're in the default namespace of an RSS feed,
+        //  record textinput or image fields
+        elseif (
+            $this->feed_type == RSS and
+            $this->current_namespace == '' and
+            $el == 'textinput') {
+            $this->intextinput = true;
+        } elseif (
+            $this->feed_type == RSS and
+            $this->current_namespace == '' and
+            $el == 'image') {
+            $this->inimage = true;
+        } # handle atom content constructs
+        elseif ($this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS)) {
+            // avoid clashing w/ RSS mod_content
+            if ($el == 'content') {
+                $el = 'atom_content';
+            }
+
+            $this->incontent = $el;
+
+
+        } // if inside an Atom content construct (e.g. content or summary) field treat tags as text
+        elseif ($this->feed_type == ATOM and $this->incontent) {
+            // if tags are inlined, then flatten
+            $attrs_str = join(' ',
+                array_map('map_attrs',
+                    array_keys($attrs),
+                    array_values($attrs)));
+
+            $this->append_content("<$element $attrs_str>");
+
+            array_unshift($this->stack, $el);
+        }
+
+        // Atom support many links per containging element.
+        // Magpie treats link elements of type rel='alternate'
+        // as being equivalent to RSS's simple link element.
+        //
+        elseif ($this->feed_type == ATOM and $el == 'link') {
+            if (isset($attrs['rel']) and $attrs['rel'] == 'alternate') {
+                $link_el = 'link';
+            } else {
+                $link_el = 'link_' . $attrs['rel'];
+            }
+
+            $this->append($link_el, $attrs['href']);
+        } // set stack[0] to current element
+        else {
+            array_unshift($this->stack, $el);
+        }
+    }
+
+    function append_content($text)
+    {
+        if ($this->initem) {
+            $this->concat($this->current_item[$this->incontent], $text);
+        } elseif ($this->inchannel) {
+            $this->concat($this->channel[$this->incontent], $text);
+        }
+    }
+
+    function concat(&$str1, $str2 = "")
+    {
+        if (!isset($str1)) {
+            $str1 = "";
+        }
+        $str1 .= $str2;
+    }
+
+    function append($el, $text)
+    {
+        if (!$el) {
+            return;
+        }
+        if ($this->current_namespace) {
+            if ($this->initem) {
+                $this->concat(
+                    $this->current_item[$this->current_namespace][$el], $text);
+            } elseif ($this->inchannel) {
+                $this->concat(
+                    $this->channel[$this->current_namespace][$el], $text);
+            } elseif ($this->intextinput) {
+                $this->concat(
+                    $this->textinput[$this->current_namespace][$el], $text);
+            } elseif ($this->inimage) {
+                $this->concat(
+                    $this->image[$this->current_namespace][$el], $text);
+            }
+        } else {
+            if ($this->initem) {
+                $this->concat(
+                    $this->current_item[$el], $text);
+            } elseif ($this->intextinput) {
+                $this->concat(
+                    $this->textinput[$el], $text);
+            } elseif ($this->inimage) {
+                $this->concat(
+                    $this->image[$el], $text);
+            } elseif ($this->inchannel) {
+                $this->concat(
+                    $this->channel[$el], $text);
+            }
+
+        }
+    }
+
+    function feed_cdata($p, $text)
+    {
+        if ($this->feed_type == ATOM and $this->incontent) {
+            $this->append_content($text);
+        } else {
+            $current_el = join('_', array_reverse($this->stack));
+            $this->append($current_el, $text);
+        }
+    }
+
+    function feed_end_element($p, $el)
+    {
+        $el = strtolower($el);
+
+        if ($el == 'item' or $el == 'entry') {
+            $this->items[] = $this->current_item;
+            $this->current_item = array();
+            $this->initem = false;
+        } elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'textinput') {
+            $this->intextinput = false;
+        } elseif ($this->feed_type == RSS and $this->current_namespace == '' and $el == 'image') {
+            $this->inimage = false;
+        } elseif ($this->feed_type == ATOM and in_array($el, $this->_CONTENT_CONSTRUCTS)) {
+            $this->incontent = false;
+        } elseif ($el == 'channel' or $el == 'feed') {
+            $this->inchannel = false;
+        } elseif ($this->feed_type == ATOM and $this->incontent) {
+            // balance tags properly
+            // note:  i don't think this is actually neccessary
+            if ($this->stack[0] == $el) {
+                $this->append_content("</$el>");
+            } else {
+                $this->append_content("<$el />");
+            }
+
+            array_shift($this->stack);
+        } else {
+            array_shift($this->stack);
+        }
+
+        $this->current_namespace = false;
+    }
+
+
 } // end class RSS
 
-function map_attrs($k, $v) {
+function map_attrs($k, $v)
+{
     return "$k=\"$v\"";
 }
 
@@ -587,19 +555,21 @@ function map_attrs($k, $v) {
 // courtesy, Ryan Currie, ryan@digibliss.com
 
 if (!function_exists('array_change_key_case')) {
-	define("CASE_UPPER",1);
-	define("CASE_LOWER",0);
+    define("CASE_UPPER", 1);
+    define("CASE_LOWER", 0);
 
 
-	function array_change_key_case($array,$case=CASE_LOWER) {
-       if ($case=CASE_LOWER) $cmd=strtolower;
-       elseif ($case=CASE_UPPER) $cmd=strtoupper;
-       foreach($array as $key=>$value) {
-               $output[$cmd($key)]=$value;
-       }
-       return $output;
-	}
+    function array_change_key_case($array, $case = CASE_LOWER)
+    {
+        if ($case = CASE_LOWER) {
+            $cmd = strtolower;
+        } elseif ($case = CASE_UPPER) {
+            $cmd = strtoupper;
+        }
+        foreach ($array as $key => $value) {
+            $output[$cmd($key)] = $value;
+        }
+        return $output;
+    }
 
 }
-
-?>

--- a/dependencies/paybox/payboxv2.inc
+++ b/dependencies/paybox/payboxv2.inc
@@ -1,786 +1,868 @@
 <?php
 
-class paybox {
+class paybox
+{
 
 // Variables privées
-var $site;
-var $rang;
-var $total;
-var $cmd;
-var $porteur;
+    var $site;
+    var $rang;
+    var $total;
+    var $cmd;
+    var $porteur;
 
-var $effectue;
-var $repondreA;
-var $refuse;
-var $annule;
-var $erreur;
+    var $effectue;
+    var $repondreA;
+    var $refuse;
+    var $annule;
+    var $erreur;
 
-var $opt;
-var $langue;
-var $devise;
-var $identifiant;
+    var $opt;
+    var $langue;
+    var $devise;
+    var $identifiant;
 
-var $output;
-var $txt;
-var $wait;
-var $boutpi;
-var $bkgd;
+    var $output;
+    var $txt;
+    var $wait;
+    var $boutpi;
+    var $bkgd;
 
-var $date;
+    var $date;
 
 // constructeur et initialiseur
-function __construct() {
-    $this->site = 'Aucun site';
-    $this->rang = 'Aucun rang';
-    $this->total = 'Aucun total';
-    $this->cmd = 'Aucune commande';
-    $this->porteur = 'Aucun porteur';
-    $this->effectue = '';
-    $this->refuse = '';
-    $this->annule = '';
-    $this->erreur = '';
-    $this->opt = '';
-    $this->langue = 'FRA';
-    $this->devise = 978;
-    $this->identifiant = '';
-    $this->annule = '';
-    $this->erreur = '';
-    $this->date = '';
-}
+    function __construct()
+    {
+        $this->site = 'Aucun site';
+        $this->rang = 'Aucun rang';
+        $this->total = 'Aucun total';
+        $this->cmd = 'Aucune commande';
+        $this->porteur = 'Aucun porteur';
+        $this->effectue = '';
+        $this->refuse = '';
+        $this->annule = '';
+        $this->erreur = '';
+        $this->opt = '';
+        $this->langue = 'FRA';
+        $this->devise = 978;
+        $this->identifiant = '';
+        $this->annule = '';
+        $this->erreur = '';
+        $this->date = '';
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_SITE
 ////////////////////////////////////////////////////////////////
-function set_site($site) {
-    // Variable exactement égale à 7 chiffres
-    $erreur = paybox::check_site($site);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_SITE', $erreur);
-        return;
-    }
-    $this->site = $site;
-    return true;
-}
 
-function check_site($site) {
-    if (7 != strlen($site)) {
-        return "IBS_SITE: Longueur de la variable incorrecte: il faut 7 "
-               . "chiffres.";
-    }
-    if (preg_match('/[^0-9]/', $site)) {
-        return "IBS_SITE : Caractère(s) incorrect(s). Le site ne doit "
-               . "contenir que des chiffres.";
-    }
-    if (!preg_match('/^\d{7}$/', $site)) {
-        return "IBS_SITE: Caractère(s) incorrect(s). Le site ne doit "
-               . "contenir que des chiffres.";
-    }
-    return true;
-}
+function paiement()
+    {
+        $ancien = error_reporting(0);
+        // on impose le mode ?
+        $commande = "PBX_MODE=4 ";
+        $site = $this->get_site();
+        $erreur = paybox::check_site($site);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $commande .= "PBX_SITE=" . escapeshellarg($site) . " ";
+        $rang = $this->get_rang();
+        $erreur = paybox::check_rang($rang);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $commande .= "PBX_RANG=" . escapeshellarg($rang) . " ";
+        $total = $this->get_total();
+        $erreur = paybox::check_total($total);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $commande .= "PBX_TOTAL=" . escapeshellarg($total) . " ";
+        $cmd = $this->get_cmd();
+        $erreur = paybox::check_cmd($cmd);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $devise = $this->get_devise();
+        if ('' != $devise) {
+            $erreur = paybox::check_devise($devise);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_DEVISE=$devise ";
+        }
+        $identifiant = $this->get_identifiant();
+        if ('' != $identifiant) {
+            $erreur = paybox::check_identifiant($identifiant);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_IDENTIFIANT=$identifiant ";
+        }
+        $commande .= "PBX_CMD=" . escapeshellarg($cmd) . " ";
+        $porteur = $this->get_porteur();
+        $erreur = paybox::check_porteur($porteur);
+        if (is_string($erreur)) {
+            return $erreur;
+        }
+        $commande .= "PBX_PORTEUR=\"$porteur\" ";
+        $effectue = $this->get_effectue();
+        if ('' != $effectue) {
+            $erreur = paybox::check_effectue($effectue);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_EFFECTUE=" . escapeshellarg($effectue) . " ";
+        }
+        $repondreA = $this->get_repondreA();
+        if ('' != $repondreA) {
+            $erreur = paybox::check_repondreA($repondreA);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_REPONDRE_A=" . escapeshellarg($repondreA) . " ";
+        }
+        $refuse = $this->get_refuse();
+        if ('' != $refuse) {
+            $erreur = paybox::check_refuse($refuse);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_REFUSE=" . escapeshellarg($refuse) . " ";
+        }
+        $annule = $this->get_annule();
+        if ('' != $annule) {
+            $erreur = paybox::check_annule($annule);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_ANNULE=" . escapeshellarg($annule) . " ";
+        }
+        $opt = $this->get_output();
+        if ('' != $opt) {
+            $erreur = paybox::check_output($opt);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_OPT=" . escapeshellarg($opt) . " ";
+        }
 
-function get_site() {
-    return($this->site);
-}
+        $txt = $this->get_txt();
+        if ('' != $txt) {
+            $erreur = paybox::check_txt($txt);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_TXT=" . escapeshellarg($txt) . " ";
+        }
+        $wait = $this->get_wait();
+        if ('' != $wait) {
+            $erreur = paybox::check_wait($wait);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_WAIT=" . escapeshellarg($wait) . " ";
+        }
+        $boutpi = $this->get_boutpi();
+        if ('' != $boutpi) {
+            $erreur = paybox::check_boutpi($boutpi);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_BOUTPI=" . escapeshellarg($boutpi) . " ";
+        }
+        $bkgd = $this->get_bkgd();
+        if ('' != $bkgd) {
+            $erreur = paybox::check_bkgd($bkgd);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_BKGD=" . escapeshellarg($bkgd) . " ";
+        }
+        $erreur = $this->get_erreur();
+        if ('' != $erreur) {
+            $lerreur = paybox::check_erreur($erreur);
+            if (is_string($lerreur)) {
+                return $lerreur;
+            }
+            $commande .= "PBX_ERREUR=" . escapeshellarg($erreur) . " ";
+        }
+        $langue = $this->get_langue();
+        if ('' != $langue) {
+            $erreur = paybox::check_langue($langue);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_LANGUE=" . escapeshellarg($langue) . " ";
+        }
+        $date = $this->get_date();
+        if ('' != $date) {
+            $erreur = paybox::check_date($date);
+            if (is_string($erreur)) {
+                return $erreur;
+            }
+            $commande .= "PBX_DATE=" . escapeshellarg($date) . " ";
+        }
+
+// ca finalise la commande...
+        $commande .= 'IBS_RETOUR="total:M;cmd:R;autorisation:A;transaction:T;status:E" ';
+        // ajouter l'operateur @, car on ne veut aucun rapport d'erreur
+        $exe = ('' == $this->identifiant) ? 'paybox' : 'payboxV2';
+        if ($_SERVER['DOCUMENT_ROOT'] == '/var/www/afup.org/htdocs') {
+            // Ancien serveur
+            $x = shell_exec('/usr/php_exec_dir/' . $exe . ' ' . $commande);
+        } else {
+            // Nouveau serveur
+            $x = shell_exec('/usr/lib/cgi-bin/paybox.cgi ' . $commande);
+        }
+        $return = trim(preg_replace('/^.*?<html>/is', '<html>', $x));
+        $error_level = error_reporting($ancien);
+        return $return;
+    }
+
+    function get_site()
+    {
+        return ($this->site);
+    }
+
+    function set_site($site)
+    {
+        // Variable exactement égale à 7 chiffres
+        $erreur = paybox::check_site($site);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_SITE', $erreur);
+            return;
+        }
+        $this->site = $site;
+        return true;
+    }
 
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_RANG
 ////////////////////////////////////////////////////////////////
-function set_rang($rang) {
-    // Variable exactement égale à 2 ou 3 chiffres
-    $erreur = paybox::check_rang($rang);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_RANG', $erreur);
-        return;
-    }
-    $this->rang = $rang;
-}
 
-function check_rang($rang) {
-    if (2 > strlen($rang) || 4 < strlen($rang)) {
-        return "IBS_RANG: Longueur de la variable incorrecte. (2 chiffres "
-               . "pour les tests | 3 chiffres en prod).";
+    function check_site($site)
+    {
+        if (7 != strlen($site)) {
+            return "IBS_SITE: Longueur de la variable incorrecte: il faut 7 "
+                . "chiffres.";
+        }
+        if (preg_match('/[^0-9]/', $site)) {
+            return "IBS_SITE : Caractère(s) incorrect(s). Le site ne doit "
+                . "contenir que des chiffres.";
+        }
+        if (!preg_match('/^\d{7}$/', $site)) {
+            return "IBS_SITE: Caractère(s) incorrect(s). Le site ne doit "
+                . "contenir que des chiffres.";
+        }
+        return true;
     }
-    if (!preg_match('/^\d{2,3}$/', $rang)) {
-        return "IBS_RANG: Caractère(s) incorrect(s). Le rang ne doit "
-               . "contenir que des chiffres.";
-    }
-    return true;
-}
 
-function get_rang() {
-    return($this->rang);
-}
+    function paybox_erreur($var, $erreur)
+    {
+        print "Erreur lors de l'initialisation de la variable $var: $erreur";
+        exit;
+    }
+
+    function get_rang()
+    {
+        return ($this->rang);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_TOTAL
 ////////////////////////////////////////////////////////////////
-function set_total($total) {
-    $erreur = paybox::check_total($total);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_TOTAL', $erreur);
-        return;
-    }
-    $this->total = $total;
-}
 
-function check_total($total) {
-    // Variable comprise entre 3 et 10 chiffres
-    if (100 > $total) {
-        return "IBS_TOTAL: Le montant doit être au moins égal à 1 euro.";
+    function set_rang($rang)
+    {
+        // Variable exactement égale à 2 ou 3 chiffres
+        $erreur = paybox::check_rang($rang);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_RANG', $erreur);
+            return;
+        }
+        $this->rang = $rang;
     }
-    if ((1 > strlen($total)) || (10 < strlen($total))) {
-        return "IBS_TOTAL: Longeur de la variable incorrecte: il faut au "
-               . "moins 1 chiffre et au plus 10 chiffres.";
-    }
-    if (preg_match('/[^0-9]/', $total)) {
-        return "IBS_TOTAL: Caractère(s) incorrect(s). Le montant ne doit "
-               . "contenir que des chiffres, pas même de points. Il est "
-               . "exprimé en centimes d'euros.";
-    }
-    return true;
-}
 
-function get_total() {
-    return($this->total);
-}
+    function check_rang($rang)
+    {
+        if (2 > strlen($rang) || 4 < strlen($rang)) {
+            return "IBS_RANG: Longueur de la variable incorrecte. (2 chiffres "
+                . "pour les tests | 3 chiffres en prod).";
+        }
+        if (!preg_match('/^\d{2,3}$/', $rang)) {
+            return "IBS_RANG: Caractère(s) incorrect(s). Le rang ne doit "
+                . "contenir que des chiffres.";
+        }
+        return true;
+    }
+
+    function get_total()
+    {
+        return ($this->total);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_CMD
 ////////////////////////////////////////////////////////////////
-function set_cmd($cmd) {
-    $erreur = paybox::check_cmd($cmd);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_CMD', $erreur);
-        return;
-    }
-     $this->cmd = $cmd;
-}
 
-function check_cmd($cmd) {
-    if (1 > strlen($cmd)) {
-        return "IBS_CMD: La longueur de la commande est trop petite.";
+    function set_total($total)
+    {
+        $erreur = paybox::check_total($total);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_TOTAL', $erreur);
+            return;
+        }
+        $this->total = $total;
     }
-    if (250 < strlen($cmd)) {
-        return "IBS_CMD: La longueur de la commande est trop grande "
-	       . "(255 caractères maximum).";
-    }
-    if (preg_match('/[^a-z0-9\- :;_\.]/is', $cmd)) {
-        return "IBS_CMD: la commande peut contenir des lettres, chiffres, "
-	       . "soulignés, tirets, points, deux-points et points-virgules.";
-    }
-    return true;
-}
 
-function get_cmd() {
-    return($this->cmd);
-}
+    function check_total($total)
+    {
+        // Variable comprise entre 3 et 10 chiffres
+        if (100 > $total) {
+            return "IBS_TOTAL: Le montant doit être au moins égal à 1 euro.";
+        }
+        if ((1 > strlen($total)) || (10 < strlen($total))) {
+            return "IBS_TOTAL: Longeur de la variable incorrecte: il faut au "
+                . "moins 1 chiffre et au plus 10 chiffres.";
+        }
+        if (preg_match('/[^0-9]/', $total)) {
+            return "IBS_TOTAL: Caractère(s) incorrect(s). Le montant ne doit "
+                . "contenir que des chiffres, pas même de points. Il est "
+                . "exprimé en centimes d'euros.";
+        }
+        return true;
+    }
+
+    function get_cmd()
+    {
+        return ($this->cmd);
+    }
 
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_PORTEUR
 ////////////////////////////////////////////////////////////////
-function set_porteur($porteur) {
-    $erreur = paybox::check_porteur($porteur);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_PORTEUR', $erreur);
-        return;
-    }
-    $this->porteur = $porteur;
-}
 
-function check_porteur($porteur) {
-    if (5 > strlen($porteur)) {
-        return "L'adresse du porteur est trop courte. Elle doit comporter au "
-               . "moins 5 caractères.";
+    function set_cmd($cmd)
+    {
+        $erreur = paybox::check_cmd($cmd);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_CMD', $erreur);
+            return;
+        }
+        $this->cmd = $cmd;
     }
-    if (80 < strlen($porteur)) {
-        return "L'adresse du porteur est trop longue. Elle doit comporter au "
-               . "plus 80 caractères.";
-    }
-    if (preg_match('/[^a-z0-9\- :;_\.@+]/is', $porteur)) {
-        return "IBS_PORTEUR: la commande peut contenir des lettres, chiffres, "
-               . "soulignés, tirets, deux-points, points-virgules ou "
-               . "arobases (@).";
-    }
-    return true;
-}
 
-function get_porteur() {
-    return($this->porteur);
-}
-
-/*
-////////////////////////////////////////////////////////////////
-// Gestion de la variable IBS_RETOUR
-////////////////////////////////////////////////////////////////
-function set_retour($retour) {
-    // Variable de 3 a 150 caracteres
-    if ((strlen($retour) < 3) || (strlen($retour) > 150)) {
-        $this->paybox_erreur("IBS_RETOUR","Longueur de la variable incorrecte. (au moins 3 caracteres et au plus 150 caracteres).");
+    function check_cmd($cmd)
+    {
+        if (1 > strlen($cmd)) {
+            return "IBS_CMD: La longueur de la commande est trop petite.";
+        }
+        if (250 < strlen($cmd)) {
+            return "IBS_CMD: La longueur de la commande est trop grande "
+                . "(255 caractères maximum).";
+        }
+        if (preg_match('/[^a-z0-9\- :;_\.]/is', $cmd)) {
+            return "IBS_CMD: la commande peut contenir des lettres, chiffres, "
+                . "soulignés, tirets, points, deux-points et points-virgules.";
+        }
+        return true;
     }
-    $this->retour = $retour;
-}
 
-function get_retour() {
-    return($this->retour);
-}
-*/
+    function get_devise()
+    {
+        return ($this->devise);
+    }
 
-////////////////////////////////////////////////////////////////
-// Gestion de la variable IBS_EFFECTUE
-////////////////////////////////////////////////////////////////
-function set_effectue($effectue) {
-    $erreur = paybox::check_effectue($effectue);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_EFFECTUE', $erreur);
-        return;
+    /*
+    ////////////////////////////////////////////////////////////////
+    // Gestion de la variable IBS_RETOUR
+    ////////////////////////////////////////////////////////////////
+    function set_retour($retour) {
+        // Variable de 3 a 150 caracteres
+        if ((strlen($retour) < 3) || (strlen($retour) > 150)) {
+            $this->paybox_erreur("IBS_RETOUR","Longueur de la variable incorrecte. (au moins 3 caracteres et au plus 150 caracteres).");
+        }
+        $this->retour = $retour;
     }
-    $this->effectue = $effectue;
-}
 
-function check_effectue($effectue) {
-    if (12 > strlen($effectue)) {
-        return "L'adresse de la page de retour après succès est trop courte. "
-               . "Elle doit comporter au moins 12 caractères.";
+    function get_retour() {
+        return($this->retour);
     }
-    if (150 < strlen($effectue)) {
-        return "L'adresse de la page de retour après succès est trop longue. "
-               . "Elle doit comporter au plus 150 caractères.";
-    }
-    if (preg_match('/[\"\'$]/is', $effectue)) {
-        return "IBS_EFFECTUE: L'adresse ne doit pas contenir de guillemets "
-               . "ou de signe dollar.";
-    }
-    return true;
-}
-
-function get_effectue() {
-    return($this->effectue);
-}
+    */
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_EFFECTUE
 ////////////////////////////////////////////////////////////////
-function set_repondreA($repondreA) {
-    $erreur = paybox::check_repondreA($repondreA);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_REPONDRE_A', $erreur);
-        return;
-    }
-    $this->repondreA = $repondreA;
-}
 
-function check_repondreA($repondreA) {
-    if (12 > strlen($repondreA)) {
-        return "L'adresse de la page de retour serveur à serveur est trop courte. "
-        . "Elle doit comporter au moins 12 caractères.";
+    function set_devise($devise)
+    {
+        $lerreur = paybox::check_devise($devise);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_DEVISE', $lerreur);
+            return;
+        }
+        $this->devise = $devise;
     }
-    if (150 < strlen($repondreA)) {
-        return "L'adresse de la page de retour serveur à serveur est trop longue. "
-        . "Elle doit comporter au plus 150 caractères.";
-    }
-    if (preg_match('/[\"\'$]/is', $repondreA)) {
-        return "IBS_EFFECTUE: L'adresse ne doit pas contenir de guillemets "
-        . "ou de signe dollar.";
-    }
-    return true;
-}
 
-function get_repondreA() {
-    return($this->repondreA);
-}
+    function check_devise($devise)
+    {
+        if (!is_int($devise)) {
+            return "IBS_DEVISE ($devise): La devise doit être le code numérique de la "
+                . "monnaie considérée (norme ISO-4217). Exemple: 978 pour "
+                . "l'euro.";
+        }
+        return true;
+    }
+
+    function get_identifiant()
+    {
+        return ($this->identifiant);
+    }
+
+////////////////////////////////////////////////////////////////
+// Gestion de la variable IBS_EFFECTUE
+////////////////////////////////////////////////////////////////
+
+    function set_identifiant($identifiant)
+    {
+        $lerreur = paybox::check_identifiant($identifiant);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_IDENTIFIANT', $lerreur);
+            return;
+        }
+        $this->identifiant = $identifiant;
+    }
+
+    function check_identifiant($identifiant)
+    {
+        if (!preg_match('/[0-9]{1,9}$/', $identifiant)) {
+            return "IBS_IDENTIFIANT: L'identifiant est constitué de 1 à 9 "
+                . "chiffres. Il s'agit de l'identifiant qui vous a été "
+                . "communiqué par Paybox.";
+        }
+        return true;
+    }
+
+    function get_porteur()
+    {
+        return ($this->porteur);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_REFUSE
 ////////////////////////////////////////////////////////////////
-function set_refuse($refuse) {
-    $erreur = paybox::check_refuse($refuse);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_REFUSE', $erreur);
-        return;
-    }
-    $this->refuse = $refuse;
-}
 
-function check_refuse($refuse) {
-    if (12 > strlen($refuse)) {
-        return "L'adresse de la page de retour après paiement refusé est "
-               . "trop courte. Elle doit comporter au moins 12 caractères.";
+    function set_porteur($porteur)
+    {
+        $erreur = paybox::check_porteur($porteur);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_PORTEUR', $erreur);
+            return;
+        }
+        $this->porteur = $porteur;
     }
-    if (150 < strlen($refuse)) {
-        return "L'adresse de la page de retour apres paiement refusé est "
-               . "trop longue. Elle doit comporter au plus 150 caractères.";
-    }
-    if (preg_match('/[\"\'$]/is', $refuse)) {
-        return "IBS_REFUSE: L'adresse ne doit pas contenir de guillemets ou "
-               . "de signe dollar.";
-    }
-    return true;
-}
 
-function get_refuse() {
-    return($this->refuse);
-}
+    function check_porteur($porteur)
+    {
+        if (5 > strlen($porteur)) {
+            return "L'adresse du porteur est trop courte. Elle doit comporter au "
+                . "moins 5 caractères.";
+        }
+        if (80 < strlen($porteur)) {
+            return "L'adresse du porteur est trop longue. Elle doit comporter au "
+                . "plus 80 caractères.";
+        }
+        if (preg_match('/[^a-z0-9\- :;_\.@+]/is', $porteur)) {
+            return "IBS_PORTEUR: la commande peut contenir des lettres, chiffres, "
+                . "soulignés, tirets, deux-points, points-virgules ou "
+                . "arobases (@).";
+        }
+        return true;
+    }
+
+    function get_effectue()
+    {
+        return ($this->effectue);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_ANNULE
 ////////////////////////////////////////////////////////////////
-function set_annule($annule) {
-    $erreur = paybox::check_annule($annule);
-    if (is_string($erreur)) {
-        $this->paybox_erreur('IBS_ANNULE', $erreur);
-        return;
-    }
-    $this->annule = $annule;
-}
 
-function check_annule($annule) {
-    if (12 > strlen($annule)) {
-        return "L'adresse de la page de retour après paiement annulé est "
-               . "trop courte. Elle doit comporter au moins 12 caractères.";
+    function set_effectue($effectue)
+    {
+        $erreur = paybox::check_effectue($effectue);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_EFFECTUE', $erreur);
+            return;
+        }
+        $this->effectue = $effectue;
     }
-    if (150 < strlen($annule)) {
-        return "L'adresse de la page de retour apres paiement annulé est "
-               . "trop longue. Elle doit comporter au plus 150 caractères.";
-    }
-    if (preg_match('/[\"\'$]/is', $annule)) {
-        return "IBS_ANNULE: L'adresse ne doit pas contenir de guillemets ou "
-               . "de signe dollar.";
-    }
-    return true;
-}
 
-function get_annule() {
-    return($this->annule);
-}
+    function check_effectue($effectue)
+    {
+        if (12 > strlen($effectue)) {
+            return "L'adresse de la page de retour après succès est trop courte. "
+                . "Elle doit comporter au moins 12 caractères.";
+        }
+        if (150 < strlen($effectue)) {
+            return "L'adresse de la page de retour après succès est trop longue. "
+                . "Elle doit comporter au plus 150 caractères.";
+        }
+        if (preg_match('/[\"\'$]/is', $effectue)) {
+            return "IBS_EFFECTUE: L'adresse ne doit pas contenir de guillemets "
+                . "ou de signe dollar.";
+        }
+        return true;
+    }
+
+    function get_repondreA()
+    {
+        return ($this->repondreA);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_ERREUR
 ////////////////////////////////////////////////////////////////
-function set_erreur($erreur) {
-    $lerreur = paybox::check_erreur($erreur);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_ANNULE', $lerreur);
-        return;
-    }
-    $this->erreur = $erreur;
-}
 
-function check_erreur($erreur) {
-    if (12 > strlen($erreur)) {
-        return "L'adresse de la page de retour après erreur est trop "
-               . "courte. Elle doit comporter au moins 12 caractères.";
+    function set_repondreA($repondreA)
+    {
+        $erreur = paybox::check_repondreA($repondreA);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_REPONDRE_A', $erreur);
+            return;
+        }
+        $this->repondreA = $repondreA;
     }
-    if (150 < strlen($erreur)) {
-        return "L'adresse de la page de retour après erreur est trop "
-               . "longue. Elle doit comporter au plus 150 caractères.";
-    }
-    if (preg_match('/[\"\'$]/is', $erreur)) {
-        return "IBS_ERREUR: L'adresse ne doit pas contenir de guillemets ou "
-               . "de signe dollar.";
-    }
-    return true;
-}
 
-function get_erreur() {
-    return($this->erreur);
-}
+    function check_repondreA($repondreA)
+    {
+        if (12 > strlen($repondreA)) {
+            return "L'adresse de la page de retour serveur à serveur est trop courte. "
+                . "Elle doit comporter au moins 12 caractères.";
+        }
+        if (150 < strlen($repondreA)) {
+            return "L'adresse de la page de retour serveur à serveur est trop longue. "
+                . "Elle doit comporter au plus 150 caractères.";
+        }
+        if (preg_match('/[\"\'$]/is', $repondreA)) {
+            return "IBS_EFFECTUE: L'adresse ne doit pas contenir de guillemets "
+                . "ou de signe dollar.";
+        }
+        return true;
+    }
+
+    function get_refuse()
+    {
+        return ($this->refuse);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_OUTPUT
 ////////////////////////////////////////////////////////////////
-function set_output($output) {
-    $lerreur = paybox::check_output($output);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_OUTPUT', $lerreur);
-        return;
-    }
-    $this->output = $output;
-}
 
-function check_output($output) {
-    if (!in_array($output, array('A','B','C','D','E'))) {
-        return "IBS_OUTPUT: le type de retour doit être A, B, C, D ou E. "
-               . "Consultez la documentation Paybox pour plus de détails.";
+    function set_refuse($refuse)
+    {
+        $erreur = paybox::check_refuse($refuse);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_REFUSE', $erreur);
+            return;
+        }
+        $this->refuse = $refuse;
     }
-    return true;
-}
 
-function get_output() {
-    return($this->output);
-}
+    function check_refuse($refuse)
+    {
+        if (12 > strlen($refuse)) {
+            return "L'adresse de la page de retour après paiement refusé est "
+                . "trop courte. Elle doit comporter au moins 12 caractères.";
+        }
+        if (150 < strlen($refuse)) {
+            return "L'adresse de la page de retour apres paiement refusé est "
+                . "trop longue. Elle doit comporter au plus 150 caractères.";
+        }
+        if (preg_match('/[\"\'$]/is', $refuse)) {
+            return "IBS_REFUSE: L'adresse ne doit pas contenir de guillemets ou "
+                . "de signe dollar.";
+        }
+        return true;
+    }
+
+    function get_annule()
+    {
+        return ($this->annule);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_LANGUE
 ////////////////////////////////////////////////////////////////
-function set_langue($langue) {
-    $lerreur = paybox::check_langue($langue);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_LANGUE', $lerreur);
-        return;
-    }
-    $this->langue = $langue;
-}
 
-function check_langue($langue) {
-    if (!in_array($langue, array("FRA","GBR","ESP","ITA","DEU"))) {
-        return "IBS_LANGUE: le type de langue doit être 'FRA', 'GBR', "
-               . "'ESP', 'ITA' ou 'DEU'. Consultez la documentation Paybox "
-               . "pour plus de détails.";
+    function set_annule($annule)
+    {
+        $erreur = paybox::check_annule($annule);
+        if (is_string($erreur)) {
+            $this->paybox_erreur('IBS_ANNULE', $erreur);
+            return;
+        }
+        $this->annule = $annule;
     }
-    return true;
-}
 
-function get_langue() {
-    return($this->langue);
-}
+    function check_annule($annule)
+    {
+        if (12 > strlen($annule)) {
+            return "L'adresse de la page de retour après paiement annulé est "
+                . "trop courte. Elle doit comporter au moins 12 caractères.";
+        }
+        if (150 < strlen($annule)) {
+            return "L'adresse de la page de retour apres paiement annulé est "
+                . "trop longue. Elle doit comporter au plus 150 caractères.";
+        }
+        if (preg_match('/[\"\'$]/is', $annule)) {
+            return "IBS_ANNULE: L'adresse ne doit pas contenir de guillemets ou "
+                . "de signe dollar.";
+        }
+        return true;
+    }
+
+    function get_output()
+    {
+        return ($this->output);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_DEVISE
 ////////////////////////////////////////////////////////////////
-function set_devise($devise) {
-    $lerreur = paybox::check_devise($devise);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_DEVISE', $lerreur);
-        return;
-    }
-    $this->devise = $devise;
-}
 
-function check_devise($devise) {
-    if (!is_int($devise)) {
-        return "IBS_DEVISE ($devise): La devise doit être le code numérique de la "
-               . "monnaie considérée (norme ISO-4217). Exemple: 978 pour "
-               . "l'euro.";
+    function set_output($output)
+    {
+        $lerreur = paybox::check_output($output);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_OUTPUT', $lerreur);
+            return;
+        }
+        $this->output = $output;
     }
-    return true;
-}
 
-function get_devise() {
-    return($this->devise);
-}
+    function check_output($output)
+    {
+        if (!in_array($output, array('A', 'B', 'C', 'D', 'E'))) {
+            return "IBS_OUTPUT: le type de retour doit être A, B, C, D ou E. "
+                . "Consultez la documentation Paybox pour plus de détails.";
+        }
+        return true;
+    }
+
+    function get_txt()
+    {
+        return ($this->txt);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_IDENTIFIANT
 ////////////////////////////////////////////////////////////////
-function set_identifiant($identifiant) {
-    $lerreur = paybox::check_identifiant($identifiant);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_IDENTIFIANT', $lerreur);
-        return;
-    }
-    $this->identifiant = $identifiant;
-}
 
-function check_identifiant($identifiant) {
-    if (!preg_match('/[0-9]{1,9}$/', $identifiant)) {
-        return "IBS_IDENTIFIANT: L'identifiant est constitué de 1 à 9 "
-	       . "chiffres. Il s'agit de l'identifiant qui vous a été "
-	       . "communiqué par Paybox.";
+    function set_txt($txt)
+    {
+        $lerreur = paybox::check_txt($txt);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_TXT', $lerreur);
+            return;
+        }
+        $this->txt = $txt;
     }
-    return true;
-}
 
-function get_identifiant() {
-    return($this->identifiant);
-}
+    function check_txt($erreur)
+    {
+        return true;
+    }
+
+    function get_wait()
+    {
+        return ($this->wait);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_TXT
 ////////////////////////////////////////////////////////////////
-function set_txt($txt) {
-    $lerreur = paybox::check_txt($txt);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_TXT', $lerreur);
-        return;
+
+    function set_wait($wait)
+    {
+        $lerreur = paybox::check_wait($wait);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_WAIT', $lerreur);
+            return;
+        }
+        $this->wait = $wait;
     }
-    $this->txt = $txt;
-}
 
-function check_txt($erreur) {
-    return true;
-}
+    function check_wait($wait)
+    {
+        if (5 < strlen($wait)) {
+            return "La durée d'attente du formulaire est trop longue. Elle ne "
+                . "doit pas excéder 5 caractères.";
+        }
+        if (preg_match('/[^0-9]/is', $wait)) {
+            return "IBS_WAIT: La durée ne doit comporter que des chiffres.";
+        }
+        return true;
+    }
 
-function get_txt() {
-    return($this->txt);
-}
+    function get_boutpi()
+    {
+        return ($this->boutpi);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_WAIT
 ////////////////////////////////////////////////////////////////
-function set_wait($wait) {
-    $lerreur = paybox::check_wait($wait);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_WAIT', $lerreur);
-        return;
-    }
-    $this->wait = $wait;
-}
 
-function check_wait($wait) {
-    if (5 < strlen($wait)) {
-        return "La durée d'attente du formulaire est trop longue. Elle ne "
-               . "doit pas excéder 5 caractères.";
+    function set_boutpi($boutpi)
+    {
+        $lerreur = paybox::check_boutpi($boutpi);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_BOUTPI', $lerreur);
+            return;
+        }
+        $this->boutpi = $boutpi;
     }
-    if (preg_match('/[^0-9]/is', $wait)) {
-        return "IBS_WAIT: La durée ne doit comporter que des chiffres.";
-    }
-    return true;
-}
 
-function get_wait() {
-    return($this->wait);
-}
+    function check_boutpi($boutpi)
+    {
+        if (50 < strlen($boutpi)) {
+            return "Le message du bouton du formulaire est trop long. Il ne doit "
+                . "pas excéder 50 caractères.";
+        }
+        return true;
+    }
+
+    function get_bkgd()
+    {
+        return ($this->bkgd);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_BOUTPI
 ////////////////////////////////////////////////////////////////
-function set_boutpi($boutpi) {
-    $lerreur = paybox::check_boutpi($boutpi);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_BOUTPI', $lerreur);
-        return;
-    }
-    $this->boutpi = $boutpi;
-}
 
-function check_boutpi($boutpi) {
-    if (50 < strlen($boutpi)) {
-        return "Le message du bouton du formulaire est trop long. Il ne doit "
-               . "pas excéder 50 caractères.";
+    function set_bkgd($bkgd)
+    {
+        $lerreur = paybox::check_bkgd($bkgd);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_BKGD', $lerreur);
+            return;
+        }
+        $this->bkgd = $bkgd;
     }
-    return true;
-}
 
-function get_boutpi() {
-    return($this->boutpi);
-}
+    function check_bkgd($bkgd)
+    {
+        if (150 < strlen($bkgd)) {
+            return "Le nom de la couleur de fond du formulaire est trop long. "
+                . "Il ne doit pas excéder 150 caractères.";
+        }
+        return true;
+    }
+
+    function get_erreur()
+    {
+        return ($this->erreur);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_BKGD
 ////////////////////////////////////////////////////////////////
-function set_bkgd($bkgd) {
-    $lerreur = paybox::check_bkgd($bkgd);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_BKGD', $lerreur);
-        return;
-    }
-    $this->bkgd = $bkgd;
-}
 
-function check_bkgd($bkgd) {
-    if (150 < strlen($bkgd)) {
-        return "Le nom de la couleur de fond du formulaire est trop long. "
-               . "Il ne doit pas excéder 150 caractères.";
+    function set_erreur($erreur)
+    {
+        $lerreur = paybox::check_erreur($erreur);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_ANNULE', $lerreur);
+            return;
+        }
+        $this->erreur = $erreur;
     }
-    return true;
-}
 
-function get_bkgd() {
-    return($this->bkgd);
-}
+    function check_erreur($erreur)
+    {
+        if (12 > strlen($erreur)) {
+            return "L'adresse de la page de retour après erreur est trop "
+                . "courte. Elle doit comporter au moins 12 caractères.";
+        }
+        if (150 < strlen($erreur)) {
+            return "L'adresse de la page de retour après erreur est trop "
+                . "longue. Elle doit comporter au plus 150 caractères.";
+        }
+        if (preg_match('/[\"\'$]/is', $erreur)) {
+            return "IBS_ERREUR: L'adresse ne doit pas contenir de guillemets ou "
+                . "de signe dollar.";
+        }
+        return true;
+    }
+
+    function get_langue()
+    {
+        return ($this->langue);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion de la variable IBS_DATE
 ////////////////////////////////////////////////////////////////
-function set_date($date) {
-    $lerreur = paybox::check_date($date);
-    if (is_string($lerreur)) {
-        $this->paybox_erreur('IBS_DATE', $lerreur);
-        return;
-    }
-    // Date au format JJ/MM/AAAA HH:MM:SS
-    $this->date = $date;
-}
 
-function check_date($date) {
-    if (preg_match('/^\d\d\/\d\d\/\d\d\d\d \d\d:\d\d:\d\d$/is', $date)) {
-        return "IBS_DATE: le format est incorrect. Le format attendu "
-               . "est: 'JJ/MM/AAAA hh:mm:ss'.";
+    function set_langue($langue)
+    {
+        $lerreur = paybox::check_langue($langue);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_LANGUE', $lerreur);
+            return;
+        }
+        $this->langue = $langue;
     }
-    return true;
-}
 
-function get_date() {
-    return($this->date);
-}
+    function check_langue($langue)
+    {
+        if (!in_array($langue, array("FRA", "GBR", "ESP", "ITA", "DEU"))) {
+            return "IBS_LANGUE: le type de langue doit être 'FRA', 'GBR', "
+                . "'ESP', 'ITA' ou 'DEU'. Consultez la documentation Paybox "
+                . "pour plus de détails.";
+        }
+        return true;
+    }
+
+    function get_date()
+    {
+        return ($this->date);
+    }
 
 ////////////////////////////////////////////////////////////////
 // Gestion des erreurs
 ////////////////////////////////////////////////////////////////
-function paybox_erreur($var, $erreur) {
-    print "Erreur lors de l'initialisation de la variable $var: $erreur";
-    exit;
-}
+
+    function set_date($date)
+    {
+        $lerreur = paybox::check_date($date);
+        if (is_string($lerreur)) {
+            $this->paybox_erreur('IBS_DATE', $lerreur);
+            return;
+        }
+        // Date au format JJ/MM/AAAA HH:MM:SS
+        $this->date = $date;
+    }
 
 
 ////////////////////////////////////////////////////////////////
 // Lancement de la requête vers Paybox
 ////////////////////////////////////////////////////////////////
-function paiement() {
-    $ancien = error_reporting(0);
-    // on impose le mode ?
-    $commande = "PBX_MODE=4 ";
-    $site = $this->get_site();
-    $erreur = paybox::check_site($site);
-    if (is_string($erreur)) {
-        return $erreur;
-    }
-    $commande .= "PBX_SITE=" . escapeshellarg($site) . " ";
-    $rang = $this->get_rang();
-    $erreur = paybox::check_rang($rang);
-    if (is_string($erreur)) {
-        return $erreur;
-    }
-    $commande .= "PBX_RANG=" . escapeshellarg($rang) . " ";
-    $total = $this->get_total();
-    $erreur = paybox::check_total($total);
-    if (is_string($erreur)) {
-        return $erreur;
-    }
-    $commande .= "PBX_TOTAL=" . escapeshellarg($total) . " ";
-    $cmd = $this->get_cmd();
-    $erreur = paybox::check_cmd($cmd);
-    if (is_string($erreur)) {
-        return $erreur;
-    }
-    $devise = $this->get_devise();
-    if ('' != $devise) {
-        $erreur = paybox::check_devise($devise);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_DEVISE=$devise ";
-    }
-    $identifiant = $this->get_identifiant();
-    if ('' != $identifiant) {
-        $erreur = paybox::check_identifiant($identifiant);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_IDENTIFIANT=$identifiant ";
-    }
-    $commande .= "PBX_CMD=" . escapeshellarg($cmd) . " ";
-    $porteur = $this->get_porteur();
-    $erreur = paybox::check_porteur($porteur);
-    if (is_string($erreur)) {
-        return $erreur;
-    }
-    $commande .= "PBX_PORTEUR=\"$porteur\" ";
-    $effectue = $this->get_effectue();
-    if ('' != $effectue) {
-        $erreur = paybox::check_effectue($effectue);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_EFFECTUE=" . escapeshellarg($effectue) . " ";
-    }
-    $repondreA = $this->get_repondreA();
-    if ('' != $repondreA) {
-        $erreur = paybox::check_repondreA($repondreA);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_REPONDRE_A=" . escapeshellarg($repondreA) . " ";
-    }
-    $refuse = $this->get_refuse();
-    if ('' != $refuse) {
-        $erreur = paybox::check_refuse($refuse);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_REFUSE=" . escapeshellarg($refuse) . " ";
-    }
-    $annule = $this->get_annule();
-    if ('' != $annule) {
-        $erreur = paybox::check_annule($annule);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_ANNULE=" . escapeshellarg($annule) . " ";
-    }
-    $opt = $this->get_output();
-    if ('' != $opt) {
-        $erreur = paybox::check_output($opt);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_OPT=" . escapeshellarg($opt) . " ";
-    }
 
-    $txt = $this->get_txt();
-    if ('' != $txt) {
-        $erreur = paybox::check_txt($txt);
-        if (is_string($erreur)) {
-            return $erreur;
+    function check_date($date)
+    {
+        if (preg_match('/^\d\d\/\d\d\/\d\d\d\d \d\d:\d\d:\d\d$/is', $date)) {
+            return "IBS_DATE: le format est incorrect. Le format attendu "
+                . "est: 'JJ/MM/AAAA hh:mm:ss'.";
         }
-        $commande .= "PBX_TXT=" . escapeshellarg($txt) . " ";
-    }
-    $wait = $this->get_wait();
-    if ('' != $wait) {
-        $erreur = paybox::check_wait($wait);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_WAIT=" . escapeshellarg($wait) . " ";
-    }
-    $boutpi = $this->get_boutpi();
-    if ('' != $boutpi) {
-        $erreur = paybox::check_boutpi($boutpi);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_BOUTPI=" . escapeshellarg($boutpi) . " ";
-    }
-    $bkgd = $this->get_bkgd();
-    if ('' != $bkgd) {
-        $erreur = paybox::check_bkgd($bkgd);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_BKGD=" . escapeshellarg($bkgd) . " ";
-    }
-    $erreur = $this->get_erreur();
-    if ('' != $erreur) {
-        $lerreur = paybox::check_erreur($erreur);
-        if (is_string($lerreur)) {
-            return $lerreur;
-        }
-        $commande .= "PBX_ERREUR=" . escapeshellarg($erreur) . " ";
-    }
-    $langue = $this->get_langue();
-    if ('' != $langue) {
-        $erreur = paybox::check_langue($langue);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_LANGUE=" . escapeshellarg($langue) . " ";
-    }
-    $date = $this->get_date();
-    if ('' != $date) {
-        $erreur = paybox::check_date($date);
-        if (is_string($erreur)) {
-            return $erreur;
-        }
-        $commande .= "PBX_DATE=" . escapeshellarg($date) . " ";
-    }
-
-// ca finalise la commande...
-    $commande .= 'IBS_RETOUR="total:M;cmd:R;autorisation:A;transaction:T;status:E" ';
-    // ajouter l'operateur @, car on ne veut aucun rapport d'erreur
-    $exe = ('' == $this->identifiant) ? 'paybox' : 'payboxV2';
-    if ($_SERVER['DOCUMENT_ROOT'] == '/var/www/afup.org/htdocs') {
-        // Ancien serveur
-        $x = shell_exec('/usr/php_exec_dir/' . $exe . ' ' . $commande);
-    } else {
-        // Nouveau serveur
-        $x = shell_exec('/usr/lib/cgi-bin/paybox.cgi ' . $commande);
-    }
-    $return = trim(preg_replace('/^.*?<html>/is', '<html>', $x));
-    $error_level = error_reporting($ancien);
-    return $return;
-} // paiement
+        return true;
+    } // paiement
 
 } // class paybox
 ?>


### PR DESCRIPTION
Lié à #768 
Changements :
* Reformatage du code
* Remplacement de `each` par `foreach`
* Mise à jour des constructeurs PHP 4
* Remplacement des utilisations de `$php_errormsg` par `error_get_last()`
* Remplacement de `split()` par `explode()` car l'usage dans le code ne nécessite pas une RegEx