### PR TITLE
Suppression du paquet sensio/generator-bundle sur planete-php.fr

### DIFF
--- a/planete/app/PlaneteAppKernel.php
+++ b/planete/app/PlaneteAppKernel.php
@@ -19,7 +19,6 @@ class PlaneteAppKernel extends Kernel
             $bundles[] = new Symfony\Bundle\DebugBundle\DebugBundle();
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
-            $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
         }
 
         return $bundles;


### PR DESCRIPTION
Suite de la pull request #1090 

J'avais oublié d'enlever sensio/generator-bundle sur le site planete-php.fr