### PR TITLE
on lance aussi les tests sur l'événement pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
Si une PR était créee depuis un fork, on ne lançait pas les tests,
ça sera maintenant le cas.