### PR TITLE
feat (#1156): admin tarification evenement - rendre le champ description non obligatoire

### DIFF
--- a/db/migrations/20221020065442_tarif_event_description_nullable.php
+++ b/db/migrations/20221020065442_tarif_event_description_nullable.php
@@ -1,0 +1,11 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class TarifEventDescriptionNullable extends AbstractMigration
+{
+    public function change()
+    {
+        $this->query("ALTER TABLE afup_forum_tarif_event MODIFY description VARCHAR(1024) DEFAULT NULL");
+    }
+}

--- a/sources/AppBundle/Association/Form/TicketEventType.php
+++ b/sources/AppBundle/Association/Form/TicketEventType.php
@@ -50,9 +50,7 @@ class TicketEventType extends AbstractType
                 'label' => 'Date de fin'
             ])
             ->add('description', TextareaType::class, [
-                'constraints' => [
-                    new NotBlank()
-                ],
+                'required' => false,
                 'label' => 'Description'
             ])
             ->add('maxTickets', IntegerType::class, [


### PR DESCRIPTION
**Impact**
Page d'administration - Tarification d'un événement

**Contenu**
- fichier migration DB
- mise à jour de la contrainte sur le champ description