### PR TITLE
Suppression de la dépendance envers mandrill/mandrill

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4112,6 +4112,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
+            "abandoned": "https://github.com/fabpot/local-php-security-checker",
             "time": "2015-11-07T08:07:40+00:00"
         },
         {
@@ -5382,49 +5383,6 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "time": "2020-04-15T18:51:10+00:00"
-        },
-        {
-            "name": "mandrill/mandrill",
-            "version": "1.0.55",
-            "source": {
-                "type": "git",
-                "url": "https://bitbucket.org/mailchimp/mandrill-api-php.git",
-                "reference": "da3adc10042eafac2e53de141b358a52b8e53596"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://bitbucket.org/mailchimp/mandrill-api-php/get/da3adc10042eafac2e53de141b358a52b8e53596.zip",
-                "reference": "da3adc10042eafac2e53de141b358a52b8e53596",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mandrill": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Mandrill Devs",
-                    "email": "community@mandrill.com",
-                    "homepage": "http://mandrill.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "API client library for the Mandrill email as a service platform",
-            "homepage": "https://bitbucket.org/mailchimp/mandrill-api-php",
-            "keywords": [
-                "api",
-                "email"
-            ],
-            "time": "2015-09-22T13:58:03+00:00"
         },
         {
             "name": "php-cs-fixer/diff",


### PR DESCRIPTION
Bitbuckt est maintenance https://bitbucket.status.atlassian.com/incidents/5q0zhsqk5dxm

Du coup le composer install ne fonctionne plus.

Cela car on va cloner mandrill/mandril

De toute façon cette livrairie n'est plus utilisée depuis
qu'on est passée sur un envoi agostic via smtp.

On supprime donc cette dépendance inutile :

```
Removing mandrill/mandrill (1.0.55)
```