### PR TITLE
on reviens sur l'ancien session handler

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -330,7 +330,9 @@ framework:
     trusted_hosts:   ~
     session:
         # https://symfony.com/doc/4.x/session/database.html#store-sessions-in-a-relational-database-mariadb-mysql-postgresql
-        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
+        #handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler
+        storage_id: session.storage.php_bridge
+        handler_id: ~
     fragments:       ~
     http_method_override: true
     assets: ~

--- a/htdocs/app.php
+++ b/htdocs/app.php
@@ -19,6 +19,8 @@ if ($_SERVER['HTTP_HOST'] === 'afup.dev' || $isDevEnv || $isTestEnv) {
         exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
     }
 
+    session_start();
+
     /** @var \Composer\Autoload\ClassLoader $loader */
     $loader = require __DIR__.'/../vendor/autoload.php';
     Debug::enable();
@@ -31,6 +33,8 @@ if ($_SERVER['HTTP_HOST'] === 'afup.dev' || $isDevEnv || $isTestEnv) {
 } else {
     /** @var \Composer\Autoload\ClassLoader $loader */
     $loader = require __DIR__.'/../vendor/autoload.php';
+
+    session_start();
 
     $kernel = new AppKernel('prod', false);
 }

--- a/htdocs/pages/planete/app.php
+++ b/htdocs/pages/planete/app.php
@@ -28,6 +28,8 @@ if ($_SERVER['HTTP_HOST'] === 'afup.dev' || $isDevEnv || $isTestEnv) {
         exit('You are not allowed to access this file. Check '.basename(__FILE__).' for more information.');
     }
 
+    session_start();
+
     /** @var ClassLoader $loader */
     $loader = require __DIR__.'/../../../vendor/autoload.php';
     Debug::enable();
@@ -40,6 +42,8 @@ if ($_SERVER['HTTP_HOST'] === 'afup.dev' || $isDevEnv || $isTestEnv) {
 } else {
     /** @var ClassLoader $loader */
     $loader = require __DIR__.'/../../../vendor/autoload.php';
+
+    session_start();
 
     $kernel = new PlaneteAppKernel('prod', false);
 }


### PR DESCRIPTION
suite au https://github.com/afup/web/pull/1446

on reviens temporairement sur l'ancien session handler

car les routes comme la gestion des articles renvoient vers la page de login

ça serait lié à ce firewall quand on est sur une page non migrée ? https://github.com/afup/web/blob/3450893ffd7053c572555c4d1fb4f44043f4b4d9/app/config/security.yml#L20

//cc @stakovicz 

(je n'ai pas pu revert, vu qu'il y a eut des changements sur les fichiers entretemps)