### PR TITLE
amélioration de l'alignement du numéro de TVA intracommunautaire sur les factures

### DIFF
--- a/sources/Afup/Utils/PDF_Facture.php
+++ b/sources/Afup/Utils/PDF_Facture.php
@@ -182,9 +182,9 @@ class PDF_Facture extends \FPDF
             $this->Ln();
 
             $this->SetFont('Arial', 'B', 6);
-            $this->Cell(145, 3, utf8_decode('Numéro de TVA intracommunautaire'), 0, 0, 'C');
+            $this->Cell(155, 3, utf8_decode('Numéro de TVA intracommunautaire'), 0, 0, 'C');
             $this->SetFont('Arial', null, 6);
-            $this->Cell(-60, 3, $this->configuration->obtenir('afup|numero_tva'), 0, 0, 'C');
+            $this->Cell(-95, 3, $this->configuration->obtenir('afup|numero_tva'), 0, 0, 'C');
         }
 
         $this->Ln();

--- a/tests/behat/features/Admin/Events/FacturesEvennement.feature
+++ b/tests/behat/features/Admin/Events/FacturesEvennement.feature
@@ -52,7 +52,7 @@ Feature: Administration - Évènements - Factures d'évènement
     Then The page "1" of the PDF should contain "Payé par CB le 02/01/2024"
     Then The page "1" of the PDF should not contain "TVA non applicable - art. 293B du CGI"
     Then The page "1" of the PDF should contain "Numéro de TVA intracommunautaire NUMERO_A_AJOUTER"
-    Then the checksum of the response content should be "e0ea03688103cc03fd9c507c1cf30dab"
+    Then the checksum of the response content should be "7502fd1912dbaed009c06339f96f0780"
 
   @reloadDbWithTestData
   @clearEmails

--- a/tests/behat/features/MembersArea/Index.feature
+++ b/tests/behat/features/MembersArea/Index.feature
@@ -91,7 +91,7 @@ Feature: Espace membre, accueil
     Then The page "1" of the PDF should contain "Total TTC 30,00 €"
     Then The page "1" of the PDF should not contain "TVA non applicable - art. 293B du CGI"
     Then The page "1" of the PDF should contain "Numéro de TVA intracommunautaire NUMERO_A_AJOUTER"
-    Then the checksum of the response content should be "ad8d0c5660f0c201c4d9112fd237c3f5"
+    Then the checksum of the response content should be "fd8220147402cc643abd87528e637f9b"
 
   @reloadDbWithTestData @vat
   Scenario: Test d'une facture de cotisation de personne morale avant 2024
@@ -136,7 +136,7 @@ Feature: Espace membre, accueil
     Then The page "1" of the PDF should contain "Total TTC 180,00 €"
     Then The page "1" of the PDF should not contain "TVA non applicable - art. 293B du CGI"
     Then The page "1" of the PDF should contain "Numéro de TVA intracommunautaire NUMERO_A_AJOUTER"
-    Then the checksum of the response content should be "5c9f09899fdd3525e31b8a4c7183cfd4"
+    Then the checksum of the response content should be "fc5995251eec12adb62c2783039fb041"
 
 
   @reloadDbWithTestData


### PR DESCRIPTION
Suite à l'ajout du numéro définitif, on améliore l'alignement de cette info dans le footer.

![Capture d’écran du 2024-01-15 20-32-07](https://github.com/afup/web/assets/320372/a9f88715-0a36-4ff5-94f6-7de69ebf3d2f)
