### PR TITLE
Fiscalisation : ajout de donnees test journal/facture et tests sur les factures

### DIFF
--- a/db/seeds/ComptaPeriode.php
+++ b/db/seeds/ComptaPeriode.php
@@ -85,6 +85,18 @@ class ComptaPeriode extends AbstractSeed
                 'date_fin'=>'2019-12-31',
                 'verouiller'=>0,
             ],
+            [
+                'id'=>14,
+                'date_debut'=>'2023-01-01',
+                'date_fin'=>'2023-12-31',
+                'verouiller'=>0,
+            ],
+            [
+                'id'=>15,
+                'date_debut'=>'2024-01-01',
+                'date_fin'=>'2024-12-31',
+                'verouiller'=>0,
+            ],
         ];
 
         $table = $this->table('compta_periode');

--- a/db/seeds/Facture.php
+++ b/db/seeds/Facture.php
@@ -1,0 +1,87 @@
+<?php
+
+use Phinx\Seed\AbstractSeed;
+
+class Facture extends AbstractSeed
+{
+    public function run()
+    {
+        $data = [
+            [
+                'id'    => '1',
+                'date_devis' => '2023-06-10',
+                'numero_devis' => '2023-01',
+                'date_facture' => '2023-06-11',
+                'numero_facture' => '2023-01',
+                'societe' => 'Krampouz',
+                'adresse' => '3, rue du port',
+                'code_postal' => '29000',
+                'ville' => 'Quimper',
+                'id_pays' =>  'FR',
+                'email' => 'mail@testmail.fr',
+                'tva_intra' => null,
+                'nom' => 'Le kellen',
+                'prenom' => 'Yan',
+                'etat_paiement' => 1,
+                'devise_facture' => 'EUR',
+                'ref_clt1' => 'Forum PHP 2023'
+            ],
+            [
+                'id'    => '2',
+                'date_devis' => '2024-01-03',
+                'numero_devis' => '2024-02',
+                'date_facture' => '2024-01-04',
+                'numero_facture' => '2023-02',
+                'societe' => 'Krampouz',
+                'adresse' => '3, rue du port',
+                'code_postal' => '29000',
+                'ville' => 'Quimper',
+                'id_pays' =>  'FR',
+                'email' => 'mail@testmail.fr',
+                'tva_intra' => null,
+                'nom' => 'Le kellen',
+                'prenom' => 'Yan',
+                'etat_paiement' => 1,
+                'devise_facture' => 'EUR',
+                'ref_clt1' => 'Forum PHP 2024'
+            ],
+        ];
+
+        $table = $this->table('afup_compta_facture');
+
+        $table->truncate();
+
+        $table
+            ->insert($data)
+            ->save()
+        ;
+
+        $dataDetails = [
+            [
+                'idafup_compta_facture' => '1',
+                'ref' => 'forum_php_2023',
+                'designation' => 'Forum PHP 2023 - Sponsoring Bronze',
+                'quantite' => '1',
+                'pu' =>  '1000',
+                'tva' => '0.00',
+            ],
+            [
+                'idafup_compta_facture' => '2',
+                'ref' => 'forum_php_2024',
+                'designation' => 'Forum PHP 2024 - Sponsoring Bronze',
+                'quantite' => '1',
+                'pu' =>  '1000',
+                'tva' => '0.00',
+            ],
+        ];
+
+        $table = $this->table('afup_compta_facture_details');
+
+        $table->truncate();
+
+        $table
+            ->insert($dataDetails)
+            ->save()
+        ;
+    }
+}

--- a/db/seeds/Facture.php
+++ b/db/seeds/Facture.php
@@ -31,7 +31,7 @@ class Facture extends AbstractSeed
                 'date_devis' => '2024-01-03',
                 'numero_devis' => '2024-02',
                 'date_facture' => '2024-01-04',
-                'numero_facture' => '2023-02',
+                'numero_facture' => '2024-02',
                 'societe' => 'Krampouz',
                 'adresse' => '3, rue du port',
                 'code_postal' => '29000',

--- a/htdocs/templates/administration/compta_facture.html
+++ b/htdocs/templates/administration/compta_facture.html
@@ -58,7 +58,7 @@
                 </a>
                 <a href="index.php?page=compta_facture&amp;action=envoyer_facture&amp;ref={$ecriture.numero_facture}"
                    data-position="left center"
-                   data-tooltip="Envoyer la facture par mail"
+                   data-tooltip="Envoyer la facture {$ecriture.numero_facture} par mail"
                    class="compact ui icon button"
                 >
                     <i class="paper plane icon"></i>

--- a/htdocs/templates/administration/compta_facture.html
+++ b/htdocs/templates/administration/compta_facture.html
@@ -51,7 +51,7 @@
                </a>
                 <a href="index.php?page=compta_facture&amp;action=telecharger_facture&amp;ref={$ecriture.numero_facture}"
                    data-position="left center"
