### PR TITLE
ajout de filtres sur les factures

### DIFF
--- a/htdocs/templates/administration/compta_facture.html
+++ b/htdocs/templates/administration/compta_facture.html
@@ -8,15 +8,16 @@
         <p>Il faut obligatoirement passer par la saisie d'un devis.</p>
     </div>
 
-    <table class="ui table striped compact celled">
+    <table class="ui table striped compact celled afup-tab-filterable">
         <thead>
             <tr>
+                <th data-tf-filter-type="select">Année</th>
                 <th><a href="index.php?page=compta_devis&amp;tri=date_consultation&amp;sens={if $smarty.get.sens == 'asc' && $smarty.get.tri == 'date_consultation'}desc{else}asc{/if}">Date</a></th>
                 <th><a href="index.php?page=compta_devis&amp;tri=evenement&amp;sens={if $smarty.get.sens == 'asc' && $smarty.get.tri == 'date_consultation'}desc{else}asc{/if}">Clients</a></th>
                 <th>Ville</th>
                 <th class="right aligned">Numero facture</th>
                 <th>Référence client</th>
-                <th class="center aligned">Etat paiement</th>
+                <th data-tf-filter-type="select" class="center aligned">Etat paiement</th>
                 <th class="right aligned">Prix</th>
                 <th></th>
            </tr>
@@ -24,6 +25,7 @@
         <tbody>
     {foreach from=$ecritures item=ecriture}
          <tr>
+            <td nowrap="nowrap">{$ecriture.date_facture|date_format:"%Y"}</td>
             <td nowrap="nowrap">{$ecriture.date_facture|date_format:"%d/%m/%Y"}</td>
              <td>{$ecriture.societe}</td>
              <td>{$ecriture.ville}</td>


### PR DESCRIPTION
Dans l'admin sur la liste des factures on peux maintenant filtrer sur l'année et sur l'état de paiement.

Cela permet de filtrer facilement sur les paiements en attente.

![Capture d’écran du 2023-09-17 12-53-22](https://github.com/afup/web/assets/320372/58e9a485-48e2-4ff5-9049-f2f430cf7382)
