### PR TITLE
page stats de l'admin : on permet de choisis l'event comparé via l'URL

### DIFF
--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -81,10 +81,12 @@ SQL;
         return $registrations;
     }
 
-    function obtenirSuivi($id_forum)
+    function obtenirSuivi($id_forum, $id_forum_precedent = null)
     {
         $forum = new Forum($this->_bdd);
-        $id_forum_precedent = $forum->obtenirForumPrecedent($id_forum);
+        if (null === $id_forum_precedent) {
+            $id_forum_precedent = $forum->obtenirForumPrecedent($id_forum);
+        }
 
         $now = new \DateTime();
         $dateForum = \DateTime::createFromFormat('U', $forum->obtenir($id_forum)['date_fin_vente']);

--- a/sources/AppBundle/Controller/Admin/Event/StatsAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/StatsAction.php
@@ -53,12 +53,19 @@ class StatsAction
     public function __invoke(Request $request)
     {
         $id = $request->query->get('id');
+        $comparedEventId = $request->query->get('compared_event_id');
 
         $event = $this->eventActionHelper->getEventById($id);
 
         $legacyInscriptions = $this->legacyModelFactory->createObject(Inscriptions::class);
 
-        $stats = $legacyInscriptions->obtenirSuivi($event->getId());
+        $comparedSerieName = 'n-1';
+        if ($comparedEventId) {
+            $comparedEvent = $this->eventActionHelper->getEventById($comparedEventId, false);
+            $comparedSerieName = $comparedEvent->getTitle();
+        }
+
+        $stats = $legacyInscriptions->obtenirSuivi($event->getId(), $comparedEventId);
         $ticketsDayOne = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_ONE, $event);
         $ticketsDayTwo = $this->ticketRepository->getPublicSoldTicketsByDay(Ticket::DAY_TWO, $event);
 
@@ -93,7 +100,7 @@ class StatsAction
                     }, $stats['suivi'])),
                 ],
                 [
-                    'name' => 'n-1',
+                    'name' => $comparedSerieName,
                     'data' => array_values(array_map(static function ($item) {
                         return $item['n_1'];
                     }, $stats['suivi'])),


### PR DESCRIPTION
réponds partiellement au #1186

cela permet de comparer des événements qui ne sont pas forcément l'événement n-1, ce qui est utile pour les AFUP Day