### PR TITLE
Compta : mise en place des zones de TVA

### DIFF
--- a/db/migrations/20240401121249_compta_zone_tva.php
+++ b/db/migrations/20240401121249_compta_zone_tva.php
@@ -1,0 +1,15 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class ComptaZoneTva extends AbstractMigration
+{
+    public function change()
+    {
+        $sql = <<<EOF
+ALTER TABLE `compta`
+  ADD `tva_zone` VARCHAR(25) DEFAULT NULL AFTER `tva_intra`;
+EOF;
+        $this->execute($sql);
+    }
+}

--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -117,6 +117,7 @@ elseif ($action == 'credit') {
         $champs['montant_ht_soumis_tva_5_5'] = $champsRecup['montant_ht_soumis_tva_5_5'];
         $champs['montant_ht_soumis_tva_10'] = $champsRecup['montant_ht_soumis_tva_10'];
         $champs['montant_ht_soumis_tva_20'] = $champsRecup['montant_ht_soumis_tva_20'];
+        $champs['tva_zone'] = $champsRecup['tva_zone'];
 
 
 
@@ -162,6 +163,7 @@ elseif ($action == 'credit') {
     $formulaire->addElement('text', 'montant_ht_soumis_tva_0', 'Montant HT non soumis à TVA' , array('size' => 30, 'maxlength' => 40, 'id' => 'compta_journal_ht_0'));
     $formulaire->addElement('static'  , 'note', '', '<a href="#" id="apply-vat-0">Calculer le montant non soumis à TVA sur la base de l\'intégralité du montant TTC</a><br /><br />');
 
+    $formulaire->addElement('select'  , 'tva_zone', 'Zone TVA', ['' => 'Non définie', 'france' => 'France', 'ue' => 'Union Européenne hors France', 'hors_ue' => 'Hors Union Européenne']);
 
 //reglement
    $formulaire->addElement('header'  , ''                         , 'Réglement');
@@ -231,7 +233,9 @@ $date_regl=$valeur['date_reglement']['Y']."-".$valeur['date_reglement']['F']."-"
                                     $valeur['montant_ht_soumis_tva_0'],
                                     $valeur['montant_ht_soumis_tva_5_5'],
                                     $valeur['montant_ht_soumis_tva_10'],
-                                    $valeur['montant_ht_soumis_tva_20']
+                                    $valeur['montant_ht_soumis_tva_20'],
+                                    $valeur['tva_zone']
+
             						);
         } else {
    			$ok = $compta->modifier(
@@ -255,7 +259,8 @@ $date_regl=$valeur['date_reglement']['Y']."-".$valeur['date_reglement']['F']."-"
                                     $valeur['montant_ht_soumis_tva_0'],
                                     $valeur['montant_ht_soumis_tva_5_5'],
                                     $valeur['montant_ht_soumis_tva_10'],
-                                    $valeur['montant_ht_soumis_tva_20']
+                                    $valeur['montant_ht_soumis_tva_20'],
+                                    $valeur['tva_zone']
             						);
         }
         if ($ok) {

--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -331,7 +331,8 @@ elseif ($action === 'export') {
         'Montant HT soumis à TVA 10',
         'TVA 10',
         'Montant HT soumis à TVA 20',
-        'TVA 20'
+        'TVA 20',
+        "Zone de TVA",
     ];
     fputcsv($fp, $columns, $csvDelimiter, $csvEnclosure);
 
@@ -363,7 +364,8 @@ elseif ($action === 'export') {
                 $line['montant_ht_10'],
                 $line['montant_tva_10'],
                 $line['montant_ht_20'],
-                $line['montant_tva_20']
+                $line['montant_tva_20'],
+                $line['tva_zone']
             ],
             $csvDelimiter,
             $csvEnclosure

--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -163,7 +163,7 @@ elseif ($action == 'credit') {
     $formulaire->addElement('text', 'montant_ht_soumis_tva_0', 'Montant HT non soumis à TVA' , array('size' => 30, 'maxlength' => 40, 'id' => 'compta_journal_ht_0'));
     $formulaire->addElement('static'  , 'note', '', '<a href="#" id="apply-vat-0">Calculer le montant non soumis à TVA sur la base de l\'intégralité du montant TTC</a><br /><br />');
 
-    $formulaire->addElement('select'  , 'tva_zone', 'Zone TVA', ['' => 'Non définie', 'france' => 'France', 'ue' => 'Union Européenne hors France', 'hors_ue' => 'Hors Union Européenne']);
+    $formulaire->addElement('select'  , 'tva_zone', 'Zone TVA', array_merge(['' => 'Non définie'], Comptabilite::TVA_ZONES));
 
 //reglement
    $formulaire->addElement('header'  , ''                         , 'Réglement');
@@ -365,7 +365,7 @@ elseif ($action === 'export') {
                 $line['montant_tva_10'],
                 $line['montant_ht_20'],
                 $line['montant_tva_20'],
-                $line['tva_zone']
+                Comptabilite::getTvaZoneLabel($line['tva_zone'], 'Non définie')
             ],
             $csvDelimiter,
             $csvEnclosure

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -17,6 +17,12 @@ use AppBundle\Model\ComptaModeReglement;
 
 class Comptabilite
 {
+    const TVA_ZONES = [
+        'france' => 'France',
+        'ue' => 'Union Européenne hors France',
+        'hors_ue' => 'Hors Union Européenne',
+    ];
+
     /**
      * @var Base_De_Donnees
      */
@@ -1186,6 +1192,15 @@ SQL;
         $requete .= 'id = ' . intval($id) . ' ';
 
         return $this->_bdd->executer($requete);
+    }
+
+    public static function getTvaZoneLabel($tvaZoneCode, $defaultValue = null)
+    {
+        if (!isset(self::TVA_ZONES[$tvaZoneCode])) {
+            return $defaultValue;
+        }
+
+        return self::TVA_ZONES[$tvaZoneCode];
     }
 }
 

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -493,14 +493,14 @@ class Comptabilite
 
     function ajouter($idoperation, $idcompte, $idcategorie, $date_ecriture, $nom_frs, $tva_intra, $montant, $description,
                      $numero, $idmode_regl, $date_regl, $obs_regl, $idevenement, $numero_operation = null,
-                     $attachmentRequired = 0, $montantHtSoumisTva0 = null, $montantHtSoumisTva55 = null, $montantHtSoumisTva10 = null, $montantHtSoumisTva20 = null)
+                     $attachmentRequired = 0, $montantHtSoumisTva0 = null, $montantHtSoumisTva55 = null, $montantHtSoumisTva10 = null, $montantHtSoumisTva20 = null, $tvaZone = null)
     {
 
         $requete = 'INSERT INTO ';
         $requete .= 'compta (';
         $requete .= 'idoperation,idcategorie,date_ecriture,nom_frs,tva_intra,montant,description,';
         $requete .= 'numero,idmode_regl,date_regl,obs_regl,idevenement, numero_operation,idcompte, attachment_required,
-        montant_ht_soumis_tva_0, montant_ht_soumis_tva_5_5, montant_ht_soumis_tva_10, montant_ht_soumis_tva_20
+        montant_ht_soumis_tva_0, montant_ht_soumis_tva_5_5, montant_ht_soumis_tva_10, montant_ht_soumis_tva_20, tva_zone
         ) ';
         $requete .= 'VALUES (';
         $requete .= $this->_bdd->echapper($idoperation) . ',';
