### PR TITLE
Fichiers yaml invalides

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -41,7 +41,7 @@ parameters:
     google_maps_api_key: ""
 
     meetup_api_consumer_key: ""
-    meetup_api_consumer_secret: "
+    meetup_api_consumer_secret: ""
 
     google_groups_api_key: ""
 

--- a/app/config/parameters.yml.dist-docker
+++ b/app/config/parameters.yml.dist-docker
@@ -44,7 +44,7 @@ parameters:
     google_maps_api_key: ""
 
     meetup_api_consumer_key: ""
-    meetup_api_consumer_secret: "
+    meetup_api_consumer_secret: ""
 
     google_groups_api_key: ""
 


### PR DESCRIPTION
Les deux fichiers de conf (parameters.yml.dist et parameters.yml.dist-docker) sont invalides. Il manque un guillemet manquant pour la clé meetup_api_consumer_secret