### PR TITLE
correction de l'adresse mail d'envoi des mails de relance

### DIFF
--- a/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
+++ b/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
@@ -54,7 +54,7 @@ abstract class AbstractUserReminder implements MembershipReminderInterface
 
         $status = $this->mailer->sendTransactional(new Message(
             $this->getSubject(),
-            MailUserFactory::sponsors(),
+            MailUserFactory::bureau(),
             new MailUser($user->getEmail())
         ), $this->getText(), MailUserFactory::bureau()->getEmail());
         $log->setMailSent($status);


### PR DESCRIPTION
Les mails de relance de cotisation étaient envoyés avec l'adresse sponsors
ce qui n'était pas logique. on utilise donc maintenant une adresse plus cohérente.