### PR TITLE
Utilisation de `getParameter` directement

### DIFF
--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -169,7 +169,7 @@ class TechLetterGenerateController extends SiteBaseController
             $template = $this->get('app.mailchimp_techletter_api')->createTemplate($subject . ' - Template', $mailContent);
 
             $response = $this->get('app.mailchimp_techletter_api')->createCampaign(
-                $this->container->getParameter('mailchimp_techletter_list'),
+                $this->getParameter('mailchimp_techletter_list'),
                 [
                     'template_id' => $template->get('id'),
                     'from_name' => "Pôle Veille de l'AFUP",

--- a/sources/AppBundle/Controller/MemberShipController.php
+++ b/sources/AppBundle/Controller/MemberShipController.php
@@ -670,7 +670,7 @@ class MemberShipController extends SiteBaseController
 
     private function prepareGeneralMeetingsReportsList()
     {
-        $dir = $this->container->getParameter('kernel.project_dir') . DIRECTORY_SEPARATOR . '/htdocs/uploads/general_meetings_reports';
+        $dir = $this->getParameter('kernel.project_dir') . DIRECTORY_SEPARATOR . '/htdocs/uploads/general_meetings_reports';
         if (!is_dir($dir)) {
             return [];
         }

--- a/sources/AppBundle/Controller/NewsController.php
+++ b/sources/AppBundle/Controller/NewsController.php
@@ -58,7 +58,7 @@ class NewsController extends SiteBaseController
 
         $image = '/images/news/' . $theme . '.png';
 
-        $url = $this->container->getParameter('kernel.project_dir') . '/htdocs' . $image ;
+        $url = $this->getParameter('kernel.project_dir') . '/htdocs' . $image ;
 
         if (false === is_file($url)) {
             return null;

--- a/sources/AppBundle/Controller/StaticController.php
+++ b/sources/AppBundle/Controller/StaticController.php
@@ -52,7 +52,7 @@ class StaticController extends SiteBaseController
 
     public function superAperoAction()
     {
-        $aperos = $this->getAperos($this->container->getParameter('super_apero_csv_url'));
+        $aperos = $this->getAperos($this->getParameter('super_apero_csv_url'));
         return $this->render(':site:superapero.html.twig', ['aperos' => $aperos]);
     }
 

--- a/sources/AppBundle/Controller/TechnoWatchController.php
+++ b/sources/AppBundle/Controller/TechnoWatchController.php
@@ -10,14 +10,14 @@ class TechnoWatchController extends SiteBaseController
 {
     public function calendarAction(Request $request)
     {
-        if ($request->query->get('key') != $this->container->getParameter('techno_watch_calendar_key')) {
+        if ($request->query->get('key') != $this->getParameter('techno_watch_calendar_key')) {
             throw $this->createNotFoundException();
         }
 
         $generator = new TechnoWatchCalendarGenerator("Veille de l'AFUP", new \DateTime());
 
         $calendar = $generator->generate(
-            $this->container->getParameter('techno_watch_calendar_url'),
+            $this->getParameter('techno_watch_calendar_url'),
             $request->query->getBoolean('display_prefix', true),
             $request->query->get('filter', '')
         );


### PR DESCRIPTION
La propriété `$container` est de type `ContainerInterface` dans laquelle il n'y a pas de méthode `getParameter`.

La méthode `getParameter` est directement accessible via un controller.