### PR TITLE
correction application mode de règlement sur les règles automatiques de compta

### DIFF
--- a/htdocs/pages/administration/compta_conf_regle.php
+++ b/htdocs/pages/administration/compta_conf_regle.php
@@ -34,7 +34,7 @@ if ($action === 'lister') {
     $formulaire->addElement('text', 'label', 'Nom de la règle', array('size' => 30, 'maxlength' => 255));
     $formulaire->addElement('text', 'condition', 'Condition', array('size' => 30, 'maxlength' => 255));
     $formulaire->addElement('select', 'is_credit', 'Crédit/débit ?', array(null => 'Les deux', '1' => 'Crédit', '0' => 'Débit'));
-    $formulaire->addElement('select', 'mode_regl_id', 'Mode de règlement', array_merge([null => 'N.C.'], ComptaModeReglement::list()));
+    $formulaire->addElement('select', 'mode_regl_id', 'Mode de règlement', [null => 'N.C.'] + ComptaModeReglement::list());
     $formulaire->addElement('select', 'vat', 'Taux de TVA', array(null => 'N.C.', '0' => '0%', '5_5' => '5.5%', '10' => '10%', '20' => '20%'));
     $formulaire->addElement('select', 'category_id', 'Catégorie', $compta->obtenirListCategories());
     $formulaire->addElement('select', 'event_id', 'Évènement', $compta->obtenirListEvenements());


### PR DESCRIPTION
On aavit un souci sur l'application des règles de mode de règlement : on avait les commissions de carte bancaires configuréees en virement mais, c'était le mode de paiement "Espèce" qui était sélectionné.

Le souci venait d'un array_merge pour la gestion du NC à null, où le tableau de liste des mode de règlement avec pour clef des int, il voyais deux tableaux non associatifs et recalculait les clefs.

cf https://www.php.net/array_merge

>  Values in the input arrays with numeric keys will be renumbered with incrementing keys starting from zero in the result array.

Voilà ce qui se passait où on peux voir les clefs recalculées :
```
php -r "var_dump(array_merge([null => 'N.C.'], [
            2 => 'Carte bancaire',
            3 => 'Virement',
            4 => 'Chèque',
            5 => 'Prélèvement',
]));"

array(5) {
  [""]=>
  string(4) "N.C."
  [0]=>
  string(14) "Carte bancaire"
  [1]=>
  string(8) "Virement"
  [2]=>
  string(7) "Chèque"
  [3]=>
  string(13) "Prélèvement"
}
```

en passant par un + on évite cela et conserve les clefs du tableau de modes de paiement :

```
php -r "var_dump([null => 'N.C.'] + [
            2 => 'Carte bancaire',
            3 => 'Virement',
            4 => 'Chèque',
            5 => 'Prélèvement',
]);"
array(5) {
  [""]=>
  string(4) "N.C."
  [2]=>
  string(14) "Carte bancaire"
  [3]=>
  string(8) "Virement"
  [4]=>
  string(7) "Chèque"
  [5]=>
  string(13) "Prélèvement"
}
```

avant:
![Capture d’écran du 2024-04-07 08-32-09](https://github.com/afup/web/assets/320372/28ebc0d4-4a7e-4726-b207-cf7f98cc6aba)


après:
![Capture d’écran du 2024-04-07 08-34-12](https://github.com/afup/web/assets/320372/38a0759b-ba88-4346-a166-db3298ec2089)
