### PR TITLE
on déplace l'export joindin dans la page sessions

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -129,9 +129,6 @@ parameters:
                 forum_planning:
                     nom: 'Planning'
                     niveau: 'ROLE_FORUM'
-                forum_joind_in:
-                    nom: 'Export sites externes'
-                    niveau: 'ROLE_ADMIN'
                 forum_partenaire:
                     nom: 'Sponsors/Partenaires'
                     niveau: 'ROLE_ADMIN'

--- a/htdocs/pages/administration/forum_joind_in.php
+++ b/htdocs/pages/administration/forum_joind_in.php
@@ -8,17 +8,20 @@ if (!defined('PAGE_LOADED_USING_INDEX')) {
     exit;
 }
 
-$action = verifierAction(array('afficher', 'telecharger_joindin'));
+$action = verifierAction(array('telecharger_joindin'));
 $tris_valides = array();
 $sens_valides = array('asc' , 'desc');
 $smarty->assign('action', $action);
 
 
-if ($action == 'afficher') {
-    // Ne rien faire. L'écran affiche simplement un lien.
-} elseif ($action == 'telecharger_joindin') {
+if ($action == 'telecharger_joindin') {
     $forum    = new Forum($bdd);
-    $forum_id = $forum->obtenirDernier();
+
+    if (!isset($_GET['id_forum']) || intval($_GET['id_forum']) == 0) {
+        $forum_id = $forum->obtenirDernier();
+    } else {
+        $forum_id = $_GET['id_forum'];
+    }
 
     $csv = $forum->obtenirCsvJoindIn($forum_id);
 

--- a/htdocs/templates/administration/forum_joind_in.html
+++ b/htdocs/templates/administration/forum_joind_in.html
@@ -1,5 +1,0 @@
-{if $action == 'afficher'}
-    <h2>Export données pour sites externes</h2>
-
-    <p><a href="index.php?page=forum_joind_in&amp;action=telecharger_joindin">Télécharger un fichier CSV des sessions pour joind.in (http://joind.in)</a></p>
-{/if}git

--- a/htdocs/templates/administration/forum_sessions.html
+++ b/htdocs/templates/administration/forum_sessions.html
@@ -12,6 +12,7 @@
 
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" /><a href="index.php?page=forum_sessions&amp;action=ajouter&amp;id_forum={$id_forum}" title="Ajouter une session">Ajouter une session</a><br />
     <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" /><a href="/admin/talk/export?id={$id_forum}" title="Exporter les inscriptions pour les badges">Exporter les sessions</a><br />
+    <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" /><a href="index.php?page=forum_joind_in&amp;action=telecharger_joindin&id_forum={$id_forum}">Télécharger un fichier CSV des sessions pour joind.in (http://joind.in)</a><br />
 <img src="{$chemin_template}images/puce.png" class="puce" alt="Puce" /><a href="/admin/talk/update_indexation" title="Met à jour algolia, permet d'avoir la liste des talks publique à jour">Indexer tous les talks</a><br />
     <br/>
     <form method="GET" name="filtre">


### PR DESCRIPTION
On a plus de cohérence dans la navigation et cela permet au passage
de choisir l'evénement, ce qui est utile pour les AFUP Day.