### PR TITLE
amélioration de la mise en forme des interviews sur event.afup.org

### DIFF
--- a/app/Resources/views/blog/talk.html.twig
+++ b/app/Resources/views/blog/talk.html.twig
@@ -1,17 +1,17 @@
 {% if widget_type == 'talk' or widget_type == 'all' %}
     <h3>{% if talks_infos|length > 1 %}Les conférences{% else %}La conférence{% endif %}</h3>
     {% for talks_info in talks_infos %}
-    <table>
+    <table class="talk-widget">
         <tr>
             <td width="80%" style="text-align: left;padding: 10px;vertical-align: top">
-                <h4>{{ talks_info.talk.getTitle }}</h4>
+                <h5>{{ talks_info.talk.getTitle }}</h5>
                 {% if talks_info.talk.useMarkdown %}
                     {{ talks_info.talk.getAbstract|raw|markdown }}
                 {% else %}
                     {{ talks_info.talk.getAbstract|raw }}
                 {% endif %}
             </td>
-            <td width="20%" style="vertical-align: middle">
+            <td width="20%" style="vertical-align: middle; text-align: center">
                 {{ talks_info.room.name }}<br />
                 {{ talks_info.planning.start|date('d/m/Y') }}<br />
                 {{ talks_info.planning.start|date('H:i') }}-{{ talks_info.planning.end|date('H:i') }}
@@ -24,7 +24,7 @@
 {% if widget_type == 'speaker' or widget_type == 'all' %}
     <h3>{% if speakers|length > 1 %}Les speakers{% else %}Le speaker{% endif %}</h3>
     {% for speaker in speakers %}
-    <table>
+    <table class="speaker-widget">
         <tr>
             <td width="20%" style="vertical-align: top">
                 <img src="{{ app.request.getSchemeAndHttpHost() }}{{ photo_storage.getUrl(speaker) }}" alt="{{ speaker.label }}"><br />

--- a/event/resources/themes/hestia-pro_child/style.css
+++ b/event/resources/themes/hestia-pro_child/style.css
@@ -220,3 +220,19 @@ article.conferenciers, .article-body.conferencier {
 	text-decoration: none;
 	color: #51ace4;
 }
+
+table.talk-widget,
+table.speaker-widget {
+	font-size: 0.8em;
+}
+
+table.talk-widget td,
+table.speaker-widget td {
+	border-top: 1px solid #f3f4f5;
+	border-left: 1px solid #f3f4f5;
+}
+
+.single-post-container {
+	width: 100%;
+	margin-left: 0;
+}


### PR DESCRIPTION
Suite à la mise en place du template plus moderne sur event.afup.org
les pages des interviews étaient devenues moins lisibles (les blocs
de conférence et speakers étaient moins dissociés du reste de la page).

Avec ces changements on rends plus lisible la page d'interview.

version avant nouveau template
![Screenshot 2021-08-19 at 12-12-56 La parole est aux speakers de l'AFUP Day](https://user-images.githubusercontent.com/320372/130104588-eeda5a8b-b862-4921-9982-4458cd7edbd0.png)



version courante en prod
![Screenshot 2021-08-19 at 12-14-08 La parole est aux speakers de l'AFUP Day](https://user-images.githubusercontent.com/320372/130104533-97d94b93-cff2-45af-a0c1-12bc7ca7cd7b.png)


version avec cette PR
![Screenshot 2021-08-19 at 12-14-46 La parole est aux speakers de l'AFUP Day](https://user-images.githubusercontent.com/320372/130104601-64311c87-ec99-41d7-967c-f60258988100.png)

