### PR TITLE
On permet de facilement tester paybox en environnement de dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ Ensuite pour le paiement il faut utiliser ces informations [de carte](http://www
 * Validité : `12/20`
 * CVV : `123`
  
+## Callbacks de paiement
+
+### Après le paiement d'une cotisation
+
+Après le paiement paybox effectue un retour sur le serveur et c'est suite à ce retour que l'on effectue des actions comme l'ajout de la cotisation. Afin d'en simplifier l'appel il existe une commande dédiée qui s'appelle comme cela, où l'argument en exemple correspond à l'URL de la page de retour sur le site après paiement.  
+
+```
+bin/console dev:callback-paybox-cotisation "https://localhost:9206/pages/administration/paybox_effectue.php?total=3000&cmd=C2020-150120201239-0-770-GALLO-E4F&autorisation=XXXXXX&transaction=588033888&status=00000"
+```

--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ Config par défaut:
 - host: localhost
 - port: 3606
 - database: web
+
+# Paiements avec Paybox
+
+Il est possible de tester les paiements Paybox en environnement de développement.
+Pour cela, les identifiant, site et rang [de test](www1.paybox.com/espace-integrateur-documentation/comptes-de-tests/) sont déjà configurés dans le fichier de configuration par défaut.
+
+Ensuite pour le paiement il faut utiliser ces informations [de carte](http://www1.paybox.com/espace-integrateur-documentation/cartes-de-tests/) (celle _"Carte participant au programme 3-D Secure (enrôlée)"_) : 
+* Numéro de carte : `4012 0010 3714 1112`
+* Validité : `12/20`
+* CVV : `123`
+ 

--- a/configs/application/config.php.dist
+++ b/configs/application/config.php.dist
@@ -41,8 +41,10 @@ $configuration['paybox_prod']['site']='';
 $configuration['paybox_prod']['rang']='';
 $configuration['paybox_test']['site']='';
 $configuration['paybox_test']['rang']='';
-$configuration['paybox']['site']='';
-$configuration['paybox']['rang']='';
+$configuration['paybox']['site']='1999888';
+$configuration['paybox']['rang']='99';
+$configuration['paybox']['identifiant']='107904482';
+
 $configuration['planete']['pertinence']='php|afup|pear|pecl|symfony|copix|jelix|wampserver|simpletest|simplexml|zend|pmo|drupal|ovidentia|mvc|magento|chrome|spip|PDO|mock|cake|hiphop|CMS|Framework|typo3|photon|pattern';
 $configuration['site']['prefix']='pages/site/';
 $configuration['site']['query_prefix']='?route=';

--- a/configs/application/config.php.dist-docker
+++ b/configs/application/config.php.dist-docker
@@ -41,8 +41,10 @@ $configuration['paybox_prod']['site']='';
 $configuration['paybox_prod']['rang']='';
 $configuration['paybox_test']['site']='';
 $configuration['paybox_test']['rang']='';
-$configuration['paybox']['site']='';
-$configuration['paybox']['rang']='';
+$configuration['paybox']['site']='1999888';
+$configuration['paybox']['rang']='99';
+$configuration['paybox']['identifiant']='107904482';
+
 $configuration['planete']['pertinence']='php|afup|pear|pecl|symfony|copix|jelix|wampserver|simpletest|simplexml|zend|pmo|drupal|ovidentia|mvc|magento|chrome|spip|PDO|mock|cake|hiphop|CMS|Framework|typo3|photon|pattern';
 $configuration['site']['prefix']='pages/site/';
 $configuration['site']['query_prefix']='?route=';

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function GuzzleHttp\Psr7\parse_query;
+
+class DevCallBackPayboxCotisationCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $help = <<<EOF
+Cette commande simplifie l'appel au callback de paybox.
+Il faut dans le container l'appeller avec un argument comme celui-ci "ttps://localhost:9206/pages/administration/paybox_effectue.php?total=3000&cmd=C2020-150120200752-0-770-GALLO-DCB&autorisation=XXXXXX&transaction=587904761&status=00000"
+Il correspond à l'URL de la page de retour de paiement.
+EOF;
+
+        $this
+            ->setName('dev:callback-paybox-cotisation')
+            ->addArgument('url_paiement_effectue')
+            ->setHelp($help)
+        ;
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $parsedUrl = parse_url($input->getArgument('url_paiement_effectue'));
+
+        $query = $parsedUrl['query'];
+
+        $params = parse_query($query);
+
+        $callBackParameters = [
+            'total' => $params['total'],
+            'cmd' => $params['cmd'],
+            'autorisation' => $params['autorisation'],
+            'transaction' => $params['transaction'],
+            'status' => $params['status'],
+        ];
+
+
+        $url = 'http://localhost:80/association/paybox-callback?' . http_build_query($callBackParameters);
+
+        $curl = curl_init($url);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_exec($curl);
+
+        $output->writeln("Appel au callback de paiement de cotisation effectué");
+    }
+}

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -5,7 +5,6 @@ namespace AppBundle\Command;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use function GuzzleHttp\Psr7\parse_query;
 
 class DevCallBackPayboxCotisationCommand extends ContainerAwareCommand
 {

--- a/sources/AppBundle/Payment/PayboxFactory.php
+++ b/sources/AppBundle/Payment/PayboxFactory.php
@@ -100,7 +100,7 @@ class PayboxFactory
         $paybox->set_langue('FRA'); // Langue de l'interface PayBox
         $paybox->set_site($this->getConf()->obtenir('paybox|site'));
         $paybox->set_rang($this->getConf()->obtenir('paybox|rang'));
-        $paybox->set_identifiant('83166771'); ///  @todo this should not be here
+        $paybox->set_identifiant($this->getConf()->obtenir('paybox|identifiant'));
 
         $paybox->set_wait(50000); // Délai d'attente avant la redirection
         $paybox->set_boutpi('R&eacute;gler par carte'); // Texte du bouton


### PR DESCRIPTION
* ajout de documentation dans le readme
* on éviter l'identifiant de boutique en dur et défini celle de test dans la conf par défaut
* ajout d'une commande pour gérer le callback des adhésions (on devra faire la même chose pour les autres paiements)