### PR TITLE
correction sur la vérification des users inscrits au slack

### DIFF
--- a/sources/AppBundle/Slack/UsersChecker.php
+++ b/sources/AppBundle/Slack/UsersChecker.php
@@ -57,14 +57,20 @@ class UsersChecker
                     $userInfo['afup_user_id'] = $userDb->getId();
                     $userInfo['user_found']=true;
 
-                    //Issue 1133 : on n'ajoute que les utilisateurs dont la date de fin de souscription est dépassée de 15 jours.
-                    //Ca revient à tester si la date d'aujourd'hui est supérieure à la date de fin de souscription + 15 jours
-                    $dateAlarm = clone $userDb->getLastSubscription();
-                    $dateAlarm = $dateAlarm->modify(self::SUBSCRIPTION_DELAY);
+                    $lastSubscription = $userDb->getLastSubscription();
 
-                    if ($dateAlarm < $today) {
-                        //Utilisateur inactif ou sans souscription : a supprimer
+                    if (null === $lastSubscription) {
                         $result[] = $userInfo;
+                    } else {
+                        //Issue 1133 : on n'ajoute que les utilisateurs dont la date de fin de souscription est dépassée de 15 jours.
+                        //Ca revient à tester si la date d'aujourd'hui est supérieure à la date de fin de souscription + 15 jours
+                        $dateAlarm = clone $lastSubscription;
+                        $dateAlarm = $dateAlarm->modify(self::SUBSCRIPTION_DELAY);
+
+                        if ($dateAlarm < $today) {
+                            //Utilisateur inactif ou sans souscription : a supprimer
+                            $result[] = $userInfo;
+                        }
                     }
                 } catch (\Symfony\Component\Security\Core\Exception\UsernameNotFoundException $e) {
                     //User Not found ! A supprimer de slack !


### PR DESCRIPTION
On peux se retrouver dans ces cas où on a un user sur slack qui n'a aucune cotisation, dans ce cas là on ne peux pas lui rajouter les 15 jours, on se retrouve avec une erreur 500 à cause d'un appel sur un null.