### PR TITLE
on ajoute les précisions HT / TTC sur la page d'adhésion

### DIFF
--- a/app/Resources/views/site/become_member.html.twig
+++ b/app/Resources/views/site/become_member.html.twig
@@ -86,7 +86,7 @@
                         </tr>
                         <tr>
                             <td class="argument-list__strong">
-                                {{ membership_fee_natural_person }}€ / an / pour une personne<br />
+                                {{ membership_fee_natural_person }}€ TTC / an / pour une personne<br />
                                 <a href="{{ url('legacy_inscription') }}" class="button button--call-to-action">Adhérer en tant que particulier</a>
                             </td>
                         </tr>
@@ -94,7 +94,7 @@
                 </table>
 
                 <p class="txtcenter">
-                    L'inscription se fait directement sur la page dédiée. Elle coûte {{ membership_fee_natural_person }} euros pour 12 mois.
+                    L'inscription se fait directement sur la page dédiée. Elle coûte {{ membership_fee_natural_person }} euros TTC pour 12 mois.
                 </p>
 
             </div>
@@ -124,7 +124,7 @@
                     </tr>
                     <tr>
                         <td class="argument-list__strong">
-                            {{ membership_fee_legal_entity }}€ / an / 3 employé(e)s<br />
+                            {{ membership_fee_legal_entity }}€ HT / an / 3 employé(e)s<br />
                             <a href="{{ url('company_membership') }}" class="button button--call-to-action">Adhérer en tant qu'entreprise</a>
                         </td>
                     </tr>
@@ -133,7 +133,7 @@
 
                 <p class="txtcenter">
                     Une préinscription est à réaliser en suivant le lien ci-dessus. L'équipe trésorerie vous recontactera pour finaliser ensuite l'inscription.
-                    Le montant de la cotisation est de {{ membership_fee_legal_entity }} euros HT par tranche de 3 employés pour 12 mois. À noter, l'AFUP ne facture pas de TVA.
+                    Le montant de la cotisation est de {{ membership_fee_legal_entity }} euros HT par tranche de 3 employés pour 12 mois.
                 </p>
 
             </div>


### PR DESCRIPTION
On précise quand les prix sont HT/TTC suite à la soumission à la TVA.

![Screenshot 2024-01-21 at 13-30-31 Devenir membre de l'AFUP](https://github.com/afup/web/assets/320372/85051e0b-32ec-47e3-9c5f-d84746b02bef)
