### PR TITLE
correction des tests unitaires quand on les lançait à minuit

### DIFF
--- a/tests/units/Afup/Association/Cotisations.php
+++ b/tests/units/Afup/Association/Cotisations.php
@@ -27,8 +27,8 @@ class Cotisations extends \atoum
             ],
             [
                 'case' => 'La cotisation précédente expire dans 1 mois, la nouvelle cotisation doit expirer dans 13 mois',
-                'date_fin' => (new \DateTime('+1 month')),
-                'expected' => (new \DateTime('+1 month'))->add(new \DateInterval('P1Y')),
+                'date_fin' => (new \DateTimeImmutable('+1 month'))->setTime(14, 0),
+                'expected' => (new \DateTimeImmutable('+1 month'))->setTime(14, 0)->add(new \DateInterval('P1Y')),
             ],
         ];
     }


### PR DESCRIPTION
En lançant les tests à minuit, ceux-ci plantaient : https://github.com/afup/web/actions/runs/6963642073/job/18949581204

Cela car on ne précisait pas l'heure dans un des tests, c'est donc chose faite.