### PR TITLE
Fix GitHub action warning set output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
  
       - name: Composer - Get Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v1
         id: cache-composer
@@ -56,7 +56,7 @@ jobs:
 
       - name: Composer - Get Cache Directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v1
         id: cache-composer


### PR DESCRIPTION
Corrige ce warning : 
https://github.com/afup/web/actions/runs/5486139106/jobs/9995842910?pr=1309#step:4:9