### PR TITLE
correction du paiement des billets par virement

### DIFF
--- a/sources/AppBundle/Compta/BankAccount/BankAccountFactory.php
+++ b/sources/AppBundle/Compta/BankAccount/BankAccountFactory.php
@@ -16,10 +16,14 @@ class BankAccountFactory
         $this->configuration = $configuration;
     }
 
-    public function createApplyableAt(\DateTimeInterface $applicationDate)
+    public function createApplyableAt(\DateTimeInterface $applicationDate = null)
     {
-        $comparisonDate = \DateTime::createFromFormat('Y-m-d', $this->configuration->obtenir('rib_ce|valid_until'));
-        $configKey = $applicationDate <= $comparisonDate ? 'rib_ce' : 'rib';
+        if (null === $applicationDate) {
+            $configKey = 'rib';
+        } else {
+            $comparisonDate = \DateTime::createFromFormat('Y-m-d', $this->configuration->obtenir('rib_ce|valid_until'));
+            $configKey = $applicationDate <= $comparisonDate ? 'rib_ce' : 'rib';
+        }
 
         return new BankAccount(
             $this->configuration->obtenir($configKey . '|etablissement'),


### PR DESCRIPTION
quand on payait les billets par virement on tombait sur une 500.

En dev on avait cette erreur

```
Catchable Fatal Error: Argument 1 passed to AppBundle\Compta\BankAccount\BankAccountFactory::createApplyableAt() must implement interface DateTimeInterface, null given, called in /var/www/html/sources/AppBundle/Controller/TicketController.php on line 302 and defined
```

Cela car ici : https://github.com/afup/web/blob/a06958c90297e474cb02c33a149a16ec127d81fe/sources/AppBundle/Controller/TicketController.php#L301

la date est nulle vu que le paiement n'a pas été réalisé. (ça pourrait être utile plus tard sur les factures d'avoir une date d'émission en plus de cette date de paiement)

On se prémuni donc de ce genre de cas, en affichant si la date est nulle, le RIB le plus récent.