### PR TITLE
BO : on évite de charger deux fois tablefilter sur le journal

### DIFF
--- a/htdocs/templates/administration/compta_journal.html
+++ b/htdocs/templates/administration/compta_journal.html
@@ -156,7 +156,6 @@
     <div class="js-upload-loader upload-loader" style="display: none;">
         <img class="loader" src="{$chemin_template}images/ajax-loader.gif" alt="Loading…" />
     </div>
-    <script src="/js_dist/admin.js"></script>
     {literal}
     <script>
         // Ventiler une ligne


### PR DESCRIPTION
On avait deux lignes de filtrage qui ne fonctionnaient pas et ça augmentait
le temps de chargement de la page (le js de l'admin était chargé à la
fois dans le template spécifique au journal et dans toutes les pages du bo).