### PR TITLE
Fiscalisation : correction sur l''import du csv

### DIFF
--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -1048,6 +1048,7 @@ SQL;
                     $categorie,
                     $date_ecriture,
                     '',
+                    '',
                     $montant,
                     $description,
                     '',


### PR DESCRIPTION
Avec l'ajout du numéro de TVA il y a eut un décalage sur l'ajout de nouvelle entrée, ça a causé un souci à l'import.

Vu que la modification des lignes se fait via le numéro d'opération, il faudra supprimer les lignes mal importées.

De plus on pourra plus tard ajouter un test sur cet import assez critique (car on début d'année prochaine ajouter de nouvelles fonctionnalités dessus).