-                   data-tooltip="Télécharger la facture"
+                   data-tooltip="Télécharger la facture {$ecriture.numero_facture}"
                    class="compact ui icon button"
                 >
                     <i class="file pdf icon"></i>

--- a/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
+++ b/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
@@ -84,3 +84,47 @@ Feature: Administration - Trésorerie - Devis/Facture
     Then the response header "Content-disposition" should match '#attachment; filename="Facture - ESN dev en folie - (.*).pdf"#'
     When I parse the pdf downloaded content
     Then The page "1" of the PDF should contain "N° TVA Intracommunautaire : FR7612345"
+
+  @reloadDbWithTestData
+  @clearEmails
+  @vat
+  Scenario: Test du PDF de facture avant 2024
+    Given I am logged in as admin and on the Administration
+    When I go to "/pages/administration/index.php?page=compta_facture"
+    Then the ".content h2" element should contain "Factures"
+    And I should see "Il n'est pas possible de créer directement une facture"
+    When I follow the button of tooltip "Télécharger la facture 2023-01"
+    Then the response header "Content-disposition" should equal 'attachment; filename="Facture - Krampouz - 2023-06-11.pdf"'
+    Given I parse the pdf downloaded content
+    Then The page "1" of the PDF should contain "Le 11/06/2023"
+    Then The page "1" of the PDF should contain "Krampouz"
+    Then The page "1" of the PDF should contain "3, rue du port"
+    Then The page "1" of the PDF should contain "Facture n° 2023-01"
+    Then The page "1" of the PDF should contain "Repère(s) :  Forum PHP 2023"
+    Then The page "1" of the PDF should contain "Comme convenu, nous vous prions de trouver votre facture"
+    Then The page "1" of the PDF should contain "Type Description Quantite Prix Total"
+    Then The page "1" of the PDF should contain "forum_php_2023 Forum PHP 2023 - Sponsoring Bronze 1.00 1000.00 € 1000 €"
+    Then The page "1" of the PDF should contain "TOTAL 1000 €"
+    Then The page "1" of the PDF should contain "TVA non applicable - art. 293B du CGI"
+
+  @reloadDbWithTestData
+  @clearEmails
+  @vat
+  Scenario: Test du PDF de facture après 2024
+    Given I am logged in as admin and on the Administration
+    When I go to "/pages/administration/index.php?page=compta_facture"
+    Then the ".content h2" element should contain "Factures"
+    And I should see "Il n'est pas possible de créer directement une facture"
+    When I follow the button of tooltip "Télécharger la facture 2024-02"
+    Then the response header "Content-disposition" should equal 'attachment; filename="Facture - Krampouz - 2024-01-04.pdf"'
+    Given I parse the pdf downloaded content
+    Then The page "1" of the PDF should contain "Le 04/01/2024"
+    Then The page "1" of the PDF should contain "Krampouz"
+    Then The page "1" of the PDF should contain "3, rue du port"
+    Then The page "1" of the PDF should contain "Facture n° 2024-02"
+    Then The page "1" of the PDF should contain "Repère(s) :  Forum PHP 2024"
+    Then The page "1" of the PDF should contain "Comme convenu, nous vous prions de trouver votre facture"
+    Then The page "1" of the PDF should contain "Type Description Quantite Prix Total"
+    Then The page "1" of the PDF should contain "forum_php_2024 Forum PHP 2024 - Sponsoring Bronze 1.00 1000.00 € 1000 €"
+    Then The page "1" of the PDF should contain "TOTAL 1000 €"
+    Then The page "1" of the PDF should contain "TVA non applicable - art. 293B du CGI"

--- a/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
+++ b/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
@@ -68,7 +68,7 @@ Feature: Administration - Trésorerie - Devis/Facture
     And I should see "Paris Cedex 7"
     And I should see "Payé"
     # Envoi de la facture par email
-    Then I follow the button of tooltip "Envoyer la facture par mail"
+    Then I follow the button of tooltip "Envoyer la facture 2023-2 par mail"
     And I should only receive the following emails:
       | from               | to                         | subject      |
       | <bonjour@afup.org> | <martine@ens-en-folie.biz> | Facture AFUP |
@@ -80,7 +80,7 @@ Feature: Administration - Trésorerie - Devis/Facture
     # Téléchargement de la facture
     When I go to "/admin/"
     And I follow "Factures"
-    And I follow the button of tooltip "Télécharger la facture"
+    And I follow the button of tooltip "Télécharger la facture 2023-2"
     Then the response header "Content-disposition" should match '#attachment; filename="Facture - ESN dev en folie - (.*).pdf"#'
     When I parse the pdf downloaded content
     Then The page "1" of the PDF should contain "N° TVA Intracommunautaire : FR7612345"


### PR DESCRIPTION
fixes #1351

Cela permettra de tester plus tard le journal.
Et surtout cela va servir de base au développement pour afficher la TVA sur les PDF de factures.