### PR TITLE
[PHPStan] Ajout d'une vérification de type d'un node

### DIFF
--- a/sources/AppBundle/Indexation/Meetups/MeetupScraper.php
+++ b/sources/AppBundle/Indexation/Meetups/MeetupScraper.php
@@ -37,6 +37,10 @@ class MeetupScraper
                     $events = $xpath->query("//*[contains(@id, 'event-card')]");
                     foreach ($events as $event) {
                         try {
+                            if (!$event instanceof \DOMElement) {
+                                throw new \Exception('Élement DOM de type invalide');
+                            }
+
                             $eventUrl = $event->getAttribute('href');
                             if (preg_match('/\/(\d+)\/$/', $eventUrl, $matches)) {
                                 $id = (int) $matches[1];


### PR DESCRIPTION
La méthode `query` retourne une liste de `\DOMNode`, classe qui ne possède pas de méthode `getAttribute` comme la classe `\DOMElement`.