### PR TITLE
Avoir des PDFs comparables

### DIFF
--- a/sources/Afup/Utils/PDF_Facture.php
+++ b/sources/Afup/Utils/PDF_Facture.php
@@ -99,6 +99,13 @@ class PDF_Facture extends \FPDF
         return $this->configuration;
     }
 
+    function _putinfo()
+    {
+        // on surcharge le _putinfo pour ne rien faire
+        // cela permet entre-autres de ne pas indiquer en métadonnées la datetime de génération du PDF
+        // ainsi les PDFs générées à des moments différents sont identiques, et donc comparables
+    }
+
     /**
      * Overrides the parent Footer method
      *


### PR DESCRIPTION
On évite de mettre le timestamp du fichier dans les métadonnées, ainsi les PDFs générés seront identiques peu importe le moment où ils sont générés et on pourra ainsi dans les prochaines PRs ajouter des tests sur ceux-ci (par exemple comparer des md5).

fixes #1344