### PR TITLE
création d'une API pour les flux de PlanetePHP

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -45,6 +45,10 @@ techletter:
     resource: "routing/techletter.yml"
     prefix: /techno_watch
 
+planete_php_api:
+    resource: "routing/planete_php_api.yml"
+    prefix: /planete-php-api
+
 badge_image:
     path: /profile/badge/{id}
     defaults: {_controller: AppBundle:Website\Badge:badge }

--- a/app/config/routing/planete_php_api.yml
+++ b/app/config/routing/planete_php_api.yml
@@ -1,0 +1,7 @@
+planete_php_api_articles:
+  path: /articles
+  defaults: {_controller: AppBundle\Controller\Planete\ArticlesController}
+
+planete_php_api_feeds:
+  path: /feeds
+  defaults: {_controller: AppBundle\Controller\Planete\FeedsController}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -685,6 +685,11 @@ services:
         autowire: true
         public: true
 
+    AppBundle\Controller\Planete\:
+        resource: '../../sources/AppBundle/Controller/Planete/*'
+        autowire: true
+        autoconfigure: true
+
     app.github.http_client:
         class: GuzzleHttp\Client
         arguments:

--- a/db/seeds/FeedArticle.php
+++ b/db/seeds/FeedArticle.php
@@ -10,7 +10,7 @@ class FeedArticle extends AbstractSeed
             'nom' => 'Un super site PHP',
             'url' => 'https://afup.org',
             'feed' => 'https://afup.org/rss.xml',
-            'etat' => 0,
+            'etat' => 1,
         ];
         $table = $this->table('afup_planete_flux');
         $table->truncate();
@@ -54,6 +54,20 @@ class FeedArticle extends AbstractSeed
                 'etat' => 0
             ],
         ];
+
+        for ($i = 0; $i < 20; $i++) {
+            $data[] = [
+                'afup_planete_flux_id' => 1,
+                'clef' => '4d5cf2e2-78bd-11ee-b962-0242ac13000' . $i,
+                'titre' => 'Un titre ' . $i,
+                'url' => 'https://afup.org/url-' . $i . '.html',
+                'maj' => time(),
+                'auteur' => 'Un super auteur ' . $i,
+                'resume' => 'Un super article ' . $i,
+                'contenu' => 'Le contenu du super article ' . $i,
+                'etat' => 1
+            ];
+        }
 
         $table = $this->table('afup_planete_billet');
         $table->truncate();

--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Planete;
+
+use PlanetePHP\FeedArticleRepository;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ArticlesController
+{
+    /** @var FeedArticleRepository */
+    private $feedArticleRepository;
+
+    public function __construct(
+        FeedArticleRepository $feedArticleRepository
+    ) {
+        $this->feedArticleRepository = $feedArticleRepository;
+    }
+
+    public function __invoke(Request $request): Response
+    {
+        $page = (int) $request->query->get("page", 1);
+
+        if ($page < 1) {
+            $page = 1;
+        }
+
+        $articles = $this->feedArticleRepository->findLatest($page - 1, DATE_RSS, 20);
+
+        $data = [];
+
+        foreach ($articles as $article) {
+            $data[] = [
+                'title' => $article->getTitle(),
+                'url' => $article->getUrl(),
+                'date' => $article->getUpdate(),
+                'author' => $article->getAuthor(),
+                'content' => $article->getContent(),
+            ];
+        }
+
+        return new Response(json_encode($data), 200, ['Content-Type' => 'application/json']);
+    }
+}

--- a/sources/AppBundle/Controller/Planete/FeedsController.php
+++ b/sources/AppBundle/Controller/Planete/FeedsController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Planete;
+
+use PlanetePHP\FeedRepository;
+use Symfony\Component\HttpFoundation\Response;
+
+final class FeedsController
+{
+    /** @var FeedRepository */
+    private $feedRepository;
+
+    public function __construct(FeedRepository $feedRepository)
+    {
+        $this->feedRepository = $feedRepository;
+    }
+
+    public function __invoke(): Response
+    {
+        $feeds = $this->feedRepository->findActive();
+
+        $data = [];
+
+        foreach ($feeds as $feed) {
+            $data[] = [
+                'name' => $feed->getName(),
+                'url' => $feed->getUrl(),
+            ];
+        }
+
+        return new Response(json_encode($data), 200, ['Content-Type' => 'application/json']);
+    }
+}

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -229,6 +229,14 @@ class FeatureContext implements Context
     }
 
     /**
+     * @Then /^the json response has the key "(?P<key>[^"]*)" with value "(?P<value>(?:[^"]|\\")*)"$/
+     */
+    public function assertResponseHasJsonKeyAndValue($key, $value)
+    {
+        $this->minkContext->assertResponseContains(sprintf('"%s":"%s"', $key, $value));
+    }
+
+    /**
      * @Then the current URL should match :arg1
      */
     public function assertCurrentUrlContains($regex)

--- a/tests/behat/features/Api/PlanetePHPApi.feature
+++ b/tests/behat/features/Api/PlanetePHPApi.feature
@@ -1,0 +1,26 @@
+Feature: PlanetePHP API routes
+
+  Scenario: Get the first page of articles
+    Given I am on "/planete-php-api/articles"
+    Then the response status code should be 200
+    And the response header "Content-Type" should match "#^application/json#"
+    And the json response has the key "title" with value "Un titre"
+    And the json response has the key "url" with value "https:\/\/afup.org\/url.html"
+    And the json response has the key "author" with value "Un super auteur"
+    And the json response has the key "content" with value "Le contenu du super article"
+
+  Scenario: Get another page of articles
+    Given I am on "/planete-php-api/articles?page=2"
+    Then the response status code should be 200
+    And the response header "Content-Type" should match "#^application/json#"
+    And the json response has the key "title" with value "Un titre 18"
+    And the json response has the key "url" with value "https:\/\/afup.org\/url-18.html"
+    And the json response has the key "author" with value "Un super auteur 18"
+    And the json response has the key "content" with value "Le contenu du super article 18"
+
+  Scenario: Get the list of feeds
+    Given I am on "/planete-php-api/feeds"
+    Then the response status code should be 200
+    And the response header "Content-Type" should match "#^application/json#"
+    And the json response has the key "name" with value "Un super site PHP"
+    And the json response has the key "url" with value "https:\/\/afup.org"


### PR DESCRIPTION
Cette API va servir à sortir PlanetePHP comme voulu dans #1422 

Il y a deux routes exposées :

- `/planete-php-api/articles` : la liste des articles
- `/planete-php-api/feeds` : la liste des source actives 