### PR TITLE
correction du build suite à la sortie de bookworm

### DIFF
--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -2,6 +2,8 @@ FROM php:5.6-apache
 
 ARG ENABLE_XDEBUG=false
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+
 ## Update system
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/docker/dockerfiles/apachephp7/Dockerfile
+++ b/docker/dockerfiles/apachephp7/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:7.0-apache
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+
 ARG ENABLE_XDEBUG=false
 
 ## Update system

--- a/docker/dockerfiles/planete/Dockerfile
+++ b/docker/dockerfiles/planete/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:5.6-apache
 
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
+
 # Install required php extensions for afup website and other management package
 RUN apt-get update && \
     apt-get install -y \


### PR DESCRIPTION
Avec la sortie de bookwork, strech qui était en lts est passée en archivée cf https://www.debian.org/releases/stretch/

et https://www.debian.org/distrib/archive

On avait des erreurs comme celle-ci lors du build :

```
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://archive.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.194.132 80]
E: Failed to fetch http://archive.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found [IP: 130.89.148.13 80]
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

Afin de les éviter on passe sur le dépot d'archives.