### PR TITLE
correction installation mailcatcher

### DIFF
--- a/docker/dockerfiles/mailcatcher/Dockerfile
+++ b/docker/dockerfiles/mailcatcher/Dockerfile
@@ -16,6 +16,9 @@ RUN apk add --no-cache --virtual .build-deps \
         ruby-dev \
         make g++ \
         sqlite-dev \
+    && gem install -v 0.1.2 net-protocol --no-ri --no-rdoc \
+    && gem install -v 0.3.0 net-smtp --no-ri --no-rdoc \
+    && gem install -v 0.2.2 net-imap --no-ri --no-rdoc \
     && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc \
     && apk del .build-deps
 


### PR DESCRIPTION
les tests ne passaient plus car des versions sur les dépendances de mailcatcher avaient changée, on les force donc et évite d'avoir des erreurs comme celle-ci :

```
	net-protocol requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```

qui faisait que les tests fonctionnels ne tournaient plus (en plus de ne plus pouvoir utiliser mailcatcher sur on rebuilde en local)