### PR TITLE
correction du build

### DIFF
--- a/docker/dockerfiles/mailcatcher/Dockerfile
+++ b/docker/dockerfiles/mailcatcher/Dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache --virtual .build-deps \
     && gem install -v 0.1.2 net-protocol --no-ri --no-rdoc \
     && gem install -v 0.3.0 net-smtp --no-ri --no-rdoc \
     && gem install -v 0.2.2 net-imap --no-ri --no-rdoc \
+    && gem install -v 1.1.2 mini_mime --no-ri --no-rdoc \
     && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc \
     && apk del .build-deps
 


### PR DESCRIPTION
Les tests ne passaient plus vu qu'il y avait un souci avec le build de mailchatcher, ce changement fait passer le build de mailcatcher en évitant cette erreur :

```
Building native extensions. This could take a while...
ERROR:  Error installing mailcatcher:
	The last version of mini_mime (>= 0.1.1) to support your Ruby & RubyGems was 1.1.2. Try installing it with `gem install mini_mime -v 1.1.2` and then running the current command again
	mini_mime requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
```