### PR TITLE
Correction lien de connexion sur mail de création de compte

### DIFF
--- a/app/Resources/views/mail_templates/confirmation_creation_compte.html.twig
+++ b/app/Resources/views/mail_templates/confirmation_creation_compte.html.twig
@@ -84,7 +84,7 @@
 
                                     <p>Connectez-vous à votre espace membre<br>
                                         login : <span>{{ login }}</span><br>
-                                        Connectez-vous au back-office à partir du site de l’AFUP, en haut à droite de la page d’accueil : <a href="http://www.afup.org">www.afup.org</a> ou en <a href="http://www.afup.org/admin">suivant le lien</a>.</p>
+                                        Connectez-vous au back-office à partir du site de l’AFUP, en haut à droite de la page d’accueil : <a href="https://afup.org">www.afup.org</a> ou en <a href="https://afup.org/member/">suivant le lien</a>.</p>
 
                                     <div class="title" style="color: #4e71b2; font-size: 18px; font-weight: bold; line-height: 24px;">Gérez votre profil membre</div>
                                     <p>Accédez au back-office pour gérer votre compte :</p>


### PR DESCRIPTION
Suite au message reçu nous avertissant qu'un lien incorrect était présent dans les mails de création de compte (inscription membre), voici la correction.
C'est la dernière occurrence que j'ai trouvé de cette url dans la codebase.