### PR TITLE
correction erreur 500 sur la page de l'ag dans l'espace membre si on était pas à jour

### DIFF
--- a/sources/AppBundle/Controller/MemberShipController.php
+++ b/sources/AppBundle/Controller/MemberShipController.php
@@ -484,7 +484,6 @@ class MemberShipController extends SiteBaseController
         if (null !== $attendee) {
             $defaultPresence = $attendee->getPresence();
             $defaultPowerId = $attendee->getPowerId();
-
         }
 
         $form = $this->createFormBuilder()

--- a/sources/AppBundle/Controller/MemberShipController.php
+++ b/sources/AppBundle/Controller/MemberShipController.php
@@ -477,8 +477,15 @@ class MemberShipController extends SiteBaseController
         }
 
         $attendee = $generalMeetingRepository->getAttendee($user->getUsername(), $latestDate);
-        Assertion::notNull($attendee);
         $lastGeneralMeetingDescription = $generalMeetingRepository->obtenirDescription($latestDate);
+
+        $defaultPresence = 0;
+        $defaultPowerId = null;
+        if (null !== $attendee) {
+            $defaultPresence = $attendee->getPresence();
+            $defaultPowerId = $attendee->getPowerId();
+
+        }
 
         $form = $this->createFormBuilder()
             ->add('presence', ChoiceType::class, ['expanded' => true, 'choices' => ['Oui' => 1, 'Non' => 2, 'Je ne sais pas encore' => 0]])
@@ -493,8 +500,8 @@ class MemberShipController extends SiteBaseController
             )
             ->add('save', SubmitType::class, ['label' => 'Confirmer'])
             ->setData([
-                'presence' => $attendee->getPresence(),
-                'id_personne_avec_pouvoir' => $attendee->getPowerId(),
+                'presence' => $defaultPresence,
+                'id_personne_avec_pouvoir' => $defaultPowerId,
             ])
             ->getForm();
 
@@ -502,7 +509,7 @@ class MemberShipController extends SiteBaseController
 
         if ($form->isValid()) {
             $data = $form->getData();
-            if (null !== $attendee->getPresence()) {
+            if (null !== $attendee) {
                 $ok = $generalMeetingRepository->editAttendee(
                     $user->getUsername(),
                     $latestDate,


### PR DESCRIPTION
Si on était pas à jour lors de la création de l'AG et qu'on est maintenant à jour, on tombait
sur une erreur 500 en allant sur la page d'AG dans l'espace membre.

Il y avait cette erreur :
```
Feb  1 18:39:04 afupsvr01 [3016]: request.CRITICAL: Uncaught PHP Exception Assert\InvalidArgumentException: "Value "<NULL>" is null, but non null value was expected." at /home/sources/web/releases/20210130123711/vendor/beberlei/assert/lib/Assert/Assertion.php line 288 {"exception":"[object] (Assert\\InvalidArgumentException(code: 15): Value \"<NULL>\" is null, but non null value was expected. at /home/sources/web/releases/20210130123711/vendor/beberlei/assert/lib/Assert/Assertion.php:288)"} []
```

Cela est dû aux changements sur les repositories dans cette page (le commit c6c6ce2f70931c180707a46cec4b301e331c0fc6).

L'attendee peut-être null, si l'adhérent ou adhérente n'avait pas compte ou n'était pas à jour
lors de la création de l'AG.

On adapte donc le code dans le controlleur pour gérer à nouveau ce cas et faire fonctionner la page.