### PR TITLE
Suppression email organisateur dans email inscription

### DIFF
--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -62,7 +62,6 @@ class Emails
     {
         $uid = md5($event->getId());
         $organizerCN = MailUserFactory::afup()->getName();
-        $organizerEmail = MailUserFactory::afup()->getEmail();
         $attendeeCN = $recipient->getName();
         $attendeeEmail = $recipient->getEmail();
         $created = (new \DateTime())->setTimezone(new \DateTimeZone('UTC'))->format('Ymd\THis\Z');
@@ -80,7 +79,7 @@ BEGIN:VEVENT
 DTSTART;VALUE=DATE:{$dtStart}
 DTEND;VALUE=DATE:{$dtEnd}
 DTSTAMP:{$created}
-ORGANIZER:CN={$organizerCN}:mailto:{$organizerEmail}
+ORGANIZER:CN={$organizerCN}
 ATTENDEE:CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;CN=
 {$attendeeEmail};X-NUM-GUESTS=0:mailto:{$attendeeCN}
 UID:{$uid}


### PR DESCRIPTION
Supprime l'email de l'organisateur dans le ICS de l'email d'inscription. Cela évite de se faire spammer via Google Calendar.