### PR TITLE
correction de l'affichage du planning dans le BO

### DIFF
--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -419,7 +419,7 @@ CODE_HTML;
 
 CODE_HTML;
                 /* On boucle maintenant sur chaque demi-heure de l'agenda (de 08h00 à 18h00 */
-                for ($h = 8; $h < 18; $h++) {
+                for ($h = 8; $h < 19; $h++) {
                     for ($i = 0; $i < 12; $i++) {
                         $bKeynote = false;
                         $m = sprintf('%02d', 5 * $i);


### PR DESCRIPTION
Dans le BO le planning ne s'affiche pas après 18h.
Or cette année il est prévu d'avoir des slots après cet horaire.
Ce changement permet de générer dans le BO le planning jusqu'à 19h.
(pour le planning affiché sur event depuis le controleur de Blog, on a pas cette contrainte).