### PR TITLE
ajout de tests sur le nom du fichier de facture de cotisation

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -105,4 +105,18 @@ class FeatureContext implements Context
     {
         $this->minkContext->assertSession()->responseHeaderEquals($headerName, $expectedValue);
     }
+
+    /**
+     * @When I follow the button of tooltip :arg1
+     */
+    public function clickLinkOfTooltip($tooltip)
+    {
+        $link = $this->minkContext->getSession()->getPage()->find('css', sprintf('a[data-tooltip="%s"]', $tooltip));
+
+        if (null === $link) {
+            throw new \Exception(sprintf('Link of tooltip "%s" not found',$tooltip));
+        }
+
+        $link->click();
+    }
 }

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -97,4 +97,12 @@ class FeatureContext implements Context
             throw new \Exception(sprintf('The select has the following values %s (expected %s)', json_encode($foundValues, JSON_UNESCAPED_UNICODE), $expectedValuesJson));
         }
     }
+
+    /**
+     * @Then the response header :arg1 should equal :arg2
+     */
+    public function assertResponseHeaderEquals($headerName, $expectedValue)
+    {
+        $this->minkContext->assertSession()->responseHeaderEquals($headerName, $expectedValue);
+    }
 }

--- a/tests/behat/features/Admin/AdminPersonnesPhysiquesCotisations.feature
+++ b/tests/behat/features/Admin/AdminPersonnesPhysiquesCotisations.feature
@@ -1,0 +1,13 @@
+Feature: Administration - Partie Personnes physiques - cotisations
+
+  @reloadDbWithTestData
+  Scenario: On test le nom du fichier PDF de cotisation récupéré depuis l'admin
+    Given I am logged in as admin and on the Administration
+    And I follow "Personnes physiques"
+    And I check "alsoDisplayInactive"
+    And I press "Filtrer"
+    Then I should see "Admin"
+    When I follow "cotisations_1"
+    Then I should see "Cotisations de Admin Admin"
+    When I follow the button of tooltip "Télécharger la facture"
+    Then the response header "Content-disposition" should equal 'attachment; filename="facture-.pdf"'

--- a/tests/behat/features/MembersArea/Index.feature
+++ b/tests/behat/features/MembersArea/Index.feature
@@ -36,3 +36,13 @@ Feature: Espace membre, accueil
     Then the "contact_details[address]" field should contain "42 rue des lilas"
     And the "contact_details[zipcode]" field should contain "75001"
     And the "contact_details[city]" field should contain "Lyon Cedex"
+
+  @reloadDbWithTestData
+  Scenario: On peux télécharger la facture de cotisation
+    Given I am logged in as admin
+    And I follow "Espace membre"
+    Then I should see "Cotisations"
+    When I follow "Consulter"
+    Then I should see "Payer ma cotisation"
+    When I follow "Télécharger la facture"
+    Then the response header "Content-disposition" should equal 'attachment; filename="facture-.pdf"'


### PR DESCRIPTION
On ajoute des tests qui permettront de valider le #907 (cf #1083)