### PR TITLE
on augmente la taille du texte du CFP

### DIFF
--- a/htdocs/css/vote.css
+++ b/htdocs/css/vote.css
@@ -891,7 +891,8 @@ div.photo-container{
     margin: auto;
     margin-top: 2rem;
     padding-top: 2rem;
-    width: 75%
+    width: 75%;
+    font-size: 1.3em;
 }
 
 #date {


### PR DESCRIPTION
le texte du CPF était un peu petit, on l'augmente afin de lui donne plus de visibilité.

exemple avant:
![Screenshot 2022-10-17 at 22-43-29 AFUP - Soumettez une conférence pour le Forum PHP 2019](https://user-images.githubusercontent.com/320372/196280591-5b2a1ab4-fd0a-4966-9a29-b3a99af3e2c8.png)

exemple après:
![Screenshot 2022-10-17 at 22-43-12 AFUP - Soumettez une conférence pour le Forum PHP 2019](https://user-images.githubusercontent.com/320372/196280635-da647a1b-30a3-4eed-b1cc-a2f26a477def.png)

