### PR TITLE
Affichage de la liste des veilles par ordre chronologique décroissant

### DIFF
--- a/app/Resources/views/admin/techletter/index.html.twig
+++ b/app/Resources/views/admin/techletter/index.html.twig
@@ -1,6 +1,25 @@
 {% extends ':admin:base_with_header.html.twig' %}
 
 {% block content %}
+
+    <div class="ui segment">
+        <h2 class="ui header">Nouvelle campagne</h2>
+        <div class="ui clearing divider"></div>
+        {{ form_start(form) }}
+        <div class="ui form">
+            <div class="inline fields">
+                <div class="field">
+                    {{ form_label(form.sendingDate) }}
+                    {{ form_widget(form.sendingDate, {"attr": { "class": "inline fields"} }) }}
+                    {{ form_errors(form.sendingDate) }}
+
+                    {{ form_row(form.save, { attr: { class : "ui blue button" }}) }}
+                </div>
+            </div>
+        </div>
+        {{ form_end(form) }}
+    </div>
+
     <h2>Campagnes</h2>
 
     <table class="ui table striped compact celled">
@@ -37,23 +56,5 @@
             {% endfor %}
         </tbody>
     </table>
-
-    <div class="ui segment">
-        <h2 class="ui header">Nouvelle campagne</h2>
-        <div class="ui clearing divider"></div>
-        {{ form_start(form) }}
-        <div class="ui form">
-            <div class="inline fields">
-                <div class="field">
-                    {{ form_label(form.sendingDate) }}
-                    {{ form_widget(form.sendingDate, {"attr": { "class": "inline fields"} }) }}
-                    {{ form_errors(form.sendingDate) }}
-
-                    {{ form_row(form.save, { attr: { class : "ui blue button" }}) }}
-                </div>
-            </div>
-        </div>
-        {{ form_end(form) }}
-    </div>
 
 {% endblock %}

--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -47,7 +47,7 @@ class TechLetterGenerateController extends SiteBaseController
 
     public function indexAction(Request $request)
     {
-        $techLetters = $this->sendingRepository->getAll();
+        $techLetters = $this->sendingRepository->getAllOrderedByDateDesc();
         $form = $this->formFactory->create(SendingType::class);
         $form->handleRequest($request);
 

--- a/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
+++ b/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
@@ -13,6 +13,17 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
 class SendingRepository extends Repository implements MetadataInitializer
 {
+    public function getAllOrderedByDateDesc()
+    {
+        $sql = <<<SQL
+SELECT afup_techletter.*
+FROM afup_techletter
+ORDER BY afup_techletter.sending_date DESC
+SQL;
+        $query = $this->getQuery($sql);
+
+        return $query->query($this->getCollection(new HydratorSingleObject()));
+    }
     public function getAllPastSent()
     {
         $sql = <<<SQL

--- a/tests/behat/features/Admin/Techletter/AdminVeilleCampagnes.feature
+++ b/tests/behat/features/Admin/Techletter/AdminVeilleCampagnes.feature
@@ -29,6 +29,6 @@ Feature: Administration - Veille - Campagnes
 
     When I follow "Campagnes"
     Then the ".content h2" element should contain "Campagnes"
-    And I should see "3" in the "tbody > tr:last-child > td:nth-child(1)" element
-    And I should see "01/02/2023" in the "tbody > tr:last-child > td:nth-child(2)" element
-    And I should see "non" in the "tbody > tr:last-child > td:nth-child(3)" element
+    And I should see "3" in the "tbody > tr:first-child > td:nth-child(1)" element
+    And I should see "01/02/2023" in the "tbody > tr:first-child > td:nth-child(2)" element
+    And I should see "non" in the "tbody > tr:first-child > td:nth-child(3)" element

--- a/tests/behat/features/Admin/Techletter/AdminVeilleCampagnes.feature
+++ b/tests/behat/features/Admin/Techletter/AdminVeilleCampagnes.feature
@@ -6,7 +6,7 @@ Feature: Administration - Veille - Campagnes
   Scenario: Créer une campagne pour la veille tech
     Given I am logged in as admin and on the Administration
     And I follow "Campagnes"
-    Then the ".content h2" element should contain "Campagnes"
+    Then the ".content h2:nth-child(2)" element should contain "Campagnes"
     And I should see "ID" in the "thead > tr:first-child > th:nth-child(1)" element
     And I should see "Date d'envoi planifiée" in the "thead > tr:first-child > th:nth-child(2)" element
     And I should see "Envoyée à mailchimp ?" in the "thead > tr:first-child > th:nth-child(3)" element
@@ -28,7 +28,7 @@ Feature: Administration - Veille - Campagnes
     And the ".content .header" element should contain "Date mise à jour"
 
     When I follow "Campagnes"
-    Then the ".content h2" element should contain "Campagnes"
+    Then the ".content h2:nth-child(2)" element should contain "Campagnes"
     And I should see "3" in the "tbody > tr:first-child > td:nth-child(1)" element
     And I should see "01/02/2023" in the "tbody > tr:first-child > td:nth-child(2)" element
     And I should see "non" in the "tbody > tr:first-child > td:nth-child(3)" element


### PR DESCRIPTION
Fix #1278 

Du coup, j'ai au passage remonté le formulaire de création d'une veille car, je ne trouvais pas logique de trier les veilles par ordre DESC, mais de devoir scroller jusqu'en bas de la page pour en créer une nouvelle.

![Screenshot from 2023-03-15 22-32-06](https://user-images.githubusercontent.com/433926/225448967-52648a40-b131-4e87-b850-8a9fe604d820.png)
