### PR TITLE
ajout du compte dans l'export Excel du journal de banque

### DIFF
--- a/htdocs/pages/administration/compta_banque.php
+++ b/htdocs/pages/administration/compta_banque.php
@@ -92,6 +92,7 @@ if ($action == 'lister') {
         $sheet->setCellValue('H3', 'Commentaire');
         $sheet->setCellValue('I3', 'Justificatif');
         $sheet->setCellValue('J3', 'Nom du justificatif');
+        $sheet->setCellValue('K3', 'Nom du compte');
     }
     foreach ($journal as $ecriture) {
         $sheet = $workbook->getSheet($ecriture['mois']);
@@ -108,6 +109,7 @@ if ($action == 'lister') {
         $sheet->setCellValue('H' . $compteurLigne[$ecriture['mois']], $ecriture['comment']);
         $sheet->setCellValue('I' . $compteurLigne[$ecriture['mois']], $ecriture['attachment_required'] ? 'Oui' : 'Non');
         $sheet->setCellValue('J' . $compteurLigne[$ecriture['mois']], $ecriture['attachment_filename']);
+        $sheet->setCellValue('K' . $compteurLigne[$ecriture['mois']], $ecriture['compta_compte_nom_compte']);
         $compteurLigne[$ecriture['mois']]++;
     }
     for ($i = 1; $i < 13; $i++) {
@@ -120,7 +122,7 @@ if ($action == 'lister') {
                 'name' => 'Ubuntu'
             )
         ));
-        $sheet->getStyle('A3:J3')->applyFromArray(array(
+        $sheet->getStyle('A3:K3')->applyFromArray(array(
             'font' => array(
                 'size' => 10,
                 'bold' => true,
@@ -134,7 +136,7 @@ if ($action == 'lister') {
                 )
             )
         ));
-        $sheet->getStyle('A4:J' . ($compteurLigne[$i] + 1))->applyFromArray(array(
+        $sheet->getStyle('A4:K' . ($compteurLigne[$i] + 1))->applyFromArray(array(
             'font' => array(
                 'size' => 10,
                 'name' => 'Ubuntu'

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -50,7 +50,8 @@ class Comptabilite
         $requete .= 'compta_reglement.reglement, ';
         $requete .= 'compta_evenement.evenement, compta.idevenement, ';
         $requete .= 'compta_categorie.categorie, compta.idcategorie, ';
-        $requete .= 'compta.attachment_required, compta.attachment_filename ';
+        $requete .= 'compta.attachment_required, compta.attachment_filename, ';
+        $requete .= 'compta_compte.nom_compte as compta_compte_nom_compte ';
         $requete .= 'FROM  ';
         $requete .= 'compta  ';
         $requete .= 'LEFT JOIN ';
@@ -59,6 +60,8 @@ class Comptabilite
         $requete .= 'compta_reglement on compta_reglement.id=compta.idmode_regl ';
         $requete .= 'LEFT JOIN ';
         $requete .= 'compta_evenement on compta_evenement.id=compta.idevenement ';
+        $requete .= 'LEFT JOIN ';
+        $requete .= 'compta_compte on compta_compte.id=compta.idcompte ';
         $requete .= 'WHERE  ';
         $requete .= 'compta.date_regl >= \'' . $periode_debut . '\' ';
         $requete .= 'AND compta.date_regl <= \'' . $periode_fin . '\'  ';


### PR DESCRIPTION
Cela permet d'avoir dans l'export Excel une colonne avec le compte.
Une second PR va probablement venir pour faire un export unifié avec plusieurs comptes.