### PR TITLE
Suppression de paramètres inutilisés

### DIFF
--- a/sources/Afup/Comptabilite/Facture.php
+++ b/sources/Afup/Comptabilite/Facture.php
@@ -589,7 +589,7 @@ class Facture
     function envoyerFacture($reference)
     {
         $configuration = $GLOBALS['AFUP_CONF'];
-        $personne = $this->obtenirParNumeroFacture($reference, 'email, nom, prenom');
+        $personne = $this->obtenirParNumeroFacture($reference);
 
         $sujet = "Facture AFUP\n";
 


### PR DESCRIPTION
La méthode `obtenirParNumeroFacture` n'a qu'un seul argument.

Les 3 en trop semblent venir d'un oubli lors d'un ancien refactor.