### PR TITLE
amélioration décompte du bot slack sur les inscrits

### DIFF
--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -213,7 +213,7 @@ class MessageFactory
             $attachment
                 ->setTitle(sprintf('Liste des inscriptions depuis le %s : ', $date->format('d/m/Y H:i')))
             ;
-            foreach ($eventStatsFiltered->ticketType->registered as $typeId => $value) {
+            foreach ($eventStatsFiltered->ticketType->confirmed as $typeId => $value) {
                 if (0 === $value) {
                     continue;
                 }
@@ -232,13 +232,13 @@ class MessageFactory
 
         if ($event->lastsOneDay()) {
             $attachment->addField((new Field())->setShort(true)->setTitle('Journée unique')
-                ->setValue($eventStats->firstDay->registered));
+                ->setValue($eventStats->firstDay->confirmed + $eventStats->firstDay->pending));
         } else {
             $attachment
                 ->addField((new Field())->setShort(true)->setTitle('Premier jour')
-                    ->setValue($eventStats->firstDay->registered))
+                    ->setValue($eventStats->firstDay->confirmed + $eventStats->firstDay->pending))
                 ->addField((new Field())->setShort(true)->setTitle('Deuxième jour')
-                    ->setValue($eventStats->secondDay->registered))
+                    ->setValue($eventStats->secondDay->confirmed + $eventStats->secondDay->pending))
             ;
         }
 


### PR DESCRIPTION
fixes #1153

cf https://github.com/afup/web/blob/6209d0f971c001f752301c1ffd3e8c8b8dfc2a88/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php#L29
et https://github.com/afup/web/blob/6209d0f971c001f752301c1ffd3e8c8b8dfc2a88/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php#L77

On affiche le nombre de confirmés (en attente de règlement ou non), afin d'éviter
de mal interpréter le nombre envoyé (les personnes ayant eut des problèmes de paiement / n'ayant pas finalisé leur inscription étaient comptées).