### PR TITLE
on lance le linter via github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,37 @@ jobs:
 
       - name: Tests - Unit
         run: ./bin/atoum
+
+  lint:
+    name: "Linter"
+    runs-on: ubuntu-16.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: PHP - Switch
+        run: sudo update-alternatives --set php /usr/bin/php5.6
+
+      - name: Composer - Get Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - uses: actions/cache@v1
+        id: cache-composer
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-php.5.6-${{ github.sha }}
+          restore-keys: composer-php.5.6-
+
+      - name: Composer - Create cache directory
+        run: mkdir -p /home/runner/.composer/cache
+        if: steps.cache-composer.outputs.cache-hit != 'true'
+
+      - name: CS fixer prerequisites
+        run: make configs/application/config.php
+
+      - name: Composer install
+        run: composer install --no-scripts
+
+      - name: Tests - CS Fixer
+        run: ./bin/php-cs-fixer fix --dry-run -vv


### PR DESCRIPTION
On passait par prettyci pour lancer le linter.
Ce service devait être arrêté en décembre 2020, notamment avec l'arrivée de Github Actions : https://prettyci.com/goodbye

On passe donc sur Github actions pour lancer ces tests, ce qui permettra de couper l'intégration à PrettyCI.