### PR TITLE
export CSV du journal : on ajoute les infos de justificatif

### DIFF
--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -308,6 +308,8 @@ elseif ($action === 'export') {
         'Crédit',
         'Règlement',
         'Commentaire',
+        'Justificatif',
+        'Nom justificatif'
     ];
     fputcsv($fp, $columns, $csvDelimiter, $csvEnclosure);
 
@@ -329,6 +331,8 @@ elseif ($action === 'export') {
                 $line['idoperation'] != 1 ? $total : '',
                 $line['reglement'],
                 $line['comment'],
+                $line['attachment_required'] ? 'Oui' : 'Non',
+                $line['attachment_filename']
             ],
             $csvDelimiter,
             $csvEnclosure


### PR DESCRIPTION
En 2024, on utilisera plus l'export Excel, mais passera par l'export CSV (l'import coté comptable sera plus récurrent et automatisé qu'avant), il manquait les infos de justificatif, ce changement corrige cela.

fixes #1341