### PR TITLE
correction du build docker/installation de node/yarn

### DIFF
--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         libmcrypt4 \
         libmcrypt-dev \
         libicu-dev \
+        apt-transport-https \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -34,6 +34,7 @@ RUN a2enmod rewrite && \
     ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf && \
     echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
 
+RUN sed -i '/^mozilla\/DST_Root_CA_X3.crt/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 RUN apt-get update && apt-get install -y build-essential wget gnupg
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get update && apt-get install -y nodejs

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         libmcrypt4 \
         libmcrypt-dev \
         libicu-dev \
+        apt-transport-https \
         wget && \
     docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
     docker-php-ext-install pdo_mysql mbstring mysqli zip gd mcrypt intl && \

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -34,6 +34,7 @@ RUN a2enmod rewrite && \
     ln -s /etc/apache2/sites-available/000-default.conf /etc/apache2/sites-enabled/000-default.conf && \
     echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
 
+RUN sed -i '/^mozilla\/DST_Root_CA_X3.crt/s/^/!/' /etc/ca-certificates.conf && update-ca-certificates -f
 RUN apt-get update && apt-get install -y build-essential wget gnupg
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get update && apt-get install -y nodejs


### PR DESCRIPTION
# correction du build docker

Lors du build docker on avait cette erreur :
```
E: The method driver /usr/lib/apt/methods/https could not be found.
E: Failed to fetch dl.yarnpkg.com/debian/dists/stable/InRelease
E: Some index files failed to download. They have been ignored, or old ones used instead.
Service 'cliphp' failed to build : The command '/bin/sh -c apt-get update && apt-get install -y yarn' returned a non-zero code: 100
```

Pour corriger cela on installe le paquet `apt-transport-https`.


# on supprime des builds docker le certfificat DST_Root_CA_X3.crt qui a expiré

On passe sur l'autre certificat root cross signed par letsencrypt
et cela permet d'avoir une installation correcte de node/yarn

(sans cela on avait cette erreur en executant yarn :
```
yarn install
/usr/share/yarn/lib/cli.js:46280
  let {
      ^

SyntaxError: Unexpected token {
```)