### PR TITLE
ajout du recaptcha sur la page de demande de dossier de sponsoring

### DIFF
--- a/app/Resources/views/event/sponsorship_file/form.html.twig
+++ b/app/Resources/views/event/sponsorship_file/form.html.twig
@@ -29,6 +29,7 @@
                 {{ form_row(leadForm.company) }}
                 {{ form_row(leadForm.website) }}
                 {{ form_row(leadForm.language) }}
+                {{ form_row(leadForm.recaptcha) }}
                 {{ form_errors(leadForm) }}
                 <div class="sponsor--become-submit">
                     <input type="submit" value="{{ 'Recevoir le dossier'|trans }}" />

--- a/sources/AppBundle/Event/Form/LeadType.php
+++ b/sources/AppBundle/Event/Form/LeadType.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Event\Form;
 
 use AppBundle\Event\Model\Lead;
+use EWZ\Bundle\RecaptchaBundle\Form\Type\EWZRecaptchaType;
+use EWZ\Bundle\RecaptchaBundle\Validator\Constraints\IsTrue as RecaptchaIsValid;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
@@ -25,6 +27,13 @@ class LeadType extends AbstractType
             ->add('language', ChoiceType::class, [
                 'choices' => ['fr' => 'fr', 'en' => 'en'],
                 'multiple' => false
+            ])
+            ->add('recaptcha', EWZRecaptchaType::class, [
+                'label' => 'Vérification',
+                'mapped' => false,
+                'constraints' => [
+                    new RecaptchaIsValid()
+                ]
             ])
         ;
     }


### PR DESCRIPTION
Cela va éviter qu'on ait des bots qui utilisent ce formulaire pour envoyer des messages non solicités sur certaines adresses, qui sont potentiellement invalides et nous cause des problèmes de réputation sur Mandrill.