### PR TITLE
correction du hash mailchimp

### DIFF
--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -93,7 +93,7 @@ class Mailchimp
      */
     private function getAddressId($email)
     {
-        return md5($email);
+        return md5(strtolower($email));
     }
 
 


### PR DESCRIPTION
le hash mailchimp doit être effectué à partir de la version minuscule
de l'adress mail.

Sans cela les appels PUT de modification ne fonctionnaient pas.