### PR TITLE
event.afup.org on met en place un redirection des liens de la version…

### DIFF
--- a/event/resources/web/.htaccess
+++ b/event/resources/web/.htaccess
@@ -4,6 +4,8 @@
 RewriteEngine On
 RewriteBase /
 
+RewriteRule ^(.*)/en/ $1 [L,R=301]
+
 RewriteRule ^forum-php-2017/programme/ /forumphp2017/programme [L,R=301]
 RewriteRule ^forum-php-2018/sponsors/ /forumphp2018/sponsors [L,R=301]
 RewriteRule ^forum-php-2018/accessibilite-et-inclusivite/ /forumphp2018/accessibilite-et-inclusivite [L,R=301]


### PR DESCRIPTION
… anglaise

Cela va permettre de supprimer la version anglaise qui pose plus de problèmes qu'autre chose.

On utilise le plugin `qTranslate-X`.
Le plugin modiie le contenu en base, on va donc conserver le plugin actif, mais désactiver la
version anglaise sinon les affichages contiendrons les tags du plugin.