@@ -521,7 +521,8 @@ class Comptabilite
         $requete .= (!$montantHtSoumisTva0 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva0)) . ',';
         $requete .= (!$montantHtSoumisTva55 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva55)) . ',';
         $requete .= (!$montantHtSoumisTva10 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva10)) . ',';
-        $requete .= (!$montantHtSoumisTva20 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva20)) . '';
+        $requete .= (!$montantHtSoumisTva20 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva20)) . ',';
+        $requete .= (!$tvaZone ? 'NULL' : $this->_bdd->echapper($tvaZone)) . '';
         $requete .= ');';
 
         $resultat = $this->_bdd->executer($requete);
@@ -533,7 +534,8 @@ class Comptabilite
 
     function modifier($id, $idoperation, $idcompte, $idcategorie, $date_ecriture, $nom_frs, $tva_intra, $montant, $description,
                       $numero, $idmode_regl, $date_regl, $obs_regl, $idevenement, $comment, $numero_operation = null, $attachmentRequired = 0,
-                      $montantHtSoumisTva0 = null, $montantHtSoumisTva55 = null, $montantHtSoumisTva10 = null, $montantHtSoumisTva20 = null
+                      $montantHtSoumisTva0 = null, $montantHtSoumisTva55 = null, $montantHtSoumisTva10 = null, $montantHtSoumisTva20 = null,
+                      $tvaZone = null
     )
     {
 
@@ -556,6 +558,7 @@ class Comptabilite
         $requete .= 'montant_ht_soumis_tva_5_5=' . (!$montantHtSoumisTva55 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva55)) . ',';
         $requete .= 'montant_ht_soumis_tva_10=' . (!$montantHtSoumisTva10 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva10)) . ',';
         $requete .= 'montant_ht_soumis_tva_20=' . (!$montantHtSoumisTva20 ? 'NULL' : $this->_bdd->echapper($montantHtSoumisTva20)) . ',';
+        $requete .= 'tva_zone=' . (!$tvaZone ? 'NULL' : $this->_bdd->echapper($tvaZone)) . ',';
         $requete .= 'comment=' . (!$comment ? 'NULL' : $this->_bdd->echapper($comment)) . ',';
         if ($numero_operation) {
             $requete .= 'numero_operation=' . $this->_bdd->echapper($numero_operation) . ',';

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -181,7 +181,8 @@ class Comptabilite
         $requete .= 'compta.montant_ht_soumis_tva_10 as montant_ht_10,   ';
         $requete .= 'compta.montant_ht_soumis_tva_10*0.1 as montant_tva_10,   ';
         $requete .= 'compta.montant_ht_soumis_tva_20 as montant_ht_20,   ';
-        $requete .= 'compta.montant_ht_soumis_tva_20*0.2 as montant_tva_20   ';
+        $requete .= 'compta.montant_ht_soumis_tva_20*0.2 as montant_tva_20,   ';
+        $requete .= 'compta.tva_zone   ';
         $requete .= 'FROM ';
         $requete .= 'compta ';
         $requete .= 'LEFT JOIN ';


### PR DESCRIPTION
fixes #1469 
on permet de typer avec une "zone de tva" les lignes de compta, cela pour pouvoir indiquer au comptable quand la ligne correspond à un sponsor hors union européenne;