### PR TITLE
fix (#1221): corrige le problème de récupération de l'URL mailchimp

### DIFF
--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -180,9 +180,10 @@ class TechLetterGenerateController extends SiteBaseController
 
             if ($this->isCsrfTokenValid('sendToMailchimpAndSchedule', $request->request->get('_csrf_token'))) {
                 try {
-                    $response = $this->get('app.mailchimp_techletter_api')->scheduleCampaign($response['id'], $sending->getSendingDate());
-                    $message = sprintf("Newsletter envoyée, verrouillée et planifiée pour être envoyée à %s sur Mailchimp",
-                        $sending->getSendingDate()->format('d/m/Y H:i')
+                    $this->get('app.mailchimp_techletter_api')->scheduleCampaign($response['id'], $sending->getSendingDate());
+                    $message = sprintf("Newsletter envoyée, verrouillée et planifiée pour être envoyée à %s (%s) sur Mailchimp",
+                        $sending->getSendingDate()->format('d/m/Y H:i'),
+                        $sending->getSendingDate()->getTimezone()->getName()
                     );
                     $this->addFlash('notice', $message);
                 } catch (\Exception $exception) {


### PR DESCRIPTION
fixes #1221 

J'ai supprimé la variable `$response` en retour de l'appel à Mailchimp elle n'était pas utilisée de toute façon.

J'en ai profité pour ajouter la `timezone` dans le message de confirmation Mailchimp. C'est un point qui a été remonté dans Slack.