### PR TITLE
correction de l'export CSV des TVA

### DIFF
--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -172,8 +172,8 @@ class Comptabilite
         $requete .= 'compta_evenement.evenement, ';
         $requete .= 'compta_categorie.categorie, ';
         $requete .= 'compta_compte.nom_compte,    ';
-        $requete .= '(compta.montant_ht_soumis_tva_0 + compta.montant_ht_soumis_tva_5_5 + compta.montant_ht_soumis_tva_10 + compta.montant_ht_soumis_tva_20) as montant_ht,   ';
-        $requete .= '((compta.montant_ht_soumis_tva_5_5*0.055) + (compta.montant_ht_soumis_tva_10*0.1) + (compta.montant_ht_soumis_tva_20*0.2)) as montant_tva,   ';
+        $requete .= '(COALESCE(compta.montant_ht_soumis_tva_0,0) + COALESCE(compta.montant_ht_soumis_tva_5_5,0) + COALESCE(compta.montant_ht_soumis_tva_10, 0) + COALESCE(compta.montant_ht_soumis_tva_20, 0)) as montant_ht,   ';
+        $requete .= '((COALESCE(compta.montant_ht_soumis_tva_5_5, 0)*0.055) + (COALESCE(compta.montant_ht_soumis_tva_10, 0)*0.1) + (compta.montant_ht_soumis_tva_20*0.2)) as montant_tva,   ';
         $requete .= 'compta.montant_ht_soumis_tva_0 as montant_ht_0,   ';
         $requete .= 'compta.montant_ht_soumis_tva_5_5 as montant_ht_5_5,   ';
         $requete .= 'compta.montant_ht_soumis_tva_5_5*0.055 as montant_tva_5_5,   ';

--- a/tests/behat/features/MembersArea/Index.feature
+++ b/tests/behat/features/MembersArea/Index.feature
@@ -66,6 +66,7 @@ Feature: Espace membre, accueil
     Then The page "1" of the PDF should contain "ADH Adhésion AFUP jusqu'au 01/01/2024 30.00 €"
     Then The page "1" of the PDF should contain "TVA non applicable - art. 293B du CGI"
     Then The page "1" of the PDF should not contain "Numéro de TVA intercommunautaire NUMERO_A_AJOUTER"
+    Then print last PDF content
     Then the checksum of the response content should be "2e334b2ea4b010d7ca71fe128370b07e"
 
   @reloadDbWithTestData @vat

--- a/tests/behat/features/MembersArea/Index.feature
+++ b/tests/behat/features/MembersArea/Index.feature
@@ -66,7 +66,6 @@ Feature: Espace membre, accueil
     Then The page "1" of the PDF should contain "ADH Adhésion AFUP jusqu'au 01/01/2024 30.00 €"
     Then The page "1" of the PDF should contain "TVA non applicable - art. 293B du CGI"
     Then The page "1" of the PDF should not contain "Numéro de TVA intercommunautaire NUMERO_A_AJOUTER"
-    Then print last PDF content
     Then the checksum of the response content should be "2e334b2ea4b010d7ca71fe128370b07e"
 
   @reloadDbWithTestData @vat


### PR DESCRIPTION
fixes #1390

Si on a pas de TVA de renseigné, le total n'est pas juste, on évite cela.