### PR TITLE
ajout de cache sur la récupération des meetups sur la home

### DIFF
--- a/sources/AppBundle/Controller/HomeController.php
+++ b/sources/AppBundle/Controller/HomeController.php
@@ -56,14 +56,30 @@ class HomeController extends SiteBaseController
             return [];
         }
 
+        $cache = $this->get('cache.system');
+        $cacheKey = 'home_algolia_meetups';
+
         try {
-            $algolia = $this->get(\AlgoliaSearch\Client::class);
-            $index = $algolia->initIndex('afup_meetups');
-            $results = $index->search('', ['hitsPerPage' => self::MAX_MEETUPS]);
+            $cacheItem = $cache->getItem($cacheKey);
+            if (!$cacheItem->isHit()) {
+                $cacheItem->expiresAfter(new \DateInterval('P1D'));
+                $cacheItem->set($this->doGetLatestMeetups());
+                $cache->save($cacheItem);
+            }
+
+            return $cacheItem->get();
+
         } catch (\AlgoliaSearch\AlgoliaException $e) {
             $this->get('logger')->error($e->getMessage());
             return [];
         }
+    }
+
+    private function doGetLatestMeetups()
+    {
+        $algolia = $this->get(\AlgoliaSearch\Client::class);
+        $index = $algolia->initIndex('afup_meetups');
+        $results = $index->search('', ['hitsPerPage' => self::MAX_MEETUPS]);
 
         return $results['hits'];
     }

--- a/sources/AppBundle/Controller/HomeController.php
+++ b/sources/AppBundle/Controller/HomeController.php
@@ -68,7 +68,6 @@ class HomeController extends SiteBaseController
             }
 
             return $cacheItem->get();
-
         } catch (\AlgoliaSearch\AlgoliaException $e) {
             $this->get('logger')->error($e->getMessage());
             return [];


### PR DESCRIPTION
cela permet d'éviter de faire des appels à l'API afin de rester en dessous
du quota.
On met en cache seulement une seule fois par jour (de toute façon l'index
n'est aussi mis à jour qu'une seule fois par jour).
Au passage on devrait aussi améliorer les perfs de la home.