### PR TITLE
Correction d'un nom de variable

### DIFF
--- a/sources/Afup/Corporate/Articles.php
+++ b/sources/Afup/Corporate/Articles.php
@@ -36,7 +36,7 @@ class Articles
         }
         $requete .= ' ORDER BY ' . $ordre;
 
-        if ($agssociatif) {
+        if ($associatif) {
             return $this->bdd->obtenirAssociatif($requete);
         } else {
             return $this->bdd->obtenirTous($requete);


### PR DESCRIPTION
La variable dans le `if` était mal nommée.

La fonction `obtenirListe` n'est appelée qu'à un seul endroit avec la valeur par défaut donc il ne devrait pas y avoir d'impact : https://github.com/afup/web/blob/master/htdocs/pages/administration/site_articles.php#L57

Avec la variable inexistante la condition valait toujours `false` : https://3v4l.org/sYtqO