### PR TITLE
correction du calcul de la TVA sur les factures d'événement multilignes

### DIFF
--- a/sources/Afup/Forum/Facturation.php
+++ b/sources/Afup/Forum/Facturation.php
@@ -312,7 +312,7 @@ class Facturation
                 $pdf->Cell(30, 5, utf8_decode($this->formatFactureValue($montant, $isSubjectedToVat)) . utf8_decode(' '), 1, 0, 'R');
             }
 
-            $totalHt = $montantHt;
+            $totalHt += $montantHt;
             $total += $montant;
         }
 


### PR DESCRIPTION
Le calcul de la TVA n'était pas bon quand on avait plusieurs lignes.