### PR TITLE
correction sur la validation des virements en attente

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -32,7 +32,7 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getNextEvents()
     {
         $query = $this
-            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
+            ->getQuery('SELECT id, path, titre, text, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
         ;
 
         $events = $query->query($this->getCollection(new HydratorSingleObject()));
@@ -43,7 +43,7 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getLastEvent()
     {
         $query = $this
-            ->getQuery('SELECT id, path, titre, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum ORDER BY date_debut DESC, id DESC')
+            ->getQuery('SELECT id, path, titre, text, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum ORDER BY date_debut DESC, id DESC')
         ;
 
         return $query->query($this->getCollection(new HydratorSingleObject()))->first();


### PR DESCRIPTION
Une erreur 500 nous a été remontée lors de la validation d'un virement en attente.

Cela vient d'un problème lors de l'envoi du mail d'inscription, après validation.

Le mail est envoyé ici : https://github.com/afup/web/blob/46fe3e2f99a767f803afa334a21919a6ec408c89/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php#L123

Où on vérifie qu'on a bien le contenu administré disponible et sinon renvoie une exception : https://github.com/afup/web/blob/2bb8beaae2a81c3bbb9f2ac8b520a14851e2320c/sources/AppBundle/Email/Emails.php#L25

Ce contenu administré n'est pas disponible car on a récupéré un objet Event qui n'a pas le champ cfp (rempli avec la valeur "text") de renseigné.

Cela car vu qu'on est sur l'event par défaut on a pas fait de getid, mais un getNextEvent/getLastEvent : https://github.com/afup/web/blob/9ca794d10802c263bdfc4fb9f829180a99102ce1/sources/AppBundle/Controller/Event/EventActionHelper.php#L50

Pour corriger cela rapidement, on rajoute donc la récupération du champ text et ainsi permettre d'envoyer les mails d'inscription lors de la validation des virements.