### PR TITLE
afup#1442 optimisation du chargement de la configuration

### DIFF
--- a/sources/Afup/Utils/Configuration.php
+++ b/sources/Afup/Utils/Configuration.php
@@ -41,13 +41,16 @@ class Configuration
 
     private function loadSymfonyParameters(): array
     {
-        $basePath = __DIR__ . '/../../../app/config';
+        static $parameters = [];
 
-        $parameters = [];
-        $this->mergeSymfonyParametersFromFile($basePath . '/parameters.yml', $parameters);
-        $this->mergeSymfonyParametersFromFile($basePath . '/config.yml', $parameters);
-        if (isset($_ENV['SYMFONY_ENV'])) {
-            $this->mergeSymfonyParametersFromFile($basePath . '/config_' . $_ENV['SYMFONY_ENV'] . '.yml', $parameters);
+        if ([] === $parameters) {
+            $basePath = __DIR__ . '/../../../app/config';
+
+            $this->mergeSymfonyParametersFromFile($basePath . '/parameters.yml', $parameters);
+            $this->mergeSymfonyParametersFromFile($basePath . '/config.yml', $parameters);
+            if (isset($_ENV['SYMFONY_ENV'])) {
+                $this->mergeSymfonyParametersFromFile($basePath . '/config_' . $_ENV['SYMFONY_ENV'] . '.yml', $parameters);
+            }
         }
 
         return $parameters;


### PR DESCRIPTION
Le temps de réponse a fortement augmenté depuis début février en PROD. Cela semble lié au chargement de la configuration (parsing yaml de fichiers) et l'accès au disque particulièrement lent en PROD.

En utilisant un tableau static, celui-ci n'est chargé qu'une fois. Cela fait une sorte de cache et économiser des parsing yaml multiple.