### PR TITLE
corrige le problème de la home de l'admin

### DIFF
--- a/sources/AppBundle/Controller/Admin/HomeAction.php
+++ b/sources/AppBundle/Controller/Admin/HomeAction.php
@@ -62,7 +62,7 @@ class HomeAction
     {
         $nextevents = $this->eventRepository->getNextEvents();
         $cards = [];
-        if ($this->security->isGranted('ROLE_FORUM')) {
+        if ($this->security->isGranted('ROLE_FORUM') && $nextevents) {
             foreach ($nextevents as $event) {
                 $stats = $this->eventStatsRepository->getStats($event->getId());
                 $info = [];


### PR DESCRIPTION
Dans le cas où il n'y a pas de prochain événement en base de données cette erreur apparaît sur la home de l'admin :

<img width="1087" alt="Capture d’écran 2023-10-17 à 21 17 08" src="https://github.com/afup/web/assets/83301974/7d1e8236-f245-44e2-888d-25f12ab1c28a">


Effectivement, `$this->eventRepository->getNextEvents();` peut retourner `null` dans ce cas et le `foreach` n'est pas content.

J'ai ajouté le test `&& $nextevents` pour corriger le problème.
