### PR TITLE
Correction de la description JSON-LD d'un évènement

### DIFF
--- a/sources/AppBundle/Event/JsonLd.php
+++ b/sources/AppBundle/Event/JsonLd.php
@@ -156,15 +156,23 @@ class JsonLd
 
     private function getDescription(Event $event)
     {
-        $description = sprintf(
-            'Le %s aura lieu les %s et %s au %s.',
+        if ($event->getDateStart()->format('Y-m-d') === $event->getDateEnd()->format('Y-m-d')) {
+            return sprintf(
+                'Le %s aura lieu le %s %s au %s.',
                 $event->getTitle(),
                 $event->getDateStart()->format('d'),
-                $event->getDateEnd()->format('d'),
                 $event->getDateEnd()->format('M'),
                 $event->getPlaceName()
             );
+        }
 
-        return $description;
+        return sprintf(
+            'Le %s aura lieu les %s et %s %s au %s.',
+            $event->getTitle(),
+            $event->getDateStart()->format('d'),
+            $event->getDateEnd()->format('d'),
+            $event->getDateEnd()->format('M'),
+            $event->getPlaceName()
+        );
     }
 }


### PR DESCRIPTION
Les évènements d'une seule journée étaient mal gérés, la date étant
répétée deux fois : `les 12 et 12 May` au lieu de `le 12 May`.

Le nom du lieu de l'évènement est désormais correctement inclus dans la
description.