### PR TITLE
Meilleure gestion des notifications des événéments

### DIFF
--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -624,4 +624,9 @@ class Event implements NotifyPropertyInterface
 
         return $this;
     }
+
+    public function isAfupDay()
+    {
+        return substr($this->getTitle(), 0, 8) == 'AFUP Day';
+    }
 }

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -14,18 +14,29 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 class EventRepository extends Repository implements MetadataInitializer
 {
     /**
+     * @deprecated il y aura surement des soucis liés à l'AFUP Day en utilisant cette méthode
+     *
      * @return Event|null
      */
     public function getNextEvent()
     {
-        $query = $this
-            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut LIMIT 1')
-        ;
-        $events = $query->query($this->getCollection(new HydratorSingleObject()));
+        $events = $this->getNextEvents();
+
         if ($events->count() === 0) {
             return null;
         }
         return $events->first();
+    }
+
+    public function getNextEvents()
+    {
+        $query = $this
+            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut LIMIT 1')
+        ;
+
+        $events = $query->query($this->getCollection(new HydratorSingleObject()));
+
+        return $events;
     }
 
     public function getNextEventForGithubUser(GithubUser $githubUser)

--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -199,7 +199,7 @@ class MessageFactory
         $inscriptionsData = $inscriptions->obtenirStatistiques($event->getId());
         $message = new Message();
         $message
-            ->setChannel('pole-forum')
+            ->setChannel($event->isAfupDay() ? 'afupday' : 'test-cfp')
             ->setUsername($event->getTitle() . ' - Inscriptions')
             ->setIconUrl('https://pbs.twimg.com/profile_images/600291061144145920/Lpf3TDQm_400x400.png')
         ;
@@ -255,7 +255,7 @@ class MessageFactory
     {
         $message = new Message();
         $message
-            ->setChannel('pole-forum')
+            ->setChannel($event->isAfupDay() ? 'afupday' : 'pole-forum')
             ->setUsername('CFP')
             ->setIconUrl('https://pbs.twimg.com/profile_images/600291061144145920/Lpf3TDQm_400x400.png')
         ;


### PR DESCRIPTION
* Sur les AFUP Day on a plus besoin de créer autant de commandes que d'événements
* Les commandes de notification pour le CFP peuvent être planifiées toute l'année et on aura pas de notification selon la config de date de fin dans l'admin
* On publie automatiquement sur la bonne room selon si c'est un AFUP Day ou un Forum