### PR TITLE
correction installation dépendances mailcatcher

### DIFF
--- a/docker/dockerfiles/mailcatcher/Dockerfile
+++ b/docker/dockerfiles/mailcatcher/Dockerfile
@@ -16,10 +16,12 @@ RUN apk add --no-cache --virtual .build-deps \
         ruby-dev \
         make g++ \
         sqlite-dev \
+    && gem install -v 0.4.0 timeout --no-ri --no-rdoc \
     && gem install -v 0.1.2 net-protocol --no-ri --no-rdoc \
     && gem install -v 0.3.0 net-smtp --no-ri --no-rdoc \
     && gem install -v 0.2.2 net-imap --no-ri --no-rdoc \
     && gem install -v 1.1.2 mini_mime --no-ri --no-rdoc \
+    && gem install -v 1.6.7 sqlite3 --no-ri --no-rdoc \
     && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc \
     && apk del .build-deps
 


### PR DESCRIPTION
On avait ce souci :

```
1.565 (18/19) Installing .build-deps (0)
1.565 (19/19) Upgrading musl-utils (1.1.20-r5 -> 1.1.20-r6)
1.571 Executing busybox-1.29.3-r10.trigger
1.578 OK: 184 MiB in 47 packages
32.46 Building native extensions. This could take a while...
32.59 ERROR:  Error installing net-protocol:
32.59 	The last version of timeout (>= 0) to support your Ruby & RubyGems was 0.4.0. Try installing it with `gem install timeout -v 0.4.0` and then running the current command again
32.59 	timeout requires Ruby version >= 2.6.0. The current ruby version is 2.5.0.
32.61 Successfully installed io-wait-0.3.1
------
Dockerfile:15
--------------------
  14 |
  15 | >>> RUN apk add --no-cache --virtual .build-deps \
  16 | >>>         ruby-dev \
  17 | >>>         make g++ \
  18 | >>>         sqlite-dev \
  19 | >>>     && gem install -v 0.1.2 net-protocol --no-ri --no-rdoc \
  20 | >>>     && gem install -v 0.3.0 net-smtp --no-ri --no-rdoc \
  21 | >>>     && gem install -v 0.2.2 net-imap --no-ri --no-rdoc \
  22 | >>>     && gem install -v 1.1.2 mini_mime --no-ri --no-rdoc \
  23 | >>>     && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc \
  24 | >>>     && apk del .build-deps
  25 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apk add --no-cache --virtual .build-deps         ruby-dev         make g++         sqlite-dev     && gem install -v 0.1.2 net-protocol --no-ri --no-rdoc     && gem install -v 0.3.0 net-smtp --no-ri --no-rdoc     && gem install -v 0.2.2 net-imap --no-ri --no-rdoc     && gem install -v 1.1.2 mini_mime --no-ri --no-rdoc     && gem install -v $MAILCATCHER_VERSION mailcatcher --no-ri --no-rdoc     && apk del .build-deps" did not complete successfully: exit code: 1
Service 'mailcatcher' failed to build : Build failed
make: *** [Makefile:76: test-functional] Error 1
Error: Process completed with exit code 2.
```

Du coup les tests ne passaient plus