### PR TITLE
ajout d'une commande de synchronisation de la liste membres-automatique

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -288,6 +288,10 @@ services:
         class: AppBundle\TechLetter\MailchimpSynchronizer
         arguments: ["@app.mailchimp_techletter_api", '@AppBundle\Association\Model\Repository\TechletterSubscriptionsRepository', "%mailchimp_techletter_list%"]
 
+    app.mailchimp_members_auto_synchronizer:
+        class: AppBundle\Mailchimp\MailchimpMembersAutoListSynchronizer
+        arguments: ['@AppBundle\Mailchimp\Mailchimp', '@AppBundle\Association\Model\Repository\UserRepository', "%mailchimp_members_list%"]
+
     Afup\Site\Utils\Configuration:
       arguments: ['%kernel.project_dir%/configs/application/config.php']
 

--- a/sources/AppBundle/Command/SynchMembersCommand.php
+++ b/sources/AppBundle/Command/SynchMembersCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SynchMembersCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this->setName('sync-members');
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $container = $this->getContainer();
+
+        $container
+           ->get('app.mailchimp_members_auto_synchronizer')
+           ->setLogger($container->get('logger'))
+           ->synchronize()
+        ;
+    }
+}

--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -44,11 +44,11 @@ class MailchimpMembersAutoListSynchronizer
 
     public function synchronize()
     {
-        $subscribdedEmailsOnMailchimp = $this->getSubscribedEmailsOnMailchimp();
-        $subscribdedEmailsOnWebsite = $this->getSubscribedEmailsOnWebsite();
+        $subscribedEmailsOnMailchimp = $this->getSubscribedEmailsOnMailchimp();
+        $subscribedEmailsOnWebsite = $this->getSubscribedEmailsOnWebsite();
 
-        $this->unsubscribeAddresses(array_diff($subscribdedEmailsOnMailchimp, $subscribdedEmailsOnWebsite));
-        $this->subscribeAddresses(array_diff($subscribdedEmailsOnWebsite, $subscribdedEmailsOnMailchimp));
+        $this->unsubscribeAddresses(array_diff($subscribedEmailsOnMailchimp, $subscribedEmailsOnWebsite));
+        $this->subscribeAddresses(array_diff($subscribedEmailsOnWebsite, $subscribedEmailsOnMailchimp));
     }
 
     /**

--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace AppBundle\Mailchimp;
+
+use AppBundle\Association\Model\Repository\TechletterSubscriptionsRepository;
+use AppBundle\Association\Model\Repository\UserRepository;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+class MailchimpMembersAutoListSynchronizer
+{
+    /**
+     * @var \AppBundle\Mailchimp\Mailchimp
+     */
+    private $mailchimp;
+
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * @var string
+     */
+    private $listId;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param \AppBundle\Mailchimp\Mailchimp $mailchimp
+     * @param TechletterSubscriptionsRepository $subscriptionsRepository
+     * @param string $listId
+     */
+    public function __construct(\AppBundle\Mailchimp\Mailchimp $mailchimp, UserRepository $userRepository, $listId)
+    {
+        $this->mailchimp = $mailchimp;
+        $this->userRepository = $userRepository;
+        $this->listId = $listId;
+        $this->logger = new NullLogger();
+    }
+
+    public function synchronize()
+    {
+        $subscribdedEmailsOnMailchimp = $this->getSubscribedEmailsOnMailchimp();
+        $subscribdedEmailsOnWebsite = $this->getSubscribedEmailsOnWebsite();
+
+        $this->unsubscribeAddresses(array_diff($subscribdedEmailsOnMailchimp, $subscribdedEmailsOnWebsite));
+        $this->subscribeAddresses(array_diff($subscribdedEmailsOnWebsite, $subscribdedEmailsOnMailchimp));
+    }
+
+    /**
+     * @param LoggerInterface $logger
+     *
+     * @return $this
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * @param array $emails
+     */
+    private function unsubscribeAddresses(array $emails)
+    {
+        foreach ($emails as $email) {
+            $this->logger->info('Unsubscribe {address} to techletter', ['address' => $email]);
+            $this->mailchimp->unSubscribeAddress($this->listId, $email);
+        }
+    }
+
+    /**
+     * @param array $emails
+     */
+    private function subscribeAddresses(array $emails)
+    {
+        foreach ($emails as $email) {
+            $this->logger->info('Subscribe {address} to techletter', ['address' => $email]);
+            $this->mailchimp->subscribeAddress($this->listId, $email);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    private function getSubscribedEmailsOnWebsite()
+    {
+        $subscribdedEmails =  [];
+
+        foreach ($this->userRepository->getActiveMembers(UserRepository::USER_TYPE_ALL) as $user) {
+            $subscribdedEmails[] = $user->getEmail();
+        }
+
+        return $subscribdedEmails;
+    }
+
+    /**
+     * @return array
+     */
+    private function getSubscribedEmailsOnMailchimp()
+    {
+        $mailsOnMailchimp = $this->mailchimp->getAllSubscribedMembersAddresses($this->listId);
+
+        return $mailsOnMailchimp;
+    }
+}


### PR DESCRIPTION
On sychronise la liste membre automatique en arrière plan via une commande
qu'on lancera régulièrement dans une cron.

Cela permettra d'éviter des problèmes ou la liste n'est pas à jour.