### PR TITLE
on grise le badge d'adhésion si la ligne d'inscription est annulée

### DIFF
--- a/htdocs/templates/administration/forum_inscriptions.html
+++ b/htdocs/templates/administration/forum_inscriptions.html
@@ -219,7 +219,7 @@
                         </td>
                     {elseif $inscription.lastsubscription < $finForum}
                         <td class="single line">
-                            <span class="ui orange label">
+                            <span class="ui {if $inscription.etat != 1}orange{/if} label">
                                 Expire le {$inscription.lastsubscription|date_format:'%d/%m/%Y'}
                             </span>
                             <a class="compact ui tiny icon button" href="/pages/event-payment/?ref=ins-{$inscription.id}&forum={$id_forum}">


### PR DESCRIPTION
On avait le badge à propos de l'adhésion qui était orange et attirait l'oeil alors que la ligne d'inscription était annulée.
On a pas besoin de mettre l'accent sur ces adhésions non à jour, on garde donc dans ce cas le badge gris.

avant:
![Capture d’écran du 2023-09-17 19-11-22](https://github.com/afup/web/assets/320372/ab5ccbe9-60d0-48b2-9b58-fc5105819ec7)

après:
![Capture d’écran du 2023-09-17 19-11-54](https://github.com/afup/web/assets/320372/8e202b39-d8c7-405e-a5b6-1fc766be32bc)
