### PR TITLE
corrections sur la gestion des events par défaut dans les pages de l'admin

### DIFF
--- a/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
@@ -75,22 +75,20 @@ class PendingBankwiresAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        if ($id !==null) {
-            $event = $this->eventActionHelper->getEventById($id);
 
-            if ($request->isMethod(Request::METHOD_POST)) {
-                if (!$this->csrfTokenManager->isTokenValid(new CsrfToken('admin_event_bankwires',
-                    $request->request->get('token')))) {
-                    $this->flashBag->add('error', 'Erreur de token CSRF, veuillez réessayer');
-                } else {
-                    $reference = $request->request->get('bankwireReceived');
-                    $invoice = $this->invoiceRepository->getByReference($reference);
-                    if ($invoice === null) {
-                        throw new NotFoundHttpException(sprintf('No invoice with this reference: "%s"', $reference));
-                    }
-                    $this->setInvoicePaid($event, $invoice);
+        $event = $this->eventActionHelper->getEventById($id);
+
+        if ($request->isMethod(Request::METHOD_POST)) {
+            if (!$this->csrfTokenManager->isTokenValid(new CsrfToken('admin_event_bankwires',
+                $request->request->get('token')))) {
+                $this->flashBag->add('error', 'Erreur de token CSRF, veuillez réessayer');
+            } else {
+                $reference = $request->request->get('bankwireReceived');
+                $invoice = $this->invoiceRepository->getByReference($reference);
+                if ($invoice === null) {
+                    throw new NotFoundHttpException(sprintf('No invoice with this reference: "%s"', $reference));
                 }
+                $this->setInvoicePaid($event, $invoice);
             }
         }
 

--- a/sources/AppBundle/Controller/Admin/Event/PricesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAction.php
@@ -36,12 +36,9 @@ class PricesAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        $ticketEventTypes = [];
-        if ($id !== null) {
-            $event = $this->eventActionHelper->getEventById($id);
-            $ticketEventTypes = $this->ticketEventTypeRepository->getTicketsByEvent($event);
-        }
+        $event = $this->eventActionHelper->getEventById($id);
+        $ticketEventTypes = $this->ticketEventTypeRepository->getTicketsByEvent($event);
+
         return new Response($this->twig->render('admin/event/prices.html.twig', [
             'ticket_event_types' => $ticketEventTypes,
             'event' => $event,

--- a/sources/AppBundle/Controller/Admin/Event/RoomAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RoomAction.php
@@ -51,47 +51,43 @@ class RoomAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        $rooms = null;
-        $addForm = null;
-        $editForms = null;
-        if ($id !== null) {
-            $event = $this->eventActionHelper->getEventById($id);
-            $rooms = $this->roomRepository->getByEvent($event);
-            $editForms = $this->getFormsForRooms($rooms);
 
-            foreach ($editForms as $form) {
-                $form->handleRequest($request);
-                if ($form->isSubmitted() && $form->isValid()) {
-                    $room = $form->getData();
-                    if ($request->request->has('delete')) {
-                        $this->roomRepository->delete($room);
-                        $this->flashBag->add('notice', sprintf('La salle "%s" a été supprimée.', $room->getName()));
-                    } else {
-                        $this->roomRepository->save($room);
-                        $this->flashBag->add('notice', sprintf('La salle "%s" a été sauvegardée.', $room->getName()));
-                    }
+        $event = $this->eventActionHelper->getEventById($id);
+        $rooms = $this->roomRepository->getByEvent($event);
+        $editForms = $this->getFormsForRooms($rooms);
 
-                    return new RedirectResponse($this->urlGenerator->generate('admin_event_room',
-                        ['id' => $event->getId()]));
+        foreach ($editForms as $form) {
+            $form->handleRequest($request);
+            if ($form->isSubmitted() && $form->isValid()) {
+                $room = $form->getData();
+                if ($request->request->has('delete')) {
+                    $this->roomRepository->delete($room);
+                    $this->flashBag->add('notice', sprintf('La salle "%s" a été supprimée.', $room->getName()));
+                } else {
+                    $this->roomRepository->save($room);
+                    $this->flashBag->add('notice', sprintf('La salle "%s" a été sauvegardée.', $room->getName()));
                 }
-            }
-
-            $newRoom = new Room();
-            $newRoom->setEventId($event->getId());
-
-            $addForm = $this->formFactory->create(RoomType::class, $newRoom);
-            $addForm->handleRequest($request);
-
-            if ($addForm->isSubmitted() && $addForm->isValid()) {
-                $newRoom = $addForm->getData();
-                $this->roomRepository->save($newRoom);
-                $this->flashBag->add('notice', sprintf('La salle "%s" a été ajoutée.', $newRoom->getName()));
 
                 return new RedirectResponse($this->urlGenerator->generate('admin_event_room',
                     ['id' => $event->getId()]));
             }
         }
+
+        $newRoom = new Room();
+        $newRoom->setEventId($event->getId());
+
+        $addForm = $this->formFactory->create(RoomType::class, $newRoom);
+        $addForm->handleRequest($request);
+
+        if ($addForm->isSubmitted() && $addForm->isValid()) {
+            $newRoom = $addForm->getData();
+            $this->roomRepository->save($newRoom);
+            $this->flashBag->add('notice', sprintf('La salle "%s" a été ajoutée.', $newRoom->getName()));
+
+            return new RedirectResponse($this->urlGenerator->generate('admin_event_room',
+                ['id' => $event->getId()]));
+        }
+
         return new Response($this->twig->render('admin/event/rooms.html.twig', [
             'event' => $event,
             'rooms' => $rooms,

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
@@ -37,10 +37,8 @@ class SpeakersManagementAction extends Controller
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        if ($id !== null) {
-            $event = $this->eventActionHelper->getEventById($id);
-        }
+
+        $event = $this->eventActionHelper->getEventById($id);
 
         return new Response($this->twig->render('admin/event/speakers_management.html.twig', [
             'event' => $event,

--- a/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
@@ -57,33 +57,30 @@ class SpecialPriceAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        $form = null;
-        if ($id !== null) {
-            $event = $this->eventActionHelper->getEventById($id);
-            /** @var User $user */
-            $user = $this->security->getUser();
-            Assertion::isInstanceOf($user, User::class);
 
-            $specialPrice = new TicketSpecialPrice();
-            $specialPrice
-                ->setToken(base64_encode(random_bytes(30)))
-                ->setEventId($event->getId())
-                ->setDateStart(new DateTime())
-                ->setDateEnd($event->getDateEndSales())
-                ->setCreatedOn(new DateTime())
-                ->setCreatorId($user->getId());
+        $event = $this->eventActionHelper->getEventById($id);
+        /** @var User $user */
+        $user = $this->security->getUser();
+        Assertion::isInstanceOf($user, User::class);
 
-            $form = $this->formFactory->create(TicketSpecialPriceType::class, $specialPrice);
-            $form->handleRequest($request);
+        $specialPrice = new TicketSpecialPrice();
+        $specialPrice
+            ->setToken(base64_encode(random_bytes(30)))
+            ->setEventId($event->getId())
+            ->setDateStart(new DateTime())
+            ->setDateEnd($event->getDateEndSales())
+            ->setCreatedOn(new DateTime())
+            ->setCreatorId($user->getId());
 
-            if ($form->isSubmitted() && $form->isValid()) {
-                $this->ticketSpecialPriceRepository->save($form->getData());
-                $this->flashBag->add('notice', 'Le token a été enregistré');
+        $form = $this->formFactory->create(TicketSpecialPriceType::class, $specialPrice);
+        $form->handleRequest($request);
 
-                return new RedirectResponse($this->urlGenerator->generate('admin_event_special_price',
-                    ['id' => $event->getId()]));
-            }
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->ticketSpecialPriceRepository->save($form->getData());
+            $this->flashBag->add('notice', 'Le token a été enregistré');
+
+            return new RedirectResponse($this->urlGenerator->generate('admin_event_special_price',
+                ['id' => $event->getId()]));
         }
 
         return new Response($this->twig->render('admin/event/special_price.html.twig', [

--- a/sources/AppBundle/Controller/Admin/Event/StatsAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/StatsAction.php
@@ -53,108 +53,102 @@ class StatsAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
-        $event = null;
-        $chart = null;
-        $pieChartConf = null;
-        $stats = null;
-        $ticketsDayOne = null;
-        $ticketsDayTwo = null;
-        if ($id !== null) {
-            $event = $this->eventActionHelper->getEventById($id);
 
-            /** @var $legacyInscriptions Inscriptions */
-            $legacyInscriptions = $this->legacyModelFactory->createObject(Inscriptions::class);
+        $event = $this->eventActionHelper->getEventById($id);
 
-            $stats = $legacyInscriptions->obtenirSuivi($event->getId());
-            $ticketsDayOne = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_ONE, $event);
-            $ticketsDayTwo = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_TWO, $event);
+        /** @var $legacyInscriptions Inscriptions */
+        $legacyInscriptions = $this->legacyModelFactory->createObject(Inscriptions::class);
 
-            $ticketTypes = [];
+        $stats = $legacyInscriptions->obtenirSuivi($event->getId());
+        $ticketsDayOne = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_ONE, $event);
+        $ticketsDayTwo = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_TWO, $event);
 
-            $chart = [
-                'chart' => [
-                    'renderTo' => 'container',
-                    'zoomType' => 'x',
-                    'spacingRight' => 20,
-                ],
-                'title' => ['text' => 'Evolution des inscriptions'],
-                'subtitle' => ['text' => 'Cliquez/glissez dans la zone pour zoomer'],
-                'xAxis' => [
-                    'type' => 'linear',
-                    'title' => ['text' => null],
-                    'allowDecimals' => false,
-                ],
-                'yAxis' => [
-                    'title' => ['text' => 'Inscriptions'],
-                    'min' => 0,
-                    'startOnTick' => false,
-                    'showFirstLabel' => false,
-                ],
-                'tooltip' => ['shared' => true],
-                'legend' => ['enabled' => true],
-                'series' => [
-                    [
-                        'name' => $event->getTitle(),
-                        'data' => array_values(array_map(static function ($item) {
-                            return $item['n'];
-                        }, $stats['suivi'])),
-                    ],
-                    [
-                        'name' => 'n-1',
-                        'data' => array_values(array_map(static function ($item) {
-                            return $item['n_1'];
-                        }, $stats['suivi'])),
-                    ],
-                ],
-            ];
+        $ticketTypes = [];
 
-            $rawStatsByType = $this->eventStatsRepository->getStats($event->getId())->ticketType->paying;
-            $totalInscrits = array_sum($rawStatsByType);
-            array_walk($rawStatsByType, function (&$item, $key) use (&$ticketTypes, $totalInscrits) {
-                if (isset($ticketTypes[$key]) === false) {
-                    $type = $this->ticketTypeRepository->get($key);
-                    $ticketTypes[$key] = $type->getPrettyName();
-                }
-                $item = ['name' => $ticketTypes[$key], 'y' => $item / $totalInscrits];
-            });
+        $chart = [
+            'chart' => [
+                'renderTo' => 'container',
+                'zoomType' => 'x',
+                'spacingRight' => 20,
+            ],
+            'title' => ['text' => 'Evolution des inscriptions'],
+            'subtitle' => ['text' => 'Cliquez/glissez dans la zone pour zoomer'],
+            'xAxis' => [
+                'type' => 'linear',
+                'title' => ['text' => null],
+                'allowDecimals' => false,
+            ],
+            'yAxis' => [
+                'title' => ['text' => 'Inscriptions'],
+                'min' => 0,
+                'startOnTick' => false,
+                'showFirstLabel' => false,
+            ],
+            'tooltip' => ['shared' => true],
+            'legend' => ['enabled' => true],
+            'series' => [
+                [
+                    'name' => $event->getTitle(),
+                    'data' => array_values(array_map(static function ($item) {
+                        return $item['n'];
+                    }, $stats['suivi'])),
+                ],
+                [
+                    'name' => 'n-1',
+                    'data' => array_values(array_map(static function ($item) {
+                        return $item['n_1'];
+                    }, $stats['suivi'])),
+                ],
+            ],
+        ];
 
-            $rawStatsByType = array_values($rawStatsByType);
+        $rawStatsByType = $this->eventStatsRepository->getStats($event->getId())->ticketType->paying;
+        $totalInscrits = array_sum($rawStatsByType);
+        array_walk($rawStatsByType, function (&$item, $key) use (&$ticketTypes, $totalInscrits) {
+            if (isset($ticketTypes[$key]) === false) {
+                $type = $this->ticketTypeRepository->get($key);
+                $ticketTypes[$key] = $type->getPrettyName();
+            }
+            $item = ['name' => $ticketTypes[$key], 'y' => $item / $totalInscrits];
+        });
 
-            $pieChartConf = [
-                "chart" => [
-                    "plotBackgroundColor" => null,
-                    "plotBorderWidth" => null,
-                    "plotShadow" => false,
-                    "type" => 'pie',
-                ],
-                "title" => [
-                    "text" => 'Répartition des types d\'inscriptions payantes',
-                ],
-                "tooltip" => [
-                    "pointFormat" => '{series.name}: <b>{point.percentage:.1f}%</b>',
-                ],
-                "plotOptions" => [
-                    "pie" => [
-                        "allowPointSelect" => true,
-                        "cursor" => 'pointer',
-                        "dataLabels" => [
-                            "enabled" => true,
-                            "format" => '<b>{point.name}</b>: {point.percentage:.1f} %',
-                            "style" => [
-                                "color" => 'black',
-                            ],
+        $rawStatsByType = array_values($rawStatsByType);
+
+        $pieChartConf = [
+            "chart" => [
+                "plotBackgroundColor" => null,
+                "plotBorderWidth" => null,
+                "plotShadow" => false,
+                "type" => 'pie',
+            ],
+            "title" => [
+                "text" => 'Répartition des types d\'inscriptions payantes',
+            ],
+            "tooltip" => [
+                "pointFormat" => '{series.name}: <b>{point.percentage:.1f}%</b>',
+            ],
+            "plotOptions" => [
+                "pie" => [
+                    "allowPointSelect" => true,
+                    "cursor" => 'pointer',
+                    "dataLabels" => [
+                        "enabled" => true,
+                        "format" => '<b>{point.name}</b>: {point.percentage:.1f} %',
+                        "style" => [
+                            "color" => 'black',
                         ],
                     ],
                 ],
-                "series" => [
-                    [
-                        "name" => 'Inscriptions',
-                        "colorByPoint" => true,
-                        "data" => $rawStatsByType,
-                    ],
+            ],
+            "series" => [
+                [
+                    "name" => 'Inscriptions',
+                    "colorByPoint" => true,
+                    "data" => $rawStatsByType,
                 ],
-            ];
-        }
+            ],
+        ];
+
         return new Response($this->twig->render('admin/event/stats.html.twig', [
             'title' => 'Suivi inscriptions',
             'event' => $event,

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
@@ -50,24 +50,21 @@ class SpeakerListAction
         Assertion::inArray($direction, self::VALID_DIRECTIONS);
         $filter = $request->query->get('filter');
         $eventId = $request->query->get('eventId');
-        $event = null;
-        $speakers=[];
-        $talks=[];
-        if ($eventId !== null) {
-            $event = $this->eventActionHelper->getEventById($eventId);
-            $speakers = $this->speakerRepository->searchSpeakers($event, $sort, $direction, $filter);
-            $talks = [];
-            foreach ($speakers as $speaker) {
-                $speakerTalks = [];
-                foreach ($this->talkRepository->getTalksBySpeaker($event, $speaker) as $talk) {
-                    if ($talk->getType() !== Talk::TYPE_PHP_PROJECT) {
-                        $speakerTalks[$talk->getTitle()] = $talk;
-                    }
+
+        $event = $this->eventActionHelper->getEventById($eventId);
+        $speakers = $this->speakerRepository->searchSpeakers($event, $sort, $direction, $filter);
+        $talks = [];
+        foreach ($speakers as $speaker) {
+            $speakerTalks = [];
+            foreach ($this->talkRepository->getTalksBySpeaker($event, $speaker) as $talk) {
+                if ($talk->getType() !== Talk::TYPE_PHP_PROJECT) {
+                    $speakerTalks[$talk->getTitle()] = $talk;
                 }
-                ksort($speakerTalks);
-                $talks[$speaker->getId()] = array_values($speakerTalks);
             }
+            ksort($speakerTalks);
+            $talks[$speaker->getId()] = array_values($speakerTalks);
         }
+
         /** @var Event[] $events */
         $events = $this->eventRepository->getAll();
 

--- a/sources/AppBundle/Controller/Event/EventActionHelper.php
+++ b/sources/AppBundle/Controller/Event/EventActionHelper.php
@@ -55,7 +55,7 @@ class EventActionHelper
         } elseif ($allowFallback) {
             $event = $this->eventRepository->getNextEvent();
 
-            if (null === $event && null !== ($latestEvent = $this->eventRepository->getLatestEvent())) {
+            if (null === $event && null !== ($latestEvent = $this->eventRepository->getLastEvent())) {
                 $event = $latestEvent;
             }
         }

--- a/sources/AppBundle/Controller/Event/EventActionHelper.php
+++ b/sources/AppBundle/Controller/Event/EventActionHelper.php
@@ -54,7 +54,12 @@ class EventActionHelper
             $event = $this->eventRepository->get((int) $id);
         } elseif ($allowFallback) {
             $event = $this->eventRepository->getNextEvent();
+
+            if (null === $event && null !== ($latestEvent = $this->eventRepository->getLatestEvent())) {
+                $event = $latestEvent;
+            }
         }
+
         if ($event === null) {
             throw new NotFoundHttpException('Could not find event');
         }

--- a/sources/AppBundle/Controller/VoteController.php
+++ b/sources/AppBundle/Controller/VoteController.php
@@ -3,6 +3,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\VoteType;
 use AppBundle\Event\Model\Repository\EventRepository;
@@ -161,11 +162,8 @@ class VoteController extends EventBaseController
 
     public function adminAction(Request $request)
     {
-        /**
-         * @var $eventRepository EventRepository
-         */
-        $eventRepository = $this->get('ting')->get(EventRepository::class);
-        $event = $this->getEvent($eventRepository, $request);
+        $eventId = $request->query->get('id');
+        $event = $this->get(EventActionHelper::class)->getEventById($eventId);
 
         $votes = $event === null ? []:$this->get('ting')->get(VoteRepository::class)->getVotesByEvent($event->getId());
 
@@ -175,19 +173,5 @@ class VoteController extends EventBaseController
             'event' => $event,
             'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
         ]);
-    }
-
-    private function getEvent(EventRepository $eventRepository, Request $request)
-    {
-        $event = null;
-        if ($request->query->has('id') !== false) {
-            $id = $request->query->getInt('id');
-            $event = $eventRepository->get($id);
-            if ($event === null) {
-                throw $this->createNotFoundException(sprintf('Could not found event'));
-            }
-        }
-
-        return $event;
     }
 }

--- a/sources/AppBundle/Controller/VoteController.php
+++ b/sources/AppBundle/Controller/VoteController.php
@@ -6,7 +6,6 @@ namespace AppBundle\Controller;
 use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\VoteType;
-use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Repository\VoteRepository;
 use AppBundle\Event\Model\Vote;

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -40,7 +40,7 @@ class EventRepository extends Repository implements MetadataInitializer
         return $events;
     }
 
-    public function getLatestEvent()
+    public function getLastEvent()
     {
         $query = $this
             ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum ORDER BY date_debut DESC, id DESC')

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -32,12 +32,21 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getNextEvents()
     {
         $query = $this
-            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
+            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
         ;
 
         $events = $query->query($this->getCollection(new HydratorSingleObject()));
 
         return $events;
+    }
+
+    public function getLatestEvent()
+    {
+        $query = $this
+            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum ORDER BY date_debut DESC, id DESC')
+        ;
+
+        return $query->query($this->getCollection(new HydratorSingleObject()))->first();
     }
 
     public function getNextEventForGithubUser(GithubUser $githubUser)


### PR DESCRIPTION

On avait plus d'event par défaut sur les pages de l'admin, le contenu était vide et il
fallait sélectionner un event. Cela n'est pas pratique. Dans la pluspart des cas on
veux accéder à l'event en cours ou au dernier event et c'est ce que modifie cette PR.