### PR TITLE
on corrige le calendrier mobile pour les horaires après 19h

### DIFF
--- a/htdocs/calendrier/js/directives/FullCalendarDirective.js
+++ b/htdocs/calendrier/js/directives/FullCalendarDirective.js
@@ -21,7 +21,7 @@ planningPHPTourApp.directive('fullcalendar', function() {
                 slotMinutes:15,
                 firstHour:8,
                 minTime:8,
-                maxTime:18,
+                maxTime:19,
                 slotEventOverlap: false,
                 h: 850,
                 timeFormat: 'HH:mm { - HH:mm}',


### PR DESCRIPTION
Sur mobile on affichait ni le burger quiz ni la keynote de cloture, cela car on allait au maximum jusqu'à 18h.

Ce n'est pas le cas de ce Forum où on a des slots sur le créneau de 19h.

On augmente donc l'heure maximum du calendrier.

avant le fix
![Screenshot 2022-09-22 at 22-56-57 Planning Forum PHP 2022](https://user-images.githubusercontent.com/320372/191849609-bc3ec4c8-96a7-4633-bb54-615c9323300d.png)


après le fix
![Screenshot 2022-09-22 at 22-53-01 Planning Forum PHP 2022](https://user-images.githubusercontent.com/320372/191849665-9c2fef44-a709-4a5d-a2b7-c77e6d7e5a81.png)

