### PR TITLE
changement du runner en ci suite à la suppression de l'image ubuntu 18.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
   unit:
     name: "Unit tests"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
  
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
 
   lint:
     name: "Linter"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -80,7 +80,7 @@ jobs:
 
   functional:
     name: "Functional tests"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION

cf https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

L'image qu'on utilisait a été supprimée, les tests en CI ne passaient plus, on corrige cela en utilisant une image qui existe.