### PR TITLE
correction de la valeur par défaut du needsUpToDateMembership

### DIFF
--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -156,7 +156,7 @@ class User implements NotifyPropertyInterface, UserInterface, \Serializable, Not
     /**
      * @var bool
      */
-    private $needsUpToDateMembership = true;
+    private $needsUpToDateMembership = false;
 
     /**
      * @return int


### PR DESCRIPTION
Le needsUpToDateMembership est manuellement configuré pour certains
membres AFUP (bureau, coordinateur/coordinatrice modérateur/modératice d'antenne..),
il doit donc être à faux par défaut (il permet un reporting pour vérifier que ces
personnes soient bien à jour de leur cotisation).