### PR TITLE
correction affichage libellés des tarifs sur la page inscription

### DIFF
--- a/sources/Afup/Bootstrap/commonStart.php
+++ b/sources/Afup/Bootstrap/commonStart.php
@@ -141,6 +141,7 @@ $AFUP_Tarifs_Forum_Lib = array(
     AFUP_FORUM_SPECIAL_PRICE => 'Tarif Spécial',
 );
 
+$GLOBALS['AFUP_Tarifs_Forum_Lib'] = $AFUP_Tarifs_Forum_Lib;
 
 
 // Initialisation de ting


### PR DESCRIPTION
depuis la modification de la gestion des globales on avait plus
certains libellés d'affichés.