### PR TITLE
on augmente la limite de temps d'indexation des talks

### DIFF
--- a/sources/AppBundle/Controller/Admin/Talk/UpdateIndexationAction.php
+++ b/sources/AppBundle/Controller/Admin/Talk/UpdateIndexationAction.php
@@ -24,6 +24,8 @@ class UpdateIndexationAction
 
     public function __invoke(Request $request)
     {
+        set_time_limit(240);
+
         $this->runner->run();
         $this->flashBag->add('notice', 'Indexation effectuée');
 


### PR DESCRIPTION
Cela permet d'éviter d'avoir cette erreur en prod :
```
Service Unavailable

The server is temporarily unable to service your request due to maintenance downtime or capacity problems. Please try again later.
```