### PR TITLE
La page meetup affiche des `null` lorsque les adresses sont vides

### DIFF
--- a/htdocs/js/meetups/list.js
+++ b/htdocs/js/meetups/list.js
@@ -38,7 +38,7 @@ search.addWidget(
                 ;
 
                 if ('undefined' !== typeof data.venue) {
-                    content += `${data.venue.name}<br />${data.venue.address_1}<br />${data.venue.city}<br />`;
+                    content += `${data.venue.name}<br />${data.venue.address_1 || ''}<br />${data.venue.city || ''}<br />`;
                 }
                 content += `<a href="#" class="description-toggler" data-toggled-html="Masquer la description">Voir la description</a>`;
 


### PR DESCRIPTION
Rendu actuel lorsque les adresses sont `null`:

![image](https://user-images.githubusercontent.com/2320425/120977841-15c07400-c774-11eb-8574-18a8155da898.png)

Cette PR fix cela