### PR TITLE
correction affichage des notices

### DIFF
--- a/sources/Afup/Bootstrap/Http.php
+++ b/sources/Afup/Bootstrap/Http.php
@@ -31,7 +31,7 @@ if (ob_get_level() === 0) {
 
 // mise à jour des paramétrages PHP en fonction de la configuration
 
-if (isset($_ENV['SYMFONY_ENV']) && $_ENV['SYMFONY_ENV'] === 'prod') {
+if (getenv('SYMFONY_ENV') === 'prod') {
     ini_set('error_reporting', E_ALL ^ E_WARNING ^ E_NOTICE);
     ini_set('display_errors', 0);
 } else {


### PR DESCRIPTION
On avait les notices d'affichées sur le site, par exemple sur la liste des admins :
```
 Notice: Uninitialized string offset: 4 in /home/sources/web/releases/20240323070111/sources/AppBundle/Association/Model/User.php on line 849
```

on corrige cela en changeant la façon de récupérer l'env symfony