### PR TITLE
on permet d'accéder au blog via une clef d'API

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -69,3 +69,5 @@ parameters:
     paybox_site: "1999888"
     paybox_rang: "32"
     paybox_identifiant: "110647233"
+
+    blog_api_key: 123456

--- a/app/config/parameters.yml.dist-docker
+++ b/app/config/parameters.yml.dist-docker
@@ -72,3 +72,5 @@ parameters:
     paybox_site: "1999888"
     paybox_rang: "32"
     paybox_identifiant: "110647233"
+
+    blog_api_key: 123456

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -58,7 +58,7 @@ security:
         - { path: ^/member, roles: [ROLE_USER, ROLE_MEMBER_EXPIRED]}
         - { path: ^/admin/(members/reporting|association/relances|talk|slackmembers/check), roles: ROLE_NO_ACCESS}
         - { path: ^/admin/, roles: ROLE_MEMBER_EXPIRED }
-        - { path: ^/blog, allow_if: "request.getClientIp() in ['217.70.189.71', '127.0.0.1', '192.168.42.1'] or request.server.get('ALLOW_BLOG_FROM_ALL') == 1" }
+        - { path: ^/blog, allow_if: "request.getClientIp() in ['217.70.189.71', '127.0.0.1', '192.168.42.1'] or request.server.get('ALLOW_BLOG_FROM_ALL') == 1 or request.headers.get('x-afup-blog-api-key') == %blog_api_key%" }
         - { path: ^/blog, roles: ROLE_NO_ACCESS }
         - { path: ^/(event/\w+/tickets|association)paybox-callback, roles: IS_AUTHENTICATED_ANONYMOUSLY, ips: "%paybox_ips%" }
         - { path: ^/(event/\w+/tickets|association)paybox-callback, roles: ROLE_SUPER_ADMIN }


### PR DESCRIPTION
Avant on se basait sur l'IP. Avec le changement d'hebergement cela
sera plus adapté de se baser sur une clef d'API passée dans les entêtes
pour autoriser l'accès aux pages apellées depuis event.afup.org.