### PR TITLE
correction erreur de memory limit lors du lancement des tests fonctionnels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker-compose.override.yml:
 vendors: vendor node_modules
 
 vendor: composer.phar composer.lock
-	php composer.phar install
+	php composer.phar install --no-scripts
 
 node_modules:
 	yarn install


### PR DESCRIPTION
On avait cette erreur lors des tests fonctionnels en CI (et en local) :

```
  [RuntimeException]
  An error occurred when executing the "'cache:clear'" command:

   // Clearing the cache for the dev environment with debug
   // true

  Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 437895 bytes) in /var/www/html/vendor/symfony/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php on line 227

  22:07:06 CRITICAL  [php] Fatal Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 437895 bytes) ["exception" => Symfony\Component\Debug\Exception\OutOfMemoryException { …}]

  In CacheClearCommand.php line 227:

    Error: Allowed memory size of 134217728 bytes exhausted (tried to allocate
    437895 bytes)
```

Qui apparaissait lors du cache warmup lancé lors de la récupération.

On évite donc celle-ci en ne lançant pas les scripts après installation des vendors.