### PR TITLE
correction de l'ajout info mastodon d'un speaker dans l'admin

### DIFF
--- a/app/Resources/views/admin/speaker/add.html.twig
+++ b/app/Resources/views/admin/speaker/add.html.twig
@@ -19,6 +19,7 @@
                 {{ form_row(form.locality) }}
                 {{ form_row(form.biography) }}
                 {{ form_row(form.twitter) }}
+                {{ form_row(form.mastodon) }}
                 {{ form_row(form.referent_person) }}
                 {{ form_row(form.referent_person_email) }}
                 {{ form_row(form.photoFile) }}

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerAddAction.php
@@ -76,6 +76,7 @@ class SpeakerAddAction
             $speaker->setLastname($data->lastname);
             $speaker->setBiography($data->biography);
             $speaker->setTwitter($data->twitter);
+            $speaker->setMastodon($data->mastodon);
             $speaker->setEmail($data->email);
             $speaker->setUser($data->githubUser !== null ? $data->githubUser->getId() : null);
             $speaker->setCompany($data->company);


### PR DESCRIPTION
L'ajout ne fonctionnait pas et le champ n'était pas bien placé.

avant:
![Screenshot 2023-04-02 at 20-16-30 Administration AFUP](https://user-images.githubusercontent.com/320372/229371466-762278bd-03a2-4e0f-9c36-d619ad2c9c40.png)


après:
![Screenshot 2023-04-02 at 20-17-57 Administration AFUP](https://user-images.githubusercontent.com/320372/229371471-5a1ca18e-a4d0-45c6-abe4-42682ff9f065.png)
