### PR TITLE
Import journal CMut et amélioration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ deps.lock
 
 /htdocs/cache
 /htdocs/tmp/twig
+/tmp/
 node_modules
 /configs/application/config.php
 /tests/simpletest

--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -565,7 +565,7 @@ elseif ($action == 'supprimer') {
 	$formulaire->addElement('header', null          , 'Import CSV');
     $formulaire->addElement('file', 'fichiercsv', 'Fichier banque'     );
     $formulaire->addElement('select', 'banque', 'Banque', [
-        Importer\CaisseEpargne::CODE => 'Caisse Epargne',
+        Importer\CaisseEpargne::CODE => "Caisse d'Épargne",
         Importer\CreditMutuel::CODE => 'Crédit Mutuel',
     ]);
 

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -898,9 +898,6 @@ SQL;
         if (!substr($csvFile[0], 0, 17) == 'Code de la banque') {
             return false;
         }
-        $forum = new Forum($this->_bdd);
-        $futurForum = $forum->obtenirDernier();
-        $futurEvenement = $this->obtenirEvenementParIdForum($futurForum);
         // On efface les 4 premières lignes
         $csvFile = array_slice($csvFile, 4);
         foreach ($csvFile as $ligne) {
@@ -924,24 +921,7 @@ SQL;
                 // On tente les préaffectations
                 $categorie = 26; // Catégorie 26 = "A déterminer"
                 $evenement = 8;  // Evénement 8 = "A déterminer"
-                if (strpos($donnees[5], 'CONTRAT 8316677013')) {
-                    if ($idoperation == 2) {// CREDIT
-                        // Virement PAYBOX
-                        if ($montant < 100) {
-                            // Vraisemblablement des cotisations
-                            $categorie = 4;  // Catégorie 4 = "Cotisation AFUP"
-                            $evenement = 27; // Evénement 27 = "Assocation AFUP"
-                        } else {
-                            // Vraisemblablement un réglement pour le prochain événement
-                            $categorie = 3;  // Catégorie 3 = "Inscription"
-                            $evenement = $futurEvenement;
-                        }
-                    } else {// DEBIT
-                        // Commission PAYBOX
-                        $categorie = 28; // Catégorie 28 = "Frais de compte"
-                        $evenement = 26; // Evénement 26 = "Gestion"
-                    }
-                }
+
                 $idmode_regl = 9;
                 switch (strtoupper(substr($donnees[2], 0, 3))) {
                     case 'CB ':

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -1017,7 +1017,7 @@ SQL;
             if (!is_array($enregistrement)) {
                 $this->ajouter(
                     $idoperation,
-                    1,
+                    $importer->getCompteId(),
                     $categorie,
                     $date_ecriture,
                     '',
@@ -1044,7 +1044,7 @@ SQL;
                 if ($modifier) {
                     $this->modifier($enregistrement['id'],
                         $enregistrement['idoperation'],
-                        1,
+                        $importer->getCompteId(),
                         $enregistrement['idcategorie'],
                         $enregistrement['date_ecriture'],
                         $enregistrement['nom_frs'],

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -9,6 +9,7 @@ namespace Afup\Site\Comptabilite;
 use Afup\Site\Forum\Forum;
 use Afup\Site\Utils\Base_De_Donnees;
 use AppBundle\Compta\Importer\Importer;
+use AppBundle\Compta\Importer\Operation;
 
 class Comptabilite
 {
@@ -896,28 +897,22 @@ SQL;
             return false;
         }
 
-        foreach ($importer->extract() as $donnees) {
-            $numero_operation = $donnees[1];
+        foreach ($importer->extract() as $operation) {
+            $numero_operation = $operation->getNumeroOperation();
             // On vérife si l'enregistrement existe déjà
             $enregistrement = $this->obtenirParNumeroOperation($numero_operation);
 
-            $date_ecriture = '20' . implode('-', array_reverse(explode('/', $donnees[0])));
-            $description = $donnees[2] . '-' . $donnees[5];
-            $donnees[3] = abs(str_replace(',', '.', $donnees[3]));
-            $donnees[4] = abs(str_replace(',', '.', $donnees[4]));
-            if ($donnees[4] == '') {
-                $idoperation = 1;
-                $montant = $donnees[3];
-            } else {
-                $idoperation = 2;
-                $montant = $donnees[4];
-            }
+            $date_ecriture = $operation->getDateEcriture();
+            $description = $operation->getDescription();
+            $idoperation = $operation->isCredit() ? 2 : 1;
+            $montant = $operation->getMontant();
+
             // On tente les préaffectations
             $categorie = 26; // Catégorie 26 = "A déterminer"
             $evenement = 8;  // Evénement 8 = "A déterminer"
 
             $idmode_regl = 9;
-            switch (strtoupper(substr($donnees[2], 0, 3))) {
+            switch (strtoupper(substr($description, 0, 3))) {
                 case 'CB ':
                     $idmode_regl = 2;
                     break;

--- a/sources/AppBundle/Compta/Importer/CaisseEpargne.php
+++ b/sources/AppBundle/Compta/Importer/CaisseEpargne.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Compta\Importer;
 
+use AppBundle\Model\ComptaCompte;
+
 class CaisseEpargne implements Importer
 {
     const CODE = 'CE';
@@ -83,5 +85,10 @@ class CaisseEpargne implements Importer
 
             yield new Operation($dateEcriture, $description, $montant, $type, $numeroOperation);
         }
+    }
+
+    public function getCompteId()
+    {
+        return ComptaCompte::COURANT_CE;
     }
 }

--- a/sources/AppBundle/Compta/Importer/CaisseEpargne.php
+++ b/sources/AppBundle/Compta/Importer/CaisseEpargne.php
@@ -45,6 +45,9 @@ class CaisseEpargne implements Importer
         return true;
     }
 
+    /**
+     * @return Operation[]
+     */
     public function extract()
     {
         foreach ($this->file as $i => $data) {
@@ -56,7 +59,26 @@ class CaisseEpargne implements Importer
                 continue;
             }
 
-            yield $data;
+            $dateEcriture = '20' . implode('-', array_reverse(explode('/', $data[0])));
+            if ('' === $data[5]) {
+                $description = $data[2];
+            } elseif (false === strpos($data[5], $data[2])) {
+                $description = $data[2] . ' - ' . $data[5];
+            } else {
+                $description = $data[5];
+            }
+
+            if ('' === $data[4]) {
+                $montant = abs(str_replace(',', '.', $data[3]));
+                $type = Operation::DEBIT;
+            } else {
+                $montant = abs(str_replace(',', '.', $data[4]));
+                $type = Operation::CREDIT;
+            }
+
+            $numeroOperation = $data[1];
+
+            yield new Operation($dateEcriture, $description, $montant, $type, $numeroOperation);
         }
     }
 }

--- a/sources/AppBundle/Compta/Importer/CaisseEpargne.php
+++ b/sources/AppBundle/Compta/Importer/CaisseEpargne.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AppBundle\Compta\Importer;
+
+class CaisseEpargne implements Importer
+{
+    const CODE = 'CE';
+
+    /**
+     * @var string
+     */
+    private $filePath;
+
+    /**
+     * @var \SplFileObject
+     */
+    private $file;
+
+    public function __construct()
+    {
+        $this->filePath;
+    }
+
+    public function initialize($filePath)
+    {
+        $this->file = new \SplFileObject($filePath, 'r');
+        $this->file->setCsvControl(';');
+        $this->file->setFlags(\SplFileObject::READ_CSV | \SplFileObject::SKIP_EMPTY);
+    }
+
+    public function validate()
+    {
+        $this->file->rewind();
+        $firstLine = $this->file->current();
+
+        if (!is_array($firstLine)) {
+            return false;
+        }
+
+        // On vérifie la première ligne
+        if ('Code de la banque' === !substr($firstLine[0], 0, 17)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function extract()
+    {
+        foreach ($this->file as $i => $data) {
+            if ($i <= 4) {
+                continue;
+            }
+
+            if (count($data) !== 7) {
+                continue;
+            }
+
+            yield $data;
+        }
+    }
+}

--- a/sources/AppBundle/Compta/Importer/CaisseEpargne.php
+++ b/sources/AppBundle/Compta/Importer/CaisseEpargne.php
@@ -68,6 +68,9 @@ class CaisseEpargne implements Importer
                 $description = $data[5];
             }
 
+            // petit nettoyage pour virer les espaces multiples
+            $description = implode(' ', array_filter(explode(' ', $description)));
+
             if ('' === $data[4]) {
                 $montant = abs(str_replace(',', '.', $data[3]));
                 $type = Operation::DEBIT;

--- a/sources/AppBundle/Compta/Importer/CreditMutuel.php
+++ b/sources/AppBundle/Compta/Importer/CreditMutuel.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Compta\Importer;
 
+use AppBundle\Model\ComptaCompte;
+
 class CreditMutuel implements Importer
 {
     const CODE = 'CMUT';
@@ -24,5 +26,10 @@ class CreditMutuel implements Importer
     public function extract()
     {
         return [];
+    }
+
+    public function getCompteId()
+    {
+        return ComptaCompte::COURANT_CMUT;
     }
 }

--- a/sources/AppBundle/Compta/Importer/CreditMutuel.php
+++ b/sources/AppBundle/Compta/Importer/CreditMutuel.php
@@ -8,14 +8,19 @@ class CreditMutuel implements Importer
 
     public function initialize($filePath)
     {
-        // TODO: Implement initialize() method.
     }
 
+    /**
+     * @return boolean
+     */
     public function validate()
     {
-        return true;
+        return false;
     }
 
+    /**
+     * @return Operation[]
+     */
     public function extract()
     {
         return [];

--- a/sources/AppBundle/Compta/Importer/CreditMutuel.php
+++ b/sources/AppBundle/Compta/Importer/CreditMutuel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Compta\Importer;
+
+class CreditMutuel implements Importer
+{
+    const CODE = 'CMUT';
+
+    public function initialize($filePath)
+    {
+        // TODO: Implement initialize() method.
+    }
+
+    public function validate()
+    {
+        return true;
+    }
+
+    public function extract()
+    {
+        return [];
+    }
+}

--- a/sources/AppBundle/Compta/Importer/Factory.php
+++ b/sources/AppBundle/Compta/Importer/Factory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Compta\Importer;
+
+class Factory
+{
+    /**
+     * @param string $code
+     * @param string $code
+     * @return Importer
+     */
+    public function create($filePath, $code)
+    {
+        switch ($code) {
+            case CreditMutuel::CODE:
+                $importer = new CreditMutuel();
+                break;
+            case CaisseEpargne::CODE:
+                $importer = new CaisseEpargne();
+                break;
+            default:
+                throw new \InvalidArgumentException("Unknown importer for code '$code'");
+        }
+
+        $importer->initialize($filePath);
+
+        return $importer;
+    }
+}

--- a/sources/AppBundle/Compta/Importer/Importer.php
+++ b/sources/AppBundle/Compta/Importer/Importer.php
@@ -16,7 +16,7 @@ interface Importer
     public function validate();
 
     /**
-     * @return mixed
+     * @return Operation[]
      */
     public function extract();
 

--- a/sources/AppBundle/Compta/Importer/Importer.php
+++ b/sources/AppBundle/Compta/Importer/Importer.php
@@ -20,4 +20,8 @@ interface Importer
      */
     public function extract();
 
+    /**
+     * @return int
+     */
+    public function getCompteId();
 }

--- a/sources/AppBundle/Compta/Importer/Importer.php
+++ b/sources/AppBundle/Compta/Importer/Importer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Compta\Importer;
+
+interface Importer
+{
+    /**
+     * @param string $filePath
+     * @return void
+     */
+    public function initialize($filePath);
+
+    /**
+     * @return boolean
+     */
+    public function validate();
+
+    /**
+     * @return mixed
+     */
+    public function extract();
+
+}

--- a/sources/AppBundle/Compta/Importer/Operation.php
+++ b/sources/AppBundle/Compta/Importer/Operation.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace AppBundle\Compta\Importer;
+
+class Operation
+{
+    const DEBIT = 'debit';
+    const CREDIT = 'credit';
+
+    private $dateEcriture;
+    private $description;
+    private $montant;
+    private $type;
+    private $numeroOperation;
+
+    /**
+     * Operation constructor.
+     *
+     * @param string $dateEcriture
+     * @param string $description
+     * @param float $montant
+     * @param string $type
+     * @param string $numeroOperation
+     */
+    public function __construct($dateEcriture, $description, $montant, $type, $numeroOperation)
+    {
+        $this->dateEcriture = $dateEcriture;
+        $this->description = $description;
+        $this->montant = $montant;
+        $this->type = $type;
+        $this->numeroOperation = $numeroOperation;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDateEcriture()
+    {
+        return $this->dateEcriture;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return float
+     */
+    public function getMontant()
+    {
+        return $this->montant;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getNumeroOperation()
+    {
+        return $this->numeroOperation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isCredit()
+    {
+        return self::CREDIT === $this->getType();
+    }
+}

--- a/sources/AppBundle/Model/ComptaCategorie.php
+++ b/sources/AppBundle/Model/ComptaCategorie.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AppBundle\Model;
+
+class ComptaCategorie
+{
+    const GOODIES = 13;
+    const FRAIS_DE_COMPTE = 28;
+    const MAILCHIMP = 31;
+    const CHARGES_SOCIALES = 32;
+    const GANDI = 37;
+    const MEETUP = 45;
+    const OUTILS = 48;
+    const PRELEVEMENT_SOURCE = 51;
+}

--- a/sources/AppBundle/Model/ComptaCompte.php
+++ b/sources/AppBundle/Model/ComptaCompte.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Model;
+
+class ComptaCompte
+{
+    const COURANT_CE = 1;
+    const COURANT_CMUT = 5;
+}

--- a/sources/AppBundle/Model/ComptaEvenement.php
+++ b/sources/AppBundle/Model/ComptaEvenement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AppBundle\Model;
+
+class ComptaEvenement
+{
+    const GESTION = 26;
+    const ASSOCIATION_AFUP = 27;
+}

--- a/sources/AppBundle/Model/ComptaModeReglement.php
+++ b/sources/AppBundle/Model/ComptaModeReglement.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace AppBundle\Model;
+
+class ComptaModeReglement
+{
+    const CB = 2;
+    const VIREMENT = 3;
+    const CHEQUE = 4;
+    const PRELEVEMENT = 5;
+}


### PR DESCRIPTION
Pas totalement terminé (pas encore le format définitif du Crédit Mutuel)

- refactoring de l'import du journal pour gérer 2 formats différents pour le Crédit Mutuel et la Caisse d'Epargne
- ajout de règles auto pour simplifier les imports

Peut être mergée en l'état, il suffira de valider le format une fois les premiers fichiers obtenus.