### PR TITLE
Ajout de propriétés manquantes dans certaines classes

### DIFF
--- a/sources/Afup/Corporate/Accueil.php
+++ b/sources/Afup/Corporate/Accueil.php
@@ -4,6 +4,11 @@ namespace Afup\Site\Corporate;
 
 class Accueil
 {
+    /**
+     * @var _Site_Base_De_Donnees|mixed
+     */
+    private $bdd;
+
     function __construct($bdd = false)
     {
         if ($bdd) {

--- a/sources/Afup/Corporate/Branche.php
+++ b/sources/Afup/Corporate/Branche.php
@@ -10,6 +10,11 @@ class Branche
      */
     protected $bdd;
 
+    /**
+     * @var mixed
+     */
+    private $conf;
+
     function __construct($bdd = false, $conf = false)
     {
         if ($bdd) {

--- a/sources/Afup/Corporate/Page.php
+++ b/sources/Afup/Corporate/Page.php
@@ -16,6 +16,11 @@ class Page
      */
     public $conf;
 
+    /**
+     * @var _Site_Base_De_Donnees
+     */
+    private $bdd;
+
     function __construct($bdd = false)
     {
         if ($bdd) {

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -35,6 +35,11 @@ class RegistrationsExportGenerator
     private $ticketRepository;
 
     /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
      * @param OfficeFinder $officeFinder
      * @param SeniorityComputer $seniorityComputer
      * @param TicketRepository $ticketRepository

--- a/sources/AppBundle/Event/Ticket/SponsorTicketHelper.php
+++ b/sources/AppBundle/Event/Ticket/SponsorTicketHelper.php
@@ -27,6 +27,11 @@ class SponsorTicketHelper
      */
     private $ticketRepository;
 
+    /**
+     * @var SponsorTicketRepository
+     */
+    private $sponsorTicketRepository;
+
     public function __construct(
         InvoiceFactory $invoiceFactory,
         InvoiceRepository $invoiceRepository,

--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -4,7 +4,6 @@ namespace AppBundle\Indexation\Meetups;
 
 use AlgoliaSearch\Client;
 use AppBundle\Offices\OfficesCollection;
-use DMS\Service\Meetup\MeetupKeyAuthClient;
 use DMS\Service\Meetup\MeetupOAuthClient;
 
 class Runner
@@ -15,24 +14,20 @@ class Runner
     protected $algoliaClient;
 
     /**
-     * @var MeetupKeyAuthClient
+     * @var MeetupOAuthClient
      */
     protected $meetupClient;
 
     /**
      * @var OfficesCollection
      */
-    protected $officesCollection;
+    protected $officiesCollection;
 
     /**
      * @var Transformer
      */
     protected $transformer;
 
-    /**
-     * @param Client $algoliaClient
-     * @param MeetupKeyAuthClient $meetupClient
-     */
     public function __construct(Client $algoliaClient, MeetupOAuthClient $meetupClient)
     {
         $this->algoliaClient = $algoliaClient;

--- a/sources/AppBundle/Payment/Paybox.php
+++ b/sources/AppBundle/Payment/Paybox.php
@@ -26,6 +26,7 @@ class Paybox
     private $porteur = null;
     private $urlRetourEffectue = null;
     private $urlRetourRefuse = null;
+    private $urlRetourErreur = null;
     private $urlRetourAnnule = null;
     private $urlRepondreA = null;
 


### PR DESCRIPTION
Les propriétés de classe non déclarée ont été [dépréciées en PHP 8.2](https://php.watch/versions/8.2/dynamic-properties-deprecated)