### PR TITLE
améliorations sur la synchro des membres auto

### DIFF
--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -54,6 +54,16 @@ class Mailchimp
      *
      * @return array
      */
+    public function getAllUnSubscribedMembersAddresses($list)
+    {
+        return $this->callMembersAddresses($list, 'unsubscribed');
+    }
+
+    /**
+     * @param string $list
+     *
+     * @return array
+     */
     public function getAllCleaneddMembersAddresses($list)
     {
         return $this->callMembersAddresses($list, 'cleaned');

--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -113,6 +113,18 @@ class Mailchimp
     }
 
     /**
+     * @param $list
+     * @param $email
+     * @return \Illuminate\Support\Collection
+     */
+    public function archiveAddress($list, $email)
+    {
+        return $this->client->delete(
+            'lists/' . $list . '/members/' . $this->getAddressId($email)
+        );
+    }
+
+    /**
      * Mailchimp uses a predictable id to allow upsert operations on subscriptions.
      * It's based on a hash of the email.
      *

--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -46,11 +46,31 @@ class Mailchimp
      */
     public function getAllSubscribedMembersAddresses($list)
     {
+        return $this->callMembersAddresses($list, 'subscribed');
+    }
+
+    /**
+     * @param string $list
+     *
+     * @return array
+     */
+    public function getAllCleaneddMembersAddresses($list)
+    {
+        return $this->callMembersAddresses($list, 'cleaned');
+    }
+
+    /**
+     * @param string $list
+     * @param string $status
+     * @return array
+     */
+    private function callMembersAddresses($list, $status)
+    {
         $response = $this->client->get(
             'lists/' . $list . '/members',
             [
                 'count' => 0,
-                'status' => 'subscribed',
+                'status' => $status,
             ]
         );
 
@@ -65,7 +85,7 @@ class Mailchimp
                     'count' => self::MAX_MEMBERS_PER_PAGE,
                     'offset' => $i * self::MAX_MEMBERS_PER_PAGE,
                     'fields' => 'members.email_address',
-                    'status' => 'subscribed',
+                    'status' => $status,
                 ]
             );
 

--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -45,11 +45,15 @@ class MailchimpMembersAutoListSynchronizer
     public function synchronize()
     {
         $subscribedEmailsOnMailchimp = array_map('strtolower', $this->mailchimp->getAllSubscribedMembersAddresses($this->listId));
+        $unSubscribedEmailsOnMailchimp = array_map('strtolower', $this->mailchimp->getAllUnSubscribedMembersAddresses($this->listId));
         $cleanedEmailsOnMailchimp = array_map('strtolower', $this->mailchimp->getAllCleaneddMembersAddresses($this->listId));
         $subscribedEmailsOnWebsite = array_map('strtolower', $this->getSubscribedEmailsOnWebsite());
 
         $addressesToArchive = array_diff($subscribedEmailsOnMailchimp, $subscribedEmailsOnWebsite);
-        $addressesToSubscribe = array_diff($subscribedEmailsOnWebsite, $subscribedEmailsOnMailchimp);
+        // Vu qu'on archive les personnes qui ne sont plus à jour de cotisation, les adresses unsubscribed sont seulemnt les personnes
+        // qui ont optout. On ne peux techniquement pas les ajouter et fonctionnellelement il faudrait fournir les infos sur leur optin
+        // on ne cherche donc pas à ajouter de nouveaux ces personnes dans les subscribers
+        $addressesToSubscribe = array_diff($subscribedEmailsOnWebsite, $subscribedEmailsOnMailchimp, $unSubscribedEmailsOnMailchimp);
 
         // Les adresses cleaned sont par exemple des hard bounces : on ne peux pas les passer en subscribred dans mailchimp
         // Il peuvent tout de même être des membres à jour de cotisation, on va ici éviter des erreurs lors de la synchro en les ignornant


### PR DESCRIPTION
Cela va permettre de corriger des erreurs de synchronisation et de limiter les personnes de la liste en les passant en archivées au lieu de les passer en unsubscribed. Cette réduction devrait permettre de réduire les coûts sur mailchimp.