### PR TITLE
correction du mail envoyé aux sponsors

### DIFF
--- a/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
+++ b/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
@@ -77,7 +77,7 @@ class SponsorTokenMail
                     ['eventSlug' => $event->getPath()],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 ),
-                '%endDate%' => $event->getDateEndSales()->format('d/m/Y')
+                '%endDate%' => $event->getDateEndSalesSponsorToken()->format('d/m/Y')
             ]
         );
 


### PR DESCRIPTION
On envoyait la mauvaise date, on envoyait la date de fin de la billeterie et pas celle de saisie des tokens sponsor.