### PR TITLE
correction affichage personnes morales homonymes sans le sélcteur d'édition des personnes physiques

### DIFF
--- a/sources/AppBundle/Association/Form/UserEditType.php
+++ b/sources/AppBundle/Association/Form/UserEditType.php
@@ -38,7 +38,7 @@ class UserEditType extends AbstractType
             ->add('companyId', ChoiceType::class, [
                 'label' => 'Personne morale',
                 'required' => false,
-                'choices' => array_flip($this->personnesMorales->obtenirListe('id, raison_sociale', 'raison_sociale', true)),
+                'choices' => array_flip($this->personnesMorales->obtenirListe('id, CONCAT(raison_sociale, " (id : ", id, ")")', 'raison_sociale', true)),
             ])
             ->add('civility', ChoiceType::class, [
                 'label' => 'Civilité',

--- a/tests/behat/features/Admin/AdminPersonnesPhysiques.feature
+++ b/tests/behat/features/Admin/AdminPersonnesPhysiques.feature
@@ -27,3 +27,49 @@ Feature: Administration - Partie Personnes physiques
     # on supprime la personne
     When I follow "supprimer_2"
     Then I should see "La personne physique a été supprimée"
+
+  @reloadDbWithTestData
+  Scenario: Si on a deux personnes morales avc le même libellé, on affiche tout de même deux entrées dans le selecteur
+    Given I am logged in as admin and on the Administration
+    And I follow "Personnes morales"
+    Then the ".content h2" element should contain "Liste des personnes morales"
+    # ajout d'une personne morale
+    When I follow "Ajouter"
+    Then I should see "Ajouter une personne morale"
+    When I press "Ajouter"
+    Then I should see "Raison sociale manquante"
+    When I fill in "raison_sociale" with "My Corp"
+    And I fill in "adresse" with "45 rue de la défense"
+    And I fill in "code_postal" with "75001"
+    And I fill in "ville" with "Paris"
+    And I fill in "nom" with "Nom contact"
+    And I fill in "prenom" with "Prénom contact"
+    And I fill in "email" with "emailcontact@mycorp.fr"
+    And I press "Ajouter"
+    Then I should see "La personne morale a été ajoutée"
+    And I should see "Liste des personnes morales"
+    And  I should see "My Corp"
+    # ajout d'une personne morale
+    When I follow "Ajouter"
+    Then I should see "Ajouter une personne morale"
+    When I press "Ajouter"
+    Then I should see "Raison sociale manquante"
+    When I fill in "raison_sociale" with "My Corp"
+    And I fill in "adresse" with "45 rue de la défense"
+    And I fill in "code_postal" with "75001"
+    And I fill in "ville" with "Paris"
+    And I fill in "nom" with "Nom contact"
+    And I fill in "prenom" with "Prénom contact"
+    And I fill in "email" with "emailcontact@mycorp.fr"
+    And I press "Ajouter"
+    Then I should see "La personne morale a été ajoutée"
+    And I should see "Liste des personnes morales"
+    # vérification coté personnes physiques
+    And I follow "Personnes physiques"
+    Then the ".content h2" element should contain "Personnes physiques"
+    # ajout d'une personne physique
+    When I follow "Ajouter"
+    Then I should see "Ajouter une personne physique"
+    When I press "Ajouter"
+    Then I should see "Cette valeur ne doit pas être vide"
+    And the "user_edit[companyId]" field should only contain the follow values '["","My Corp (id : 354)","My Corp (id : 355)"]'


### PR DESCRIPTION
Quand on affichait, sur l'édition d'une personne morale le sélecteur de choix de personne physique,
on affichait le nom.

Maintenant sur le ChoiceType l'option ChoicesAsValues n'est plus utilisable.

Du coup il y a un array_flip de fait, et dans l'opération on perd une des personnes physiques si on avait un doublon.

Pour éviter cela, on fait un correctif (pas forcément idéal, mais fonctionnel), où on va afficher aussi l'id de
la personne morale dans le sélecteur.