### PR TITLE
[PHPStan] Dépendance sur la classe au lieu de l'interface

### DIFF
--- a/sources/AppBundle/Github/GithubClient.php
+++ b/sources/AppBundle/Github/GithubClient.php
@@ -5,17 +5,17 @@ namespace AppBundle\Github;
 use AppBundle\Event\Model\GithubUser;
 use AppBundle\Github\Exception\UnableToFindGithubUserException;
 use AppBundle\Github\Exception\UnableToGetGithubUserInfosException;
-use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Client;
 use GuzzleHttp\RequestOptions;
 
 class GithubClient
 {
     /**
-     * @var ClientInterface
+     * @var Client
      */
     private $githubClient;
 
-    public function __construct(ClientInterface $githubClient)
+    public function __construct(Client $githubClient)
     {
         $this->githubClient = $githubClient;
     }


### PR DESCRIPTION
L'interface n'a qu'une seule implémentation et les méthodes `get` et autre n'y sont pas. À savoir que dans la v7 de Guzzle ces méthodes sont présentes de façon concrète dans la classe `Client`.

@see https://github.com/guzzle/guzzle/blob/7.8/src/ClientTrait.php#L42