### PR TITLE
PHP 7 upgrade fpdf

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "erusev/parsedown": "^1.6",
     "robmorgan/phinx": "^0.9.2",
     "presta/sitemap-bundle": "^1.5",
-    "setasign/fpdf": "1.53",
+    "setasign/fpdf": "^1.8",
     "ezyang/htmlpurifier": "^4.10",
     "phpoffice/phpspreadsheet": "^1.6",
     "phpmailer/phpmailer": "5.2.9",
@@ -106,22 +106,6 @@
     "behat/mink-goutte-driver": "^1.2"
   },
   "repositories": [
-    {
-      "type": "package",
-      "package": {
-        "name": "setasign/fpdf",
-        "version": "1.53",
-        "dist": {
-          "url": "http://www.fpdf.org/en/dl.php?v=153&f=zip",
-          "type": "zip"
-        },
-        "autoload": {
-          "files": [
-            "fpdf.php"
-          ]
-        }
-      }
-    },
     {
       "type": "package",
       "package": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b02a5bda029a7c3d77208e67833d4254",
+    "content-hash": "febe7f0243722c670ef43ef351ca557f",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -4038,17 +4038,49 @@
         },
         {
             "name": "setasign/fpdf",
-            "version": "1.53",
+            "version": "1.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0"
+            },
             "dist": {
                 "type": "zip",
-                "url": "http://www.fpdf.org/en/dl.php?v=153&f=zip"
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-zlib": "*"
             },
             "type": "library",
             "autoload": {
-                "files": [
+                "classmap": [
                     "fpdf.php"
                 ]
-            }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.6"
+            },
+            "time": "2023-06-26T14:44:25+00:00"
         },
         {
             "name": "smarty/smarty",
@@ -6101,6 +6133,7 @@
         "ext-json": "*",
         "ext-dom": "*",
         "ext-libxml": "*",
+        "ext-openssl": "*",
         "ext-curl": "*"
     },
     "platform-dev": [],

--- a/sources/Afup/Utils/PDF_Facture.php
+++ b/sources/Afup/Utils/PDF_Facture.php
@@ -33,7 +33,7 @@ class PDF_Facture extends \FPDF
      */
     function __construct($configuration, BankAccount $bankAccount, $orientation = 'P', $unit = 'mm', $format = 'A4')
     {
-        parent::FPDF($orientation, $unit, $format);
+        parent::__construct($orientation, $unit, $format);
         $this->bankAccount = $bankAccount;
 
         $this->setAFUPConfiguration($configuration);


### PR DESCRIPTION
On met à jour FPDF pour PHP 7. 0

Suppression de la partie `repository` du `composer.json` comme la version est maintenant disponible dans packagist.
Mise à jour faite via composer.

Traite l'issue #1331