### PR TITLE
Migration des tests de travis-ci à Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on: [push]
+
+jobs:
+
+  unit:
+    name: "Unit tests"
+    runs-on: ubuntu-16.04
+ 
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["5.6", "7.0"]
+ 
+    steps:
+      - uses: actions/checkout@v2
+ 
+      - name: PHP - Switch
+        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+ 
+      - name: Composer - Get Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v1
+        id: cache-composer
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-php.${{ matrix.php }}-${{ github.sha }}
+          restore-keys: composer-php.${{ matrix.php }}-
+
+      - name: Composer - Create cache directory
+        run: mkdir -p /home/runner/.composer/cache
+        if: steps.cache-composer.outputs.cache-hit != 'true'
+
+      - name: Composer install
+        run: composer install --no-scripts
+
+      - name: Tests - Unit
+        run: ./bin/atoum

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: php
-php:
-  - 5.6
-  - 7.0
-sudo: false
-script:
-  - composer install --no-scripts
-  - ./bin/atoum


### PR DESCRIPTION
Avec les changements au niveau de l'offre de travis-ci :
https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing

et les lenteurs rencontrés sur ce service sur ces dernières semaines,

ainsi que le fait qu'on pourra plus facilement ensuite y ajouter d'autres tests
(migrer PrettyCi, lancer des tests fonctionnels ou d'analyse statique),

il sera une bonne chose de migrer vers Github Actions pour l'intégration continue :
c'est ce qu'effectue cette PR.

Merci à @oallain pour l'inspiration (sur https://www.synolia.com/synolab/outils/comment-tester-plugin-sylius/).