### PR TITLE
on fait en sorte que s'il y a une erreur dans la synchro des membres auto, on ne bloque pas le reste de la synchro

### DIFF
--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -102,12 +102,13 @@ class MailchimpMembersAutoListSynchronizer
             try {
                 $this->mailchimp->subscribeAddressWithoutConfirmation($this->listId, $email);
             } catch (\Exception $e) {
+                $this->logger->error('Error subscribing {address} to techletter', ['address' => $email, 'message' => $e->getMessage()]);
                 $errors[$email] = $email . ' : ' . $e->getMessage();
             }
         }
 
         if (count($errors)) {
-            throw new \RuntimeException('Errors during subscribeAddresses : '. implode($errors, PHP_EOL));
+            throw new \RuntimeException('Errors during subscribeAddresses : ' . implode($errors, PHP_EOL));
         }
     }
 

--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -94,9 +94,20 @@ class MailchimpMembersAutoListSynchronizer
      */
     private function subscribeAddresses(array $emails)
     {
+        $errors = [];
+
         foreach ($emails as $email) {
             $this->logger->info('Subscribe {address} to techletter', ['address' => $email]);
-            $this->mailchimp->subscribeAddressWithoutConfirmation($this->listId, $email);
+
+            try {
+                $this->mailchimp->subscribeAddressWithoutConfirmation($this->listId, $email);
+            } catch (\Exception $e) {
+                $errors[$email] = $email . ' : ' . $e->getMessage();
+            }
+        }
+
+        if (count($errors)) {
+            throw new \RuntimeException('Errors during subscribeAddresses : '. implode($errors, PHP_EOL));
         }
     }
 


### PR DESCRIPTION
Lorsqu'on subscribait des personnes sur mailchimp parfois on pouvait avoir cette erreur (ici dans ce cas le statut est actuellement en "pending")

```
{"title":"Member In Compliance State","status":400,"detail":"****@*****.me is in a compliance state due to unsubscribe, bounce, or compliance review and cannot be subscribed.","instance":"5299cbb7-8605-bc4a-e8a0-9d5bf8fbedb3"}"
```

Du coup cela bloquait la synchronisation, on avait des comptes qui n'étaient pas ajoutés dans la liste.

Afin d'éviter cela si on a une erreur, on la catche, et on renvoie une exception à la fin.

La problème existe toujours et sera à corriger, mais il sera limité à un certain nombre de cas et permettra d'éviter d'avoir des membres non synchronisés.