### PR TITLE
feat (#1138): redirection dynamique de become-sponsor

### DIFF
--- a/app/config/routing/global.yml
+++ b/app/config/routing/global.yml
@@ -3,3 +3,7 @@ home:
   defaults: {_controller: AppBundle:Home:display}
   options:
     sitemap: true
+
+become_sponsor_latest:
+  path: /become-sponsor
+  defaults: {_controller: AppBundle:Lead:becomeSponsorLatest}

--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -19,7 +19,6 @@
 
 RewriteEngine On
 
-RewriteRule ^become-sponsor$  "/event/afupday2022lille/sponsor/become-sponsor" [L,R=302]
 RewriteRule ^super-apero$  "/association/super-apero" [L,R=302]
 RewriteRule ^superapero$  "/association/super-apero" [L,R=302]
 RewriteRule ^association/super-apero-8-mars-2018$ "/super-apero" [L,R=302]

--- a/sources/AppBundle/Controller/LeadController.php
+++ b/sources/AppBundle/Controller/LeadController.php
@@ -4,6 +4,8 @@ namespace AppBundle\Controller;
 
 use AppBundle\Event\Form\LeadType;
 use AppBundle\Event\Model\Lead;
+use AppBundle\Event\Model\Repository\EventRepository;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
 
@@ -44,5 +46,17 @@ class LeadController extends EventBaseController
     {
         $event = $this->checkEventSlug($eventSlug);
         return $this->render(':event/sponsorship_file:thanks.html.twig', ['event' => $event]);
+    }
+
+    /**
+     * Redirige vers la page de sponsoring du dernier événement.
+     *
+     * @return RedirectResponse
+     */
+    public function becomeSponsorLatestAction()
+    {
+        $event = $this->get('ting')->get(EventRepository::class)->getCurrentEvent();
+
+        return new RedirectResponse($this->generateUrl('sponsor_leads', ['eventSlug' => $event->getPath()]));
     }
 }

--- a/tests/behat/features/PublicSite/Sponsor.feature
+++ b/tests/behat/features/PublicSite/Sponsor.feature
@@ -1,0 +1,7 @@
+Feature: Site Public - Devenir sponsor
+
+  @reloadDbWithTestData
+  Scenario: Depuis /become-sponsor, on est redirigé vers la page de sponsoring du dernier événement
+    Given I go to "/become-sponsor"
+    Then the url should match "/event/forum/sponsor/become-sponsor"
+    And the ".container h2" element should contain "Devenir sponsor"


### PR DESCRIPTION
Rend la redirection `/become-sponsor` dynamique vers le dernier événement courant.
Issue #1138 