### PR TITLE
correction sur l'export des inscriptions pour badges pour l'afup day 2021

### DIFF
--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -68,6 +68,10 @@ class Ticket implements NotifyPropertyInterface
     const TYPE_FORUM_PHP_LIVE_SOUTIEN_5 = 123;
     const TYPE_FORUM_PHP_LIVE_SOUTIEN_6 = 124;
 
+    const TYPE_AFUP_DAY_2021_LIVE_1 = 125;
+    const TYPE_AFUP_DAY_2021_LIVE_2 = 126;
+    const TYPE_AFUP_DAY_2021_LIVE_3 = 127;
+    const TYPE_AFUP_DAY_2021_LIVE_4 = 128;
 
     const SPECIAL_PRICE = AFUP_FORUM_SPECIAL_PRICE;
 

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -172,6 +172,10 @@ class RegistrationsExportGenerator
             case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_2:
             case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_3:
             case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_4:
+            case Ticket::TYPE_AFUP_DAY_2021_LIVE_1:
+            case Ticket::TYPE_AFUP_DAY_2021_LIVE_2:
+            case Ticket::TYPE_AFUP_DAY_2021_LIVE_3:
+            case Ticket::TYPE_AFUP_DAY_2021_LIVE_4:
                 return 'PASS JOUR 1';
                 break;
             case AFUP_FORUM_DEUXIEME_JOURNEE:


### PR DESCRIPTION
Il manquait du mapping sur les tarifs, on avait donc une 500.