### PR TITLE
Add link to Slack member administration

### DIFF
--- a/app/Resources/views/admin/slackmembers/index.html.twig
+++ b/app/Resources/views/admin/slackmembers/index.html.twig
@@ -4,7 +4,7 @@
     <h2>Vérification adhésion des membres inscrits au Slack</h2>
     <div class="ui message">
         <p>Cette page liste les membres qui ne sont plus à jour de cotisation depuis plus de 15 jours ou que l'on n'a pas pu rattacher à une adhésion.</p>
-        <p>Page de <a href="https://afup.slack.com/admin" target="_blank">Gestion des membres Slack</a>.</p>
+        <p>Page de <a href="https://afup-membres.slack.com/admin" target="_blank">Gestion des membres Slack</a>.</p>
     </div>
 
     {% if results %}

--- a/app/Resources/views/admin/slackmembers/index.html.twig
+++ b/app/Resources/views/admin/slackmembers/index.html.twig
@@ -4,6 +4,7 @@
     <h2>Vérification adhésion des membres inscrits au Slack</h2>
     <div class="ui message">
         <p>Cette page liste les membres qui ne sont plus à jour de cotisation depuis plus de 15 jours ou que l'on n'a pas pu rattacher à une adhésion.</p>
+        <p>Page de <a href="https://afup.slack.com/admin" target="_blank">Gestion des membres Slack</a>.</p>
     </div>
 
     {% if results %}


### PR DESCRIPTION
Ajout du lien vers la page d'administration des membres Slack directement dans la page du BO concernée pour faciliter la gestion des membres.