### PR TITLE
correction sur les personnes présentes dans le google group membres@a…

### DIFF
--- a/sources/AppBundle/Command/UpdateMailingListMembersCommand.php
+++ b/sources/AppBundle/Command/UpdateMailingListMembersCommand.php
@@ -1,17 +1,20 @@
 <?php
 
-
 namespace AppBundle\Command;
 
 use Afup\Site\Association\Assemblee_Generale;
 use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Association\Model\User;
+use AppBundle\Groups\GroupRepository;
+use Google_Service_Directory_Member;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateMailingListMembersCommand extends ContainerAwareCommand
 {
+    const MEMBERS_MAILING_ADDRESS = 'membres@afup.org';
+
     /**
      * @see Command
      */
@@ -47,6 +50,8 @@ class UpdateMailingListMembersCommand extends ContainerAwareCommand
             return !in_array($member->getEmail(), $emails);
         };
 
+        $this->addMissingMembers($groupsRepository, $emails, $output);
+
         $lists = $mailingListRepository->getAllMailingLists(true);
 
         foreach ($lists as $list) {
@@ -58,6 +63,28 @@ class UpdateMailingListMembersCommand extends ContainerAwareCommand
             foreach ($membersOfListNonMemberAfup as $member) {
                 $output->write(sprintf('Removing "%s"', $member->getEmail()));
                 if ($groupsRepository->removeMember($list->getEmail(), $member->getEmail()) !== false) {
+                    $output->writeln('[OK]');
+                } else {
+                    $output->writeln('[NOK]');
+                }
+            }
+        }
+    }
+
+    private function addMissingMembers(GroupRepository $groupsRepository, $membersAfupEmails, OutputInterface $output)
+    {
+        $membersOfList = $groupsRepository->getMembers(self::MEMBERS_MAILING_ADDRESS);
+
+        $listEmails = [];
+        /** @var Google_Service_Directory_Member $memberOfList */
+        foreach ($membersOfList as $memberOfList) {
+            $listEmails[$memberOfList->getEmail()] = true;
+        }
+
+        foreach ($membersAfupEmails as $memberEmail) {
+            if (!isset($listEmails[$memberEmail])) {
+                $output->write(sprintf('Adding "%s"', $memberEmail));
+                if ($groupsRepository->addMember(self::MEMBERS_MAILING_ADDRESS, $memberEmail) !== false) {
                     $output->writeln('[OK]');
                 } else {
                     $output->writeln('[NOK]');


### PR DESCRIPTION
…fup.org

On avait seulement 387 personnes dans membres@afup.org, on devrais en avoir 666.
Pour cette mailing list, les membres sont ajoutés via des events qui ne fonctionnent pas forcément.
La commande de synchro va ici seulement supprimer les membres plus à jour de cotisation.
Pour ce groupe spécial où tous les membres sont forcément inscrits, on passe donc sur un système
plus robuste où on a la commande qui une fois par jour va ajouter et supprimer les membres.
On va donc dans un second temps pouvoir supprimer les events d'ajout en front s'il y en a encore.