### PR TITLE
Issue #1133 pour changer le seuil de détection slackmembre

### DIFF
--- a/app/Resources/views/admin/slackmembers/index.html.twig
+++ b/app/Resources/views/admin/slackmembers/index.html.twig
@@ -2,6 +2,9 @@
 
 {% block content %}
     <h2>Vérification adhésion des membres inscrits au Slack</h2>
+    <div class="ui message">
+        <p>Cette page liste les membres qui ne sont plus à jour de cotisation depuis plus de 15 jours ou que l'on n'a pas pu rattacher à une adhésion.</p>
+    </div>
 
     {% if results %}
     <table class="ui table striped compact celled">
@@ -41,6 +44,6 @@
         </tbody>
     </table>
     {% else %}
-        Aucune incohérence détectée dans les utilisateurs sur slack.
+        <p>Aucune incohérence détectée dans les utilisateurs sur slack.</p>
     {% endif %}
 {% endblock %}

--- a/sources/AppBundle/Slack/UsersChecker.php
+++ b/sources/AppBundle/Slack/UsersChecker.php
@@ -6,6 +6,7 @@ use AppBundle\Association\Model\Repository\UserRepository;
 
 class UsersChecker
 {
+    const SUBSCRIPTION_DELAY = '+15 days';
     /**
      * @var UsersClient
      */
@@ -55,7 +56,13 @@ class UsersChecker
                     $userInfo['afup_last_subscription']=$userDb->getLastSubscription();
                     $userInfo['afup_user_id'] = $userDb->getId();
                     $userInfo['user_found']=true;
-                    if ($userDb->getLastSubscription() < $today) {
+
+                    //Issue 1133 : on n'ajoute que les utilisateurs dont la date de fin de souscription est dépassée de 15 jours.
+                    //Ca revient à tester si la date d'aujourd'hui est supérieure à la date de fin de souscription + 15 jours
+                    $dateAlarm = clone $userDb->getLastSubscription();
+                    $dateAlarm = $dateAlarm->modify(self::SUBSCRIPTION_DELAY);
+
+                    if ($dateAlarm < $today) {
                         //Utilisateur inactif ou sans souscription : a supprimer
                         $result[] = $userInfo;
                     }


### PR DESCRIPTION
Les personnes physiques arrivant en fin de cotisation reçoivent plusieurs relances par mail dont la dernière est 15 jours après la date de fin de cotisation. 
Or, le tableau dans l'admin liste les personnes dont la cotisation vient juste d'expirer sans tenir compte de ce délai de 15 jours.