### PR TITLE
Ajout d'un code de retour aux commandes

### DIFF
--- a/sources/AppBundle/Command/CfpNotificationCommand.php
+++ b/sources/AppBundle/Command/CfpNotificationCommand.php
@@ -58,5 +58,7 @@ class CfpNotificationCommand extends ContainerAwareCommand
 
             $this->getContainer()->get(\AppBundle\Notifier\SlackNotifier::class)->sendMessage($message);
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/CleanThrottlingCommand.php
+++ b/sources/AppBundle/Command/CleanThrottlingCommand.php
@@ -24,5 +24,7 @@ class CleanThrottlingCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->getContainer()->get(\AppBundle\Security\ActionThrottling\ActionThrottling::class)->clearOldLogs();
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -55,5 +55,7 @@ EOF;
         curl_exec($curl);
 
         $output->writeln("Appel au callback de paiement de cotisation effectué");
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
+++ b/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
@@ -59,5 +59,7 @@ class GeneralMeetupNotificationCommand extends Command
                 $this->urlGenerator
             ));
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/IndexMeetupsCommand.php
+++ b/sources/AppBundle/Command/IndexMeetupsCommand.php
@@ -37,5 +37,7 @@ class IndexMeetupsCommand extends ContainerAwareCommand
 
         $runner = new Runner($algoliaClient, $meetupRepository);
         $runner->run();
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/IndexTalksCommand.php
+++ b/sources/AppBundle/Command/IndexTalksCommand.php
@@ -27,5 +27,7 @@ class IndexTalksCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->runner->run();
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/RegistrationsExporterCommand.php
+++ b/sources/AppBundle/Command/RegistrationsExporterCommand.php
@@ -35,5 +35,7 @@ class RegistrationsExporterCommand extends ContainerAwareCommand
         $file = new \SplFileObject($input->getArgument('file'), 'w+');
 
         $container->get(\AppBundle\Event\Ticket\RegistrationsExportGenerator::class)->export($event, $file);
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/SlackMemberNotificationCommand.php
+++ b/sources/AppBundle/Command/SlackMemberNotificationCommand.php
@@ -30,5 +30,7 @@ class SlackMemberNotificationCommand extends ContainerAwareCommand
             $message = $this->getContainer()->get(\AppBundle\Slack\MessageFactory::class)->createMessageForMemberNotification($nbResults);
             $this->getContainer()->get(\AppBundle\Notifier\SlackNotifier::class)->sendMessage($message);
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/SubscriptionReminderCommand.php
+++ b/sources/AppBundle/Command/SubscriptionReminderCommand.php
@@ -83,6 +83,8 @@ class SubscriptionReminderCommand extends ContainerAwareCommand
             $output->writeln(sprintf('<info>%s entreprises</info>', $users->count()));
             $this->handleReminders($output, $reminder, $users, $dryRun);
         }
+
+        return 0;
     }
 
     private function handleReminders(

--- a/sources/AppBundle/Command/SynchMembersCommand.php
+++ b/sources/AppBundle/Command/SynchMembersCommand.php
@@ -28,5 +28,7 @@ class SynchMembersCommand extends ContainerAwareCommand
            ->setLogger($container->get('logger'))
            ->synchronize()
         ;
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/SynchTechLetterCommand.php
+++ b/sources/AppBundle/Command/SynchTechLetterCommand.php
@@ -28,5 +28,7 @@ class SynchTechLetterCommand extends ContainerAwareCommand
            ->setLogger($container->get('logger'))
            ->synchronize()
         ;
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/TicketStatsNotificationCommand.php
+++ b/sources/AppBundle/Command/TicketStatsNotificationCommand.php
@@ -50,5 +50,7 @@ class TicketStatsNotificationCommand extends ContainerAwareCommand
 
             $this->getContainer()->get(\AppBundle\Notifier\SlackNotifier::class)->sendMessage($message);
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/TwitterBotCommand.php
+++ b/sources/AppBundle/Command/TwitterBotCommand.php
@@ -42,6 +42,8 @@ class TwitterBotCommand extends ContainerAwareCommand
             $container->get(\TwitterAPIExchange::class)
         );
         $runner->execute($this->getEventFilter($input));
+
+        return 0;
     }
 
     /**

--- a/sources/AppBundle/Command/TwitterListCreateCommand.php
+++ b/sources/AppBundle/Command/TwitterListCreateCommand.php
@@ -36,6 +36,8 @@ class TwitterListCreateCommand extends ContainerAwareCommand
 
         $twitterListCreator = new ListCreator($container->get(\TwitterAPIExchange::class), $ting->get(SpeakerRepository::class));
         $twitterListCreator->create($event, $input->getOption('custom-name'));
+
+        return 0;
     }
 
     /**

--- a/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
+++ b/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
@@ -35,5 +35,7 @@ class UpdateCompanyMemberStateCommand extends ContainerAwareCommand
             $companyMember->setStatus($hasUptoDateMembershipFee ? 1 : 0);
             $companyMemberRepository->save($companyMember);
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
+++ b/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
@@ -63,5 +63,7 @@ class UpdateMailchimpMembersCommand extends ContainerAwareCommand
         } else {
             $output->writeln("Pas d'erreur durant le traitement");
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/UpdateUserStateCommand.php
+++ b/sources/AppBundle/Command/UpdateUserStateCommand.php
@@ -34,5 +34,7 @@ class UpdateUserStateCommand extends ContainerAwareCommand
             $user->setStatus($hasUptoDateMembershipFee ? User::STATUS_ACTIVE : User::STATUS_INACTIVE);
             $userRepository->save($user);
         }
+
+        return 0;
     }
 }

--- a/sources/AppBundle/Command/VideosDataCommand.php
+++ b/sources/AppBundle/Command/VideosDataCommand.php
@@ -83,5 +83,7 @@ class VideosDataCommand extends ContainerAwareCommand
         }
 
         $output->writeln(json_encode($data, JSON_PRETTY_PRINT));
+
+        return 0;
     }
 }


### PR DESCRIPTION
Il existe une constante `Command::SUCCESS` mais elle n'existe que depuis la version `5.1` de `symfony/console` : https://github.com/symfony/console/commit/27327a59875896d8b8e577ccddc35d92d7654664