### PR TITLE
on permet de s'auhentifier à l'api meetup en oauth

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -39,7 +39,9 @@ parameters:
     trello_token: ""
 
     google_maps_api_key: ""
-    meetup_api_key: ""
+
+    meetup_api_consumer_key: ""
+    meetup_api_consumer_secret: "
 
     google_groups_api_key: ""
 

--- a/app/config/parameters.yml.dist-docker
+++ b/app/config/parameters.yml.dist-docker
@@ -42,6 +42,10 @@ parameters:
     trello_token: ""
 
     google_maps_api_key: ""
+
+    meetup_api_consumer_key: ""
+    meetup_api_consumer_secret: "
+
     google_groups_api_key: ""
 
     techno_watch_calendar_url: "https://docs.google.com/spreadsheets/d/2cUeAk86Ov7BLYyn0Ad9ge3ecbsdboeQH64wIU9a9Zzp/export?format=csv"

--- a/sources/AppBundle/Command/IndexMeetupsCommand.php
+++ b/sources/AppBundle/Command/IndexMeetupsCommand.php
@@ -24,9 +24,14 @@ class IndexMeetupsCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $meetupClient = \DMS\Service\Meetup\MeetupKeyAuthClient::factory(['key' => $this->getContainer()->getParameter('meetup_api_key')]);
+        $container = $this->getContainer();
 
-        $runner = new Runner($this->getContainer()->get(\AlgoliaSearch\Client::class), $meetupClient);
+        $meetupClient = \DMS\Service\Meetup\MeetupOAuthClient::factory([
+            'consumer_key' => $container->getParameter('meetup_api_consumer_key'),
+            'consumer_secret' => $container->getParameter('meetup_api_consumer_secret'),
+        ]);
+
+        $runner = new Runner($container->get(\AlgoliaSearch\Client::class), $meetupClient);
         $runner->run();
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -5,6 +5,7 @@ namespace AppBundle\Indexation\Meetups;
 use AlgoliaSearch\Client;
 use AppBundle\Offices\OfficesCollection;
 use DMS\Service\Meetup\MeetupKeyAuthClient;
+use DMS\Service\Meetup\MeetupOAuthClient;
 
 class Runner
 {
@@ -32,7 +33,7 @@ class Runner
      * @param Client $algoliaClient
      * @param MeetupKeyAuthClient $meetupClient
      */
-    public function __construct(Client $algoliaClient, MeetupKeyAuthClient $meetupClient)
+    public function __construct(Client $algoliaClient, MeetupOAuthClient $meetupClient)
     {
         $this->algoliaClient = $algoliaClient;
         $this->meetupClient = $meetupClient;


### PR DESCRIPTION
l'authentification via clef d'API n'est plus autorisée. il faut donc passer par oauth pour récupérer les derniers meetups.