### PR TITLE
configuration cors pour openfeedback

### DIFF
--- a/sources/AppBundle/Controller/EventController.php
+++ b/sources/AppBundle/Controller/EventController.php
@@ -147,6 +147,10 @@ class EventController extends EventBaseController
 
         $generator = new OpenfeedbackJsonGenerator($talkRepository, $photoStorage);
 
-        return new JsonResponse($generator->generate($event));
+        $response =  new JsonResponse($generator->generate($event));
+
+        $response->headers->set('Access-Control-Allow-Origin', 'https://openfeedback.io');
+
+        return $response;
     }
 }


### PR DESCRIPTION
la validation de l'url par openfeedback se fait coté client, c'est le navigateur qui fait la requête. On a donc une requête Cross Origin qui est faite et ne passait pas.
Afin d'éviter cela, on autorise openfeedback à faire l'appel en crossorigin.