### PR TITLE
Génération des ids de facture

### DIFF
--- a/sources/Afup/Comptabilite/Facture.php
+++ b/sources/Afup/Comptabilite/Facture.php
@@ -278,15 +278,21 @@ class Facture
 
     function genererNumeroFacture()
     {
-        // afup_cotisations
-        $requete = 'SELECT';
-        $requete .= "  MAX(CAST(SUBSTRING_INDEX(numero_facture, '-', -1) AS UNSIGNED)) + 1 ";
-        $requete .= 'FROM';
-        $requete .= ' afup_compta_facture ';
-        $requete .= 'WHERE';
-        $requete .= '  LEFT(numero_facture, 4)=' . $this->_bdd->echapper(date('Y'));
-        $index = $this->_bdd->obtenirUn($requete);
-        return date('Y') . '-' . (is_null($index) ? 1 : $index);
+        $year = (int) date('Y');
+
+        $sql = "SELECT MAX(CAST(SUBSTRING_INDEX(numero_facture, '-', -1) AS UNSIGNED)) + 1
+            FROM afup_compta_facture
+            WHERE LEFT(numero_facture, 4)=";
+        $index = $this->_bdd->obtenirUn($sql.$year);
+
+        // index null = changement d'année
+        // on va chercher l'index de l'année dernière
+        if (null === $index) {
+            $index = $this->_bdd->obtenirUn($sql.($year-1));
+            $index = (int) (is_null($index) ? 1 : $index);
+        }
+
+        return "$year-$index";
     }
 
     function genererNumeroDevis()


### PR DESCRIPTION
Pour l'issue : #1347

Je propose de me baser sur le fait que l'`$index` soit `null` (changement d'année) pour aller chercher celui de l'année précédente.

Je garde aussi la possibilité qu'il n'y ai rien l'année précédente pour forcer l'incrémentation à 1.

fixes #1347