### PR TITLE
mise à jour de calcul du quorum suite à la mise à jour des statuts de février 2020

### DIFF
--- a/sources/AppBundle/GeneralMeeting/GeneralMeetingRepository.php
+++ b/sources/AppBundle/GeneralMeeting/GeneralMeetingRepository.php
@@ -389,7 +389,7 @@ SQL
      */
     public function obtenirEcartQuorum(DateTimeInterface $date, $nombrePersonnesAJourDeCotisation)
     {
-        $quorum = (int) ceil($nombrePersonnesAJourDeCotisation / 3);
+        $quorum = (int) ceil($nombrePersonnesAJourDeCotisation / 4);
 
         return $this->countAttendeesAndPowers($date) - $quorum;
     }


### PR DESCRIPTION
Maintenant celui-ci est de "minimale d'au moins un quart des membres actifs".

fixes #1030