### PR TITLE
On n'exporte pas les billets en erreur de paiement pour la génération des badges

### DIFF
--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -93,8 +93,12 @@ class RegistrationsExportGenerator
         $tickets = $this->ticketRepository->getByEvent($event);
 
         foreach ($tickets as $ticket) {
-            if ($ticket->getStatus() == Ticket::STATUS_CANCELLED) {
+            if (
+                $ticket->getStatus() == Ticket::STATUS_CANCELLED
+                ||  $ticket->getStatus() == Ticket::STATUS_ERROR
+            ) {
                 // On n'exporte pas les billets inscriptions annulées
+                // ou en erreur de paiement
                 continue;
             }
 

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -93,12 +93,14 @@ class RegistrationsExportGenerator
         $tickets = $this->ticketRepository->getByEvent($event);
 
         foreach ($tickets as $ticket) {
+            $status = $ticket->getStatus();
             if (
-                $ticket->getStatus() == Ticket::STATUS_CANCELLED
-                ||  $ticket->getStatus() == Ticket::STATUS_ERROR
+                $status == Ticket::STATUS_CANCELLED
+                ||  $status == Ticket::STATUS_ERROR
+                ||  $status == Ticket::STATUS_DECLINED
             ) {
                 // On n'exporte pas les billets inscriptions annulées
-                // ou en erreur de paiement
+                // ou en erreur de paiement / refusées
                 continue;
             }
 


### PR DESCRIPTION
Je cache pas que j'ai un peu fait ça l'aveugle. 
J'avoue avoir raté un truc sur le mapping des colonnes entre "etat" et "status" mais je suis confiant :sweat_smile: 
