### PR TITLE
fix (#1193): tarif spécial CFP

### DIFF
--- a/app/Resources/translations/validators.fr.yml
+++ b/app/Resources/translations/validators.fr.yml
@@ -6,3 +6,4 @@
 'You must use the same email for your ticket and you membership.': "Vous devez utiliser l'adresse email liée à votre adhésion pour ce billet."
 'You must be connected with a valid membership to order this ticket.': "Vous devez être connecté et avoir une adhésion en cours de validité pour commander ce billet"
 'Please, upload a photo.': "Veuillez ajouter une photo de profil."
+'You can only order one ticket "{{ ticket_pretty_name }}".': Vous ne pouvez commander qu'un seul billet "{{ ticket_pretty_name }}"

--- a/app/Resources/views/event/ticket/ticket.html.twig
+++ b/app/Resources/views/event/ticket/ticket.html.twig
@@ -108,6 +108,7 @@
             </div>
 
             {% set currentDate = 'now'|date('Y-m-d') %}
+            {{ form_errors(ticketForm.tickets) }}
 
             {% for key,ticket in ticketForm.tickets %}
                 <fieldset class="f{{ key+1 }} tickets--fieldset">
@@ -120,8 +121,8 @@
                         {{ form_row(ticket.phoneNumber) }}
                         {{ form_row(ticket.nearestOffice) }}
 
-                        {{ form_errors(ticket.ticketEventType) }}
                         {{ form_label(ticket.ticketEventType) }}
+                        {{ form_errors(ticket.ticketEventType) }}
                         <ul class="tickets--type-list">
                             {% set endDate = null %}
                             {% for type in ticket.ticketEventType %}

--- a/db/seeds/EventTarif.php
+++ b/db/seeds/EventTarif.php
@@ -28,6 +28,13 @@ class EventTarif extends AbstractSeed
                 'date_start' => '2010-01-01 10:00:00',
                 'date_end' => '2099-12-31 23:59:59',
             ],
+            [
+                'id_tarif' => 5,
+                'id_event' => Event::ID_FORUM,
+                'price' => 2,
+                'date_start' => '2010-01-01 10:00:00',
+                'date_end' => '2099-12-31 23:59:59',
+            ],
         ];
 
         $table = $this->table('afup_forum_tarif_event');

--- a/db/seeds/Tarif.php
+++ b/db/seeds/Tarif.php
@@ -51,6 +51,17 @@ class Tarif extends AbstractSeed
                 'day' => 'one,two',
                 'cfp_submitter_only' => false,
             ],
+            [
+                'id' => 5,
+                'technical_name' => 'AFUP_CFP',
+                'pretty_name' => 'Spécial CFP',
+                'public' => true,
+                'members_only' => false,
+                'default_price' => 2,
+                'active' => true,
+                'day' => 'one,two',
+                'cfp_submitter_only' => true,
+            ],
         ];
 
         $table = $this->table('afup_forum_tarif');

--- a/sources/AppBundle/Event/Form/PurchaseType.php
+++ b/sources/AppBundle/Event/Form/PurchaseType.php
@@ -59,6 +59,7 @@ class PurchaseType extends AbstractType
                     'member_type' => $options['member_type'],
                     'is_cfp_submitter' => $options['is_cfp_submitter'],
                     'special_price_token' => $options['special_price_token'],
