### PR TITLE
ajout de cache sur les images docker lors des tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
       - name: Tests - Functional
         run: make test-functional


### PR DESCRIPTION
ajout de cache sur les images docker pour ne pas les recréer à chaque fois et gagner en temps de test fonctionnels 

avant : 11 minutes
https://github.com/afup/web/actions/runs/3980011537/jobs/6822809025

après : 5 minutes
https://github.com/afup/web/actions/runs/3980160863/jobs/6823054240