### PR TITLE
QR Code Sponsor : on ajoute l'option lors de la création du token

### DIFF
--- a/app/Resources/views/admin/event/sponsor_ticket.html.twig
+++ b/app/Resources/views/admin/event/sponsor_ticket.html.twig
@@ -47,6 +47,7 @@
                 <th>Token</th>
                 <th class="right aligned">Invitations totales</th>
                 <th class="right aligned">Invitations utilisées</th>
+                <th class="right aligned">Peut scanner QR Codes</th>
                 <th colspan="3"></th>
             </tr>
         </thead>
@@ -61,6 +62,7 @@
                 <td>{{ token.token }}</td>
                 <td class="right aligned">{{ token.maxInvitations }}</td>
                 <td class="right aligned">{{ token.usedInvitations }}</td>
+                <td class="right aligned">{% if token.qrCodesScanner %}OUI{% else %}-{% endif %}</td>
                 <td class="right aligned">
                     <form class="sponsor--token-admin-view" method="post" action="{{ url('sponsor_ticket_home', {eventSlug: event.path}) }}">
                         <input type="hidden" name="sponsor_token" value="{{ token.token }}" />
@@ -99,7 +101,7 @@
                 <th colspan="2"><strong>Total</strong></th>
                 <th class="right aligned">{{ totalInvitations }}</th>
                 <th class="right aligned">{{ totalUsedInvitations }}</th>
-                <th></th>
+                <th colspan="4"></th>
             </tr>
         </tfoot>
     </table>

--- a/db/migrations/20240410113835_sponsor_option_qr_code.php
+++ b/db/migrations/20240410113835_sponsor_option_qr_code.php
@@ -1,0 +1,16 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class SponsorOptionQrCode extends AbstractMigration
+{
+    public function change()
+    {
+        $table = $this->table('afup_forum_sponsors_tickets');
+        $table->addColumn('qr_codes_scanner', 'boolean', [
+            'null' => false,
+            'default' => false,
+        ])->update();
+    }
+}

--- a/sources/AppBundle/Event/Form/SponsorTokenType.php
+++ b/sources/AppBundle/Event/Form/SponsorTokenType.php
@@ -4,6 +4,7 @@ namespace AppBundle\Event\Form;
 
 use AppBundle\Event\Model\SponsorTicket;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -24,6 +25,10 @@ class SponsorTokenType extends AbstractType
             ->add('token', TextType::class)
             ->add('maxInvitations', IntegerType::class, [
                 'label' => 'Nombre d\'invitations'
+            ])
+            ->add('qrCodesScanner', CheckboxType::class, [
+                'label' => 'Autoriser le scan de QR Codes',
+                'required' => false
             ])
         ;
     }

--- a/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
@@ -4,6 +4,7 @@ namespace AppBundle\Event\Model\Repository;
 
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\SponsorTicket;
+use CCMBenchmark\Ting\Driver\Mysqli\Serializer\Boolean;
 use CCMBenchmark\Ting\Repository\Metadata;
 use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
@@ -84,6 +85,12 @@ class SponsorTicketRepository extends Repository implements MetadataInitializer
                 'columnName' => 'creator_id',
                 'fieldName' => 'creatorId',
                 'type' => 'int'
+            ])
+            ->addField([
+                'columnName' => 'qr_codes_scanner',
+                'fieldName' => 'qrCodesScanner',
+                'type' => 'bool',
+                'serializer' => Boolean::class
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/SponsorTicket.php
+++ b/sources/AppBundle/Event/Model/SponsorTicket.php
@@ -69,6 +69,11 @@ class SponsorTicket implements NotifyPropertyInterface
     private $creatorId;
 
     /**
+     * @var bool
+     */
+    private $qrCodesScanner = false;
+
+    /**
      * @return int
      */
     public function getId()
@@ -264,5 +269,24 @@ class SponsorTicket implements NotifyPropertyInterface
     public function getPendingInvitations()
     {
         return $this->maxInvitations - $this->usedInvitations;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getQrCodesScanner()
+    {
+        return $this->qrCodesScanner;
+    }
+
+    /**
+     * @param bool $qrCodesScanner
+     * @return SponsorTicket
+     */
+    public function setQrCodesScanner($qrCodesScanner)
+    {
+        $this->propertyChanged('qrCodesScanner', $this->qrCodesScanner, $qrCodesScanner);
+        $this->qrCodesScanner = $qrCodesScanner;
+        return $this;
     }
 }


### PR DESCRIPTION
### Scan de QR Codes pour les sponsors du forum 

Ajout dans l'admin, sur la page de gestion des tokens sponsors, de l'option à cocher autorisant ou non le sponsor à utiliser l'outil de scan de visiteurs.