+                    'error_bubbling' => false,
                 ]
             ])
             ->add('paymentType', ChoiceType::class, [

--- a/sources/AppBundle/Event/Form/TicketType.php
+++ b/sources/AppBundle/Event/Form/TicketType.php
@@ -146,6 +146,7 @@ class TicketType extends AbstractType
                 'label' => 'Formule',
                 'choices' => $filteredEventTickets,
                 'choice_label' => 'ticketType.prettyName',
+                'error_bubbling' => false,
                 'choice_attr' => function (\AppBundle\Event\Model\TicketEventType $type, $key, $index) use ($options, $event) {
                     $attr = [
                         'data-description' => $type->getDescription(),

--- a/sources/AppBundle/Event/Model/Invoice.php
+++ b/sources/AppBundle/Event/Model/Invoice.php
@@ -118,6 +118,7 @@ class Invoice implements NotifyPropertyInterface
      * @var Ticket[]
      * @Assert\Valid()
      * @AfupAssert\CorporateMember(groups={"corporate"})
+     * @AfupAssert\TicketsCfpSubmitter()
      */
     private $tickets = [];
 

--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -113,17 +113,24 @@ class SpeakerRepository extends Repository implements MetadataInitializer
     }
 
     /**
+     * Retourne `true` si le speaker avec l'email ($email) a soumis au moins 1 CFP pour l'évènement ($event) passé en paramètre.
+     *
      * @param Event $event
      * @param string $email
      *
-     * @return Speaker|null
+     * @return bool
      */
-    public function getByEventAndEmail(Event $event, $email)
+    public function hasCFPSubmitted(Event $event, $email)
     {
-        return $this->getBy([
-            'eventId' => $event->getId(),
-            'email' => $email,
-        ])->first();
+        $query = $this->getPreparedQuery(
+            'SELECT COUNT(afup_conferenciers.conferencier_id) AS cfp
+        FROM afup_conferenciers
+        JOIN afup_conferenciers_sessions ON (afup_conferenciers_sessions.conferencier_id = afup_conferenciers.conferencier_id)
+        JOIN afup_sessions ON (afup_conferenciers_sessions.session_id = afup_sessions.session_id)
+        WHERE afup_sessions.id_forum = :eventId AND afup_conferenciers.email = :email'
+        )->setParams(['eventId' => $event->getId(), 'email' => $email]);
+
+        return $query->query()->first()[0]->cfp > 0;
     }
 
     /**

--- a/sources/AppBundle/Event/Ticket/PurchaseTypeFactory.php
+++ b/sources/AppBundle/Event/Ticket/PurchaseTypeFactory.php
@@ -62,7 +62,7 @@ class PurchaseTypeFactory
             }
         }
 
-        $isCfpSubmitter = null !== $user && null !== $this->speakerRepository->getByEventAndEmail($event, $user->getEmail());
+        $isCfpSubmitter = null !== $user && $this->speakerRepository->hasCFPSubmitted($event, $user->getEmail());
 
         $invoice = $this->invoiceFactory->createInvoiceForEvent($event);
         $ticket = new Ticket();

--- a/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitter.php
+++ b/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppBundle\Event\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class TicketsCfpSubmitter extends Constraint
+{
+    public $messageTooMuchCfpSubmitterTickets = 'You can only order one ticket "{{ ticket_pretty_name }}".';
+
+    public function getTargets()
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitterValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitterValidator.php
@@ -10,7 +10,7 @@ class TicketsCfpSubmitterValidator extends ConstraintValidator
 {
     /**
      * @param Ticket[] $value
-     * @param PersonalMember $constraint
+     * @param TicketsCfpSubmitter $constraint
      * @return void
      */
     public function validate($value, Constraint $constraint)
@@ -27,7 +27,7 @@ class TicketsCfpSubmitterValidator extends ConstraintValidator
                 if ($specialCFPSubmitter > 1) {
                     $this->context->buildViolation($constraint->messageTooMuchCfpSubmitterTickets)
                         ->setParameter('{{ ticket_pretty_name }}', $ticket->getTicketEventType()->getTicketType()->getPrettyName())
-                        ->atPath($index)
+                        ->atPath('[' . $index . '].ticketEventType')
                         ->addViolation()
                     ;
                 }

--- a/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitterValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/TicketsCfpSubmitterValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AppBundle\Event\Validator\Constraints;
+
+use AppBundle\Event\Model\Ticket;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class TicketsCfpSubmitterValidator extends ConstraintValidator
+{
+    /**
+     * @param Ticket[] $value
+     * @param PersonalMember $constraint
+     * @return void
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        $specialCFPSubmitter = 0;
+
+        foreach ($value as $index => $ticket) {
+            if ($ticket->getTicketEventType() &&
+                $ticket->getTicketEventType()->getTicketType() &&
+                $ticket->getTicketEventType()->getTicketType()->getIsRestrictedToCfpSubmitter()) {
+                $specialCFPSubmitter++;
+
+                // On autorise qu'un seul ticket au tarif CFP submitter
+                if ($specialCFPSubmitter > 1) {
+                    $this->context->buildViolation($constraint->messageTooMuchCfpSubmitterTickets)
+                        ->setParameter('{{ ticket_pretty_name }}', $ticket->getTicketEventType()->getTicketType()->getPrettyName())
+                        ->atPath($index)
+                        ->addViolation()
+                    ;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Corrige le bug : https://github.com/afup/web/issues/1193

On vérifie qu'il y a eu au moins 1 CFP de proposer pour pouvoir bénéficier du tarif préférentiel.
Modification de la requête SQL pour faire le lien avec la table `afup_sessions`.

J'ai également ajouté un tarif préférentiel CFP (`'cfp_submitter_only' => true`) en fixture.