### PR TITLE
on utilise la même version de php que celle utilisée pour composer po…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,12 +47,12 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "./bin/console cache:clear --no-warmup",
-      "./bin/console assets:install --relative htdocs"
+      "@php bin/console cache:clear --no-warmup",
+      "@php bin/console assets:install --relative htdocs"
     ],
     "post-update-cmd": [
-      "./bin/console cache:clear --no-warmup",
-      "./bin/console assets:install --relative htdocs"
+      "@php bin/console cache:clear --no-warmup",
+      "@php bin/console assets:install --relative htdocs"
     ]
   },
   "config": {


### PR DESCRIPTION
…ur les scripts de post install

Lors du composer install en prod on avait cette erreur :
```
poser.phar/bin/composer:61", " /home/sources/web/releases/20240214075605/composer.phar:24", "19 packages you are using are looking for funding.", "Use the `composer fund` command to find out more!", "> post-install-cmd: ./bin/console cache:clear --no-warmup", "PHP Parse error:  syntax error, unexpected ':', expecting ';' or '{' in /home/sources/web/releases/20240214075605/sources/Afup/Utils/Configuration.php on line 42", "Script ./bin/console cache:clear --no-warmup handling the post-install-cmd event returned with error code 255"], "stdout": "", "stdout_lines": []}
```

Cela car on a ce type hint :
https://github.com/afup/web/blob/ec400fd38da29f6b59b3d47e0f5fa7070ca05285/sources/Afup/Utils/Configuration.php#L42

Et que lors du cache clear cette classe est appellé et que le cache clear était appellé avec le binaire php par défaut et pas celui "php7.0".

On précise donc d'utiliser le même binaire de php que celui utilisé pour lancer composer.