### PR TITLE
On permet d'avoir une date de fin de vente des token sponsor différente de la billeterie

### DIFF
--- a/app/Resources/views/event/ticket/sponsor.html.twig
+++ b/app/Resources/views/event/ticket/sponsor.html.twig
@@ -17,7 +17,7 @@
 
             {% else %}
                 <p>
-                    {% trans with { '%date%': "<b>" ~ event.dateEndSales|localizeddate('full', 'none') ~ "</b>" } %}
+                    {% trans with { '%date%': "<b>" ~ event.dateEndSalesSponsorToken|localizeddate('full', 'none') ~ "</b>" } %}
                         Enregistrez vous-même vos invités avant le %date% dernier délai. Vos invités recevront leur convocation quelques jours avant l’événement.
                     {% endtrans %}
                 </p>

--- a/db/migrations/20220802172610_date_fin_vente_token_sponsor.php
+++ b/db/migrations/20220802172610_date_fin_vente_token_sponsor.php
@@ -1,0 +1,12 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class DateFinVenteTokenSponsor extends AbstractMigration
+{
+    public function change()
+    {
+        $this->query("ALTER TABLE afup_forum ADD date_fin_vente_token_sponsor int(11) DEFAULT NULL AFTER date_fin_vente");
+    }
+}

--- a/db/seeds/Event.php
+++ b/db/seeds/Event.php
@@ -35,6 +35,7 @@ class Event extends AbstractSeed
                 'date_fin_vote' => date('Y-m-d H:i:s', ($event - $oneMonthInSeconds * 2) + $oneDayInSeconds * 7),
                 'date_fin_prevente' => $now + $oneMonthInSeconds,
                 'date_fin_vente' => $event - $oneDayInSeconds * 7,
+                'date_fin_vente_token_sponsor' => $event - $oneDayInSeconds * 7,
                 'date_fin_saisie_repas_speakers' => $event - $oneDayInSeconds * 7,
                 'date_fin_saisie_nuites_hotel' => $event - $oneDayInSeconds * 7,
                 'place_name' => 'Paris',

--- a/htdocs/pages/administration/forum_gestion.php
+++ b/htdocs/pages/administration/forum_gestion.php
@@ -84,6 +84,8 @@ $formulaire->addElement('date', 'date_fin_prevente', 'Date de fin de pré-vente'
     ['language' => 'fr', 'format' => "dMYH:i:s", 'minYear' => 2001, 'maxYear' => date('Y') + 5]);
 $formulaire->addElement('date', 'date_fin_vente', 'Date de fin de vente',
     ['language' => 'fr', 'format' => "dMYH:i:s", 'minYear' => 2001, 'maxYear' => date('Y') + 5]);
+$formulaire->addElement('date', 'date_fin_vente_token_sponsor', 'Date de fin de vente tokens sponsors',
+    ['language' => 'fr', 'format' => "dMYH:i:s", 'minYear' => 2001, 'maxYear' => date('Y') + 5]);
 $formulaire->addElement('date', 'date_fin_saisie_repas_speakers', 'Date de fin saisie repas confférenciers',
     ['language' => 'fr', 'format' => "dMYH:i:s", 'minYear' => 2001, 'maxYear' => date('Y') + 5]);
 $formulaire->addElement('date', 'date_fin_saisie_nuites_hotel', 'Date de fin saisie nuités hotel',
@@ -186,6 +188,7 @@ if ($formulaire->validate()) {
             $formulaire->exportValue('date_fin_vote'),
             $formulaire->exportValue('date_fin_prevente'),
             $formulaire->exportValue('date_fin_vente'),
+            $formulaire->exportValue('date_fin_vente_token_sponsor'),
             $formulaire->exportValue('date_fin_saisie_repas_speakers'),
             $formulaire->exportValue('date_fin_saisie_nuites_hotel'),
             $formulaire->exportValue('date_annonce_planning'),
@@ -224,6 +227,7 @@ if ($formulaire->validate()) {
             $formulaire->exportValue('date_fin_vote'),
             $formulaire->exportValue('date_fin_prevente'),
             $formulaire->exportValue('date_fin_vente'),
+            $formulaire->exportValue('date_fin_vente_token_sponsor'),
             $formulaire->exportValue('date_fin_saisie_repas_speakers'),
             $formulaire->exportValue('date_fin_saisie_nuites_hotel'),
             $formulaire->exportValue('date_annonce_planning'),

--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -594,6 +594,7 @@ CODE_HTML;
         $date_fin_vote,
         $date_fin_prevente,
         $date_fin_vente,
+        $date_fin_vente_token_sponsor,
         $date_fin_saisie_repas_speakers,
         $date_fin_saisie_nuites_hotel,
         $date_annonce_planning,
@@ -610,7 +611,7 @@ CODE_HTML;
     ) {
         $requete = 'INSERT INTO ';
         $requete .= '  afup_forum (id, titre, nb_places, date_debut, date_fin, annee, date_fin_appel_projet,';
-        $requete .= '  date_fin_appel_conferencier, date_fin_vote, date_fin_prevente, date_fin_vente, date_fin_saisie_repas_speakers, date_fin_saisie_nuites_hotel, date_annonce_planning, path, `text`, `trello_list_id`,
+        $requete .= '  date_fin_appel_conferencier, date_fin_vote, date_fin_prevente, date_fin_vente, date_fin_vente_token_sponsor, date_fin_saisie_repas_speakers, date_fin_saisie_nuites_hotel, date_annonce_planning, path, `text`, `trello_list_id`,
         `logo_url`, `place_name`, `vote_enabled`, `speakers_diner_enabled`, `accomodation_enabled`, `waiting_list_url`, `place_address`) ';
         $requete .= 'VALUES (null,';
         $requete .= $this->_bdd->echapper($titre) . ',';
@@ -623,6 +624,7 @@ CODE_HTML;
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vote, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_prevente, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vente, true) . ',';
+        $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vente_token_sponsor, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_repas_speakers, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_nuites_hotel, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_annonce_planning, true) . ',';
@@ -653,6 +655,7 @@ CODE_HTML;
         $date_fin_vote,
         $date_fin_prevente,
         $date_fin_vente,
