### PR TITLE
Corrige l'override de docker compose

### DIFF
--- a/compose.override.yml-dist
+++ b/compose.override.yml-dist
@@ -16,12 +16,3 @@ services:
   mailcatcher:
     ports:
       - "1181:1080"
-  apachephp7:
-    ports:
-      - "9235:80"
-   # environment:
-   #   XDEBUG_CONFIG: "remote_connect_back=1 profiler_enable=1 remote_autostart=0 remote_enable=1"
-  mailcatcher:
-    ports:
-      - "1080:1080"
-      - "1025:1025"


### PR DESCRIPTION
```console
$make docker-up
CURRENT_UID=1000 ENABLE_XDEBUG= docker compose build
parsing /home/albin/Project/afup/web/compose.override.yml: yaml: unmarshal errors:
  line 24: mapping key "mailcatcher" already defined at line 16
make: *** [Makefile:21 : var/logs/.docker-build] Erreur 15
```
puis
```console
$make docker-up
CURRENT_UID=1000 ENABLE_XDEBUG= docker compose build
service "apachephp7" has neither an image nor a build context specified: invalid compose project
make: *** [Makefile:21 : var/logs/.docker-build] Erreur 15

```
Corrige les 2 erreurs ci-dessus dans l'override du `docker compose`.
On a 2 fois `mailctaher` et `apachephp7` n'existe plus.