### PR TITLE
Suppression d'une variable inexistante

### DIFF
--- a/sources/Afup/Utils/Mailing.php
+++ b/sources/Afup/Utils/Mailing.php
@@ -60,7 +60,7 @@ class Mailing
     {
         $blacklist_sql = $blacklist ? '1' : '0';
         $requete = 'SELECT';
-        $requete .= '  ' . $champs;
+        $requete .= '  ';
         $requete .= 'FROM';
         $requete .= '  afup_email ';
         $requete .= 'WHERE blacklist = ' . $blacklist_sql;


### PR DESCRIPTION
La variable `$champs` n'existe pas et ne sert donc à rien : https://3v4l.org/gkHaB

La fonction `obtenirEmails` ne semble plus servir nul part, on peut peut-être la supprimer ?