### PR TITLE
feat (afup#905): mcrypt CBC replace by openssl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "ext-json": "*",
     "ext-dom": "*",
     "ext-libxml": "*",
+    "ext-openssl": "*",
     "beberlei/assert": "^2.9",
     "league/oauth2-github": "^0.2.1",
     "symfony/symfony": "^3.4",

--- a/htdocs/pages/administration/compta_facture.php
+++ b/htdocs/pages/administration/compta_facture.php
@@ -4,6 +4,7 @@
 use Afup\Site\Comptabilite\Facture;
 use Afup\Site\Utils\Pays;
 use Afup\Site\Utils\Logs;
+use Afup\Site\Utils\Utils;
 
 /** @var \AppBundle\Controller\LegacyController $this */
 if (!defined('PAGE_LOADED_USING_INDEX')) {
@@ -30,7 +31,7 @@ $comptaFact = new Facture($bdd);
 if ($action == 'lister') {
 	$ecritures = $comptaFact->obtenirFacture();
   foreach ($ecritures as &$e) {
-    $e['link'] = urlencode(base64_encode(mcrypt_cbc(MCRYPT_TripleDES, 'PaiementFactureAFUP_AFUP', $e['id'], MCRYPT_ENCRYPT, '@PaiFact')));;
+    $e['link'] = urlencode(Utils::cryptFromText($e['id']));
   }
 	$smarty->assign('ecritures', $ecritures);
 } elseif ($action == 'telecharger_facture') {

--- a/htdocs/pages/paiement/index.php
+++ b/htdocs/pages/paiement/index.php
@@ -7,7 +7,7 @@ require_once dirname(__FILE__) .'/../../../sources/Afup/Bootstrap/Http.php';
 
 $comptaFact = new Facture($bdd);
 
-$ref = trim(mcrypt_cbc (MCRYPT_TripleDES, 'PaiementFactureAFUP_AFUP', base64_decode(str_replace(' ', '+', urldecode($_GET['ref']))), MCRYPT_DECRYPT, '@PaiFact'));
+$ref = \Afup\Site\Utils\Utils::decryptFromText(urldecode($_GET['ref']));
 
 $facture = $comptaFact->obtenir($ref);
 if ($facture) {

--- a/sources/Afup/Utils/Utils.php
+++ b/sources/Afup/Utils/Utils.php
@@ -54,6 +54,30 @@ class Utils
         }
         return $url;
     }
-}
 
-?>
+    public static function cryptFromText($text)
+    {
+        // return base64_encode(mcrypt_cbc(MCRYPT_TripleDES, 'PaiementFactureAFUP_AFUP', $text, MCRYPT_ENCRYPT, '@PaiFact'));
+
+        if (strlen($text) % 8) {
+            $text = str_pad($text, strlen($text) + 8 - strlen($text) % 8, "\0");
+        }
+
+        $key = 'PaiementFactureAFUP_AFUP';
+        $iv = '@PaiFact';
+
+        return base64_encode(openssl_encrypt($text, 'des-ede3-cbc', $key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, $iv));
+    }
+
+    public static function decryptFromText($text)
+    {
+        // return trim(mcrypt_cbc(MCRYPT_TripleDES, 'PaiementFactureAFUP_AFUP', base64_decode(str_replace(' ', '+', $text)), MCRYPT_DECRYPT, '@PaiFact'));
+
+        $ref = base64_decode(str_replace(' ', '+', $text));
+
+        $key = 'PaiementFactureAFUP_AFUP';
+        $iv = '@PaiFact';
+
+        return trim(openssl_decrypt($ref, 'des-ede3-cbc', $key, OPENSSL_RAW_DATA | OPENSSL_ZERO_PADDING, $iv));
+    }
+}

--- a/tests/units/Afup/Utils/Utils.php
+++ b/tests/units/Afup/Utils/Utils.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Afup\Site\Utils\tests\units;
+
+use Afup\Site\Utils\Utils as UtilsToTest;
+
+class Utils extends \atoum
+{
+    protected function dataProvider()
+    {
+        return [
+            [
+                'decrypted' => 1,
+                'encrypted' => '03bITNI5Ono=',
+            ],
+            [
+                'decrypted' => '1',
+                'encrypted' => '03bITNI5Ono=',
+            ],
+            [
+                'decrypted' => '12345',
+                'encrypted' => 'EIx0Y/wJQ+I=',
+            ],
+            [
+                'decrypted' => 'abcdef',
+                'encrypted' => 'UvM1BUAJ5jQ=',
+            ],
+            [
+                'decrypted' => 'L\'AFUP est trop mortelle !',
+                'encrypted' => '6MSKdnJmUMW7YrnxXDe/5mKySbAiO2C9ubfR3NcG/fc=',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testCryptFromText($decrypted, $encrypted)
+    {
+        $this
+            ->string(UtilsToTest::cryptFromText($decrypted))
+            ->isEqualTo($encrypted);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testDecryptFromText($decrypted, $encrypted)
+    {
+        $this
+            ->string(UtilsToTest::decryptFromText($encrypted))
+            ->isEqualTo($decrypted);
+    }
+}


### PR DESCRIPTION
Remplacement de la fonction `mcrypt_cbc` par `openssl_encrypt`.

J'ai repris des valeurs générées avec l'ancienne fonction pour créer les tests unitaires.
J'ai également laissé l'ancien code en commentaire pour pouvoir investiguer en cas de régression.