### PR TITLE
correction du montant payé quand on adhere en tant que personne morale

### DIFF
--- a/sources/AppBundle/Association/CompanyMembership/SubscriptionManagement.php
+++ b/sources/AppBundle/Association/CompanyMembership/SubscriptionManagement.php
@@ -4,6 +4,7 @@
 namespace AppBundle\Association\CompanyMembership;
 
 use Afup\Site\Association\Cotisations;
+use Afup\Site\Utils\Utils;
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\LegacyModelFactory;
 
@@ -29,7 +30,7 @@ class SubscriptionManagement
         $subscription->ajouter(
             AFUP_PERSONNES_MORALES,
             $company->getId(),
-            ceil($numberOfMembers / AFUP_PERSONNE_MORALE_SEUIL) * AFUP_COTISATION_PERSONNE_MORALE,
+            ceil($numberOfMembers / AFUP_PERSONNE_MORALE_SEUIL) * AFUP_COTISATION_PERSONNE_MORALE * (1 + Utils::MEMBERSHIP_FEE_VAT_RATE),
             null,
             null,
             (new \DateTime())->format('U'),

--- a/tests/behat/features/PublicSite/Register.feature
+++ b/tests/behat/features/PublicSite/Register.feature
@@ -60,7 +60,7 @@ Feature: Site Public - Register
     And I fill in "company_member[invitations][0][email]" with "registeredUser@gmail.com"
     And I press "Enregistrer mon adhésion"
     And I should see "Adhésion enregistrée !"
-    And I should see "Montant de la cotisation: 150.00 Euros"
+    And I should see "Montant de la cotisation: 180.00 Euros"
     When I press "Régler par carte"
     # Pour suivre la redirection POST de Paybox
     And I submit the form with name "PAYBOX"


### PR DESCRIPTION
Quand on adhere en tant que personne morale on payait toujours 150€ au lieu des 180€ (TTC).

C'était bien le cas sur la page cotisation pour le renouvellement, mais n'était pas pris en compte lors de l'adhesion.

Maintenant ça donne cela:
![Screenshot 2024-01-22 at 20-15-49 Afup - Association française des utilisateurs de PHP](https://github.com/afup/web/assets/320372/542b1d8b-8626-44af-afbd-1b3ca43d9f1b)