+        $date_fin_vente_token_sponsor,
         $date_fin_saisie_repas_speakers,
         $date_fin_saisie_nuites_hotel,
         $date_annonce_planning,
@@ -680,6 +683,7 @@ CODE_HTML;
         $requete .= '  date_fin_vote=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vote, false) . ',';
         $requete .= '  date_fin_prevente=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_prevente, true) . ',';
         $requete .= '  date_fin_vente=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vente, true) . ',';
+        $requete .= '  date_fin_vente_token_sponsor=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_vente_token_sponsor, true) . ',';
         $requete .= '  date_fin_saisie_repas_speakers=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_repas_speakers, true) . ',';
         $requete .= '  date_fin_saisie_nuites_hotel=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_nuites_hotel, true) . ',';
         $requete .= '  date_annonce_planning=' . $this->_bdd->echapperSqlDateFromQuickForm($date_annonce_planning, true) . ',';

--- a/sources/AppBundle/Controller/TicketController.php
+++ b/sources/AppBundle/Controller/TicketController.php
@@ -108,7 +108,7 @@ class TicketController extends EventBaseController
         $ticketForm->handleRequest($request);
 
         if ($ticketForm->isSubmitted() && $ticketForm->isValid() && $sponsorTicket->getPendingInvitations() > 0) {
-            if ($event->getDateEndSales() < new \DateTime()) {
+            if ($event->getDateEndSalesSponsorToken() < new \DateTime()) {
                 return $this->render(':event/ticket:sold_out.html.twig', ['event' => $event]);
             }
 
@@ -148,7 +148,7 @@ class TicketController extends EventBaseController
             'ticketForm' => $ticketForm->createView(),
             'registeredTickets' => $sponsorTicketHelper->getRegisteredTickets($sponsorTicket),
             'edit' => $edit,
-            'sold_out' => $event->getDateEndSales() < new \DateTime(),
+            'sold_out' => $event->getDateEndSalesSponsorToken() < new \DateTime(),
         ]);
     }
 

--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -68,6 +68,11 @@ class Event implements NotifyPropertyInterface
     /**
      * @var DateTime
      */
+    private $dateEndSalesSponsorToken;
+
+    /**
+     * @var DateTime
+     */
     private $dateEndSpeakersDinerInfosCollection;
 
     /**
@@ -346,6 +351,28 @@ class Event implements NotifyPropertyInterface
     {
         $this->propertyChanged('dateEndSales', $this->dateEndSales, $dateEndSales);
         $this->dateEndSales = $dateEndSales;
+        return $this;
+    }
+
+
+    /**
+     * @return DateTime
+     */
+    public function getDateEndSalesSponsorToken()
+    {
+        return $this->dateEndSalesSponsorToken;
+    }
+
+    /**
+     * @param DateTime $dateEndSalesSponsorToken
+     *
+     * @return $this
+     */
+    public function setDateEndSalesSponsorToken($dateEndSalesSponsorToken)
+    {
+        $this->propertyChanged('dateEndSalesSponsorToken', $this->dateEndSalesSponsorToken, $dateEndSalesSponsorToken);
+        $this->dateEndSalesSponsorToken = $dateEndSalesSponsorToken;
+
         return $this;
     }
 

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -258,6 +258,14 @@ SQL;
                 ]
             ])
             ->addField([
+                'columnName' => 'date_fin_vente_token_sponsor',
+                'fieldName' => 'dateEndSalesSponsorToken',
+                'type' => 'datetime',
+                'serializer_options' => [
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
+                ]
+            ])
+            ->addField([
                 'columnName' => 'date_fin_saisie_repas_speakers',
                 'fieldName' => 'dateEndSpeakersDinerInfosCollection',
                 'type' => 'datetime',


### PR DESCRIPTION
On permet d'avoir une date de fin de vente des token sponsor différente de la billeterie.
Pour cela, on ajoute un nouveau champ en base, administrable et qu'on utilise sur le controlleur des tokens sponsor.