### PR TITLE
Corrige la prise de ticket en mobile

### DIFF
--- a/htdocs/js/inscription.js
+++ b/htdocs/js/inscription.js
@@ -47,11 +47,11 @@ $(document).ready(function(){
 
     var manageFieldSet = function (nbInscriptions) {
         for (var i = 1; i < (nbMaxPersonnes - 1); i++) {
-            $('fieldset.tickets--fieldset').hide();
+            $('fieldset.tickets--fieldset').attr('style','display:none !important');
         }
 
         for (var i = 1; i < (nbInscriptions + 1); i++) {
-            $('fieldset.f' + i).show();
+            $('fieldset.f' + i).attr('style','display:block !important');
             $('fieldset.f' + i).find('input[data-required=true]').attr('required', true);
 			if (typeof $('input[name="purchase[tickets][' + i +'][ticketType]"]:checked').val() === "undefined") {
 			    $('fieldset.f' + i).find('ul.tickets--type-list input[type=radio]:not(:disabled):first').attr('checked', true);


### PR DESCRIPTION
Suite à une remonté sur le Slack : 
> Je viens de voir que sur mobile, en tout cas avec firefox, la page pour prendre sa place pour l'afup day affiche les blocs pour les 10 personnes malgré le fait que la liste déroulante est sur 1. J'ai eu beau changé la valeur dans la liste déroulante mais ça ne fait rien.
> Voilà bisous :envoie_un_bisou:

Voici la correction à la surcharge d'un `!important` dans le CSS ici : 
https://github.com/afup/web/blob/855a76d9b9276f9f445fab6201008c041f86b818/htdocs/templates/site/scss/base/responsive-mobile.scss#L7