### PR TITLE
correction des factures envoyées pour le prochain AFUP Day

### DIFF
--- a/sources/Afup/Forum/Facturation.php
+++ b/sources/Afup/Forum/Facturation.php
@@ -165,7 +165,7 @@ class Facturation
             $pdf->Ln();
             $pdf->SetFillColor(255, 255, 255);
 
-            $pdf->Cell(50, 5, utf8_decode($inscription['pretty_name']), 1);
+            $pdf->Cell(50, 5, $this->truncate(utf8_decode($inscription['pretty_name']), 27), 1);
             $pdf->Cell(100, 5, utf8_decode($inscription['prenom']) . ' ' . utf8_decode($inscription['nom']), 1);
             $pdf->Cell(40, 5, utf8_decode($inscription['montant']) . utf8_decode(' '), 1);
             $total += $inscription['montant'];
@@ -184,6 +184,15 @@ class Facturation
         } else {
             $pdf->Output($chemin, 'F');
         }
+    }
+
+    protected function truncate($value, $length)
+    {
+        if ($value <= $legth) {
+            return $value;
+        }
+
+        return substr($value, 0, $length) . '...';
     }
 
     /**


### PR DESCRIPTION
Sur le prochain AFUP Day les factures étaient mal affichées : le texte dépassait
de la cellule.

Cela car cette année le type de billet était plus long qu'à l'accoutumée.

On tronque donc le type de billet s'il est plus long que la cellule.