### PR TITLE
Fix docker build

### DIFF
--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -2,6 +2,12 @@ FROM php:5.6-apache
 
 ARG ENABLE_XDEBUG=false
 
+## Update system
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove --purge -y && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN if [ "$ENABLE_XDEBUG" = "true" ]; then echo ************ XDEBUG ENABLED **********; \
 else echo ------------ XDEBUG DISABLED ==========; fi
 
@@ -22,6 +28,7 @@ RUN apt-get update && \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev && \
+    apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Configuration of apache & php
@@ -33,13 +40,20 @@ RUN a2enmod rewrite && \
     ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf && \
     echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
 
-RUN apt-get update && apt-get install -y build-essential wget gnupg
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        wget \
+        gnupg && \
+    curl -k -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y yarn && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install local user mapped to the host user uid
 ARG uid=1008

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -24,10 +24,6 @@ RUN apt-get update && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
     if [ "$ENABLE_XDEBUG" = "true" ]; then pecl install xdebug-2.5.5 && docker-php-ext-enable xdebug; fi && \
-    apt-get remove -y \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev && \
     apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -2,6 +2,12 @@ FROM php:7.0-apache
 
 ARG ENABLE_XDEBUG=false
 
+## Update system
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove --purge -y && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN if [ "$ENABLE_XDEBUG" = "true" ]; then echo ************ XDEBUG ENABLED **********; \
 else echo ------------ XDEBUG DISABLED ==========; fi
 
@@ -22,6 +28,7 @@ RUN apt-get update && \
         libfreetype6-dev \
         libjpeg62-turbo-dev \
         libpng-dev && \
+    apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 
 # Configuration of apache & php
@@ -33,13 +40,20 @@ RUN a2enmod rewrite && \
     ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf && \
     echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
 
-RUN apt-get update && apt-get install -y build-essential wget gnupg
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && \
+    apt-get install -y \
+        build-essential \
+        wget \
+        gnupg && \
+    curl -k -sL https://deb.nodesource.com/setup_6.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update && apt-get install -y yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update && \
+    apt-get install -y yarn && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pecl install ast-1.0.1
 RUN echo 'extension=ast.so' >> "/usr/local/etc/php/php.ini"

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -24,10 +24,6 @@ RUN apt-get update && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \
     if [ "$ENABLE_XDEBUG" = "true" ]; then pecl install xdebug-2.6.1 && docker-php-ext-enable xdebug; fi && \
-    apt-get remove -y \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev && \
     apt-get autoremove --purge -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hello,
En voulant commencer a contriuer pour l'hacktoberfest, je n'ai pa réussi à lancer le projet.

J'ai apporté quelques fixes au process de build afin de régler le soucis:
  * Mise à jour complète des paquets. Principalement pour le paquet `ca-certificates` suite à la révocation du ROOT Let's Encrypt qui empechait la récupération du script d'installation nodejs.
  * Refacto des installations de nodejs et yarn pour produire des images plus "light".

Les commandes `make docker-up` et `make init` sont désormais fonctionnelles.