### PR TITLE
correction de la synchronisation de la veille

### DIFF
--- a/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
+++ b/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
@@ -80,7 +80,7 @@ class MailchimpSynchronizer
     {
         foreach ($emails as $email) {
             $this->logger->info('Subscribe {address} to techletter', ['address' => $email]);
-            $this->mailchimp->subscribeAddress($this->listId, $email);
+            $this->mailchimp->subscribeAddressWithoutConfirmation($this->listId, $email);
         }
     }
 


### PR DESCRIPTION
On avait un peu plus de 40 mails qui n'étaient pas inscrits à cause de cela.