### PR TITLE
mise à jour de la distribution utilisée en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP with tools
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '{{ matrix.php }}'
+          php-version: '${{ matrix.php }}'
  
       - name: Composer - Get Cache Directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
  
-      - name: PHP - Switch
-        run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php }}
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '{{ matrix.php }}'
  
       - name: Composer - Get Cache Directory
         id: composer-cache
@@ -47,8 +49,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: PHP - Switch
-        run: sudo update-alternatives --set php /usr/bin/php5.6
+      - name: Setup PHP with tools
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '5.6'
 
       - name: Composer - Get Cache Directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
   unit:
     name: "Unit tests"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
  
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
 
   lint:
     name: "Linter"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2
@@ -76,7 +76,7 @@ jobs:
 
   functional:
     name: "Functional tests"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Ubuntu 16.04 n'est plus supporté sur les Github Actions : https://github.com/actions/virtual-environments/issues/3287

Les tests ne se lançaient donc plus.

On utilise donc une version plus récente pour lancer nos tests avec shivammathur/setup-php vu que php 5.6 n'est pas sur ubuntu-18.04