### PR TITLE
test de la configuration : on remet la conf dans l'état précédent

### DIFF
--- a/tests/behat/features/Admin/Divers/Configuration.feature
+++ b/tests/behat/features/Admin/Divers/Configuration.feature
@@ -5,8 +5,15 @@ Feature: Administration - Configuration
     Given I am logged in as admin and on the Administration
     And I follow "Configuration du site"
     Then I should see "Configuration"
-    And I should see "32, Boulevard de Strasbourg CS 30108"
-    And I fill in "afup|adresse" with "32, Boulevard de Nantes CS 30108"
+    And the response should contain "Paris Cedex 10"
+    And I fill in "afup|ville" with "Paris Cedex 12"
     When I press "Enregistrer"
     Then the ".content .message" element should contain "La configuration a été enregistrée"
-    And I should see "32, Boulevard de Nantes CS 30108"
+    And the response should contain "Paris Cedex 12"
+    # on remet la valeur d'origine vu qu'on modifie un fichier
+    # ce n'est pas idéal, mais à terme il faudrait plutôt qu'on ne modifie pas le fichier
+    # et que les infos pertinentes à modifier le soient en base et le reste soit dans de la conf statique
+    And I fill in "afup|ville" with "Paris Cedex 10"
+    When I press "Enregistrer"
+    Then the ".content .message" element should contain "La configuration a été enregistrée"
+    And the response should contain "Paris Cedex 10"


### PR DESCRIPTION
Lors de la PR https://github.com/afup/web/pull/1373 on s'est rendus compte que ce test influait sur les autres.

En effet, il consiste à modifier un fichier de conf sur le disque.

On fait donc en sorte de revenir à la valeur précédente une fois le test terminé (et on le fait sur la ville au lieu de l'adresse pour évite de se poser des soucis de sauts de ligne).

Ce n'est pas idéal, mais ici c'est tout ce mécanisme qui est à revoir plus tard pour mettre dans de la conf en dur les valeurs qui ne sont pas censées bouger et mettre en base les valeurs modiables depuis l'admin (comme la conf pour le planete par exemple).