### PR TITLE
correction du lancement du scraping des meetups

### DIFF
--- a/sources/AppBundle/Command/IndexMeetupsCommand.php
+++ b/sources/AppBundle/Command/IndexMeetupsCommand.php
@@ -7,6 +7,7 @@ use AlgoliaSearch\Client;
 use AppBundle\Event\Model\Repository\MeetupRepository;
 use AppBundle\Indexation\Meetups\Runner;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -19,6 +20,7 @@ class IndexMeetupsCommand extends ContainerAwareCommand
     {
         $this
             ->setName('indexing:meetups')
+            ->addOption('run-scraping')
         ;
     }
 
@@ -35,9 +37,22 @@ class IndexMeetupsCommand extends ContainerAwareCommand
         $algoliaClient = $container->get(Client::class);
         $meetupRepository = $ting->get(MeetupRepository::class);
 
+        if ($input->getOption('run-scraping')) {
+            $this->runScraping($output);
+        }
+
         $runner = new Runner($algoliaClient, $meetupRepository);
         $runner->run();
 
         return 0;
+    }
+
+    private function runScraping($output)
+    {
+        $greetInput = new ArrayInput([
+            'command' => 'scrapping-meetup-event',
+        ]);
+
+        $this->getApplication()->doRun($greetInput, $output);
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -49,29 +49,10 @@ class Runner
     public function run()
     {
         $index = $this->initIndex();
-        $command = ['./bin/console', 'scrapping-meetup-event'];
-        $process = new Process($command);
-
-        try {
-            $process->start();
-
-            while ($process->isRunning()) {
-                echo "En cours de scrapping des meetups...\n";
-                usleep(500000);
-            }
-
-            echo $process->getOutput();
-        } catch (ProcessFailedException $exception) {
-            if (!$process->isSuccessful()) {
-                throw new ProcessFailedException($process);
-            }
-        }
 
         echo "Indexation des meetups en cours ...\n\n";
 
-
         $meetups = $this->getTransformedMeetupsFromDatabase();
-
 
         $index->clearIndex();
         $index->addObjects($meetups, 'meetup_id');

--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -9,8 +9,6 @@ use AppBundle\Event\Model\Meetup;
 use AppBundle\Event\Model\Repository\MeetupRepository;
 use AppBundle\Offices\OfficesCollection;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
 
 class Runner
 {


### PR DESCRIPTION
Le scraping des meetups se lançait avec une erreur silencieuse.

Si on modifiait le code pour faire un mustRun on voyait bien le souci :

```
  [Symfony\Component\Process\Exception\ProcessFailedException]
  The command "'./bin/console' 'scrapping-meetup-event'" failed.

  Exit Code: 127(Command not found)

  Working directory: /var/www

  Output:
  ================

  Error Output:
  ================
  sh: 1: exec: ./bin/console: not found
```

La cron est lancée comme cela :
```
0 0 * * * www-data /usr/bin/php7.0 /home/sources/web/current/bin/console  --env=prod indexing:meetups
```

Cette façon de lancer la commande de meetups ne fonctionnait pas vu qu'on était pas dans le dossier /home/sources/web/current/

On change donc la façon de lancer le scraping pour le faire en dehors du runner et éviter d'avoir des erreurs silencieuses / être dépendant d'où est lancée la commande.