### PR TITLE
correction erreur 500 sur la page adhésion

### DIFF
--- a/sources/AppBundle/Controller/LegacyController.php
+++ b/sources/AppBundle/Controller/LegacyController.php
@@ -72,7 +72,9 @@ class LegacyController extends Controller
 
     public function registerAction(Request $request)
     {
-        global $bdd, $droits;
+        global $droits;
+
+        $bdd = $GLOBALS['AFUP_DB'];
 
         $server = $_SERVER;
         $_SERVER['REQUEST_URI'] = '/administration/';


### PR DESCRIPTION
Depuis le 3f484c13d2bcc724214c522d3f452222177c779e il y avait une erreur 500
sur la page d'adhésion des personnes physiques (la variable $bdd était vide).
On efectue un premier fix (pas forcément très beau) pour faire fonctionner
cette fonctionnalité critique.