### PR TITLE
QR Code Sponsor : supprimer le scan d'un visiteur

### DIFF
--- a/app/Resources/translations/messages.en.yml
+++ b/app/Resources/translations/messages.en.yml
@@ -182,6 +182,7 @@ speaker_from_previous_event: "We filled the form with the profile you used on a 
 "Télécharger en CSV": "Download CSV"
 "Supprimer": "Delete"
 "Lancer l'outil de scan de QR Codes": "Run QR Code Scanner"
+"Confirmez-vous la suppression du QR Code de #prenom# #nom# ?": "Can you confirm that you want to remove the QR Code of #prenom# #nom#?"
 sponsor.qr_code_scanner.disclaimer: Please confirm that the participant agrees for you to scan their badge!
 sponsor.qr_code_scanner.valid_code: Code valid! Please wait...
 sponsor.qr_code_scanner.invalid_code: Incorrect QR Code!

--- a/app/Resources/views/event/sponsor/scan.html.twig
+++ b/app/Resources/views/event/sponsor/scan.html.twig
@@ -8,17 +8,34 @@
             <a class="button sponsor_scan" href="{{ url('sponsor_scan_new', {eventSlug: event.path}) }}">{% trans %}Scanner un QR Code{% endtrans %}</a>
 
             <h2 class="h3-like">{% trans %}QR CODES SCANNÉS{% endtrans %}</h2>
-            <a class="button button__medium" href="{{ path('sponsor_scan_export', {eventSlug: event.path}) }}">{% trans %}Télécharger en CSV{% endtrans %}</a>
+            <a class="button button__medium" href="{{ url('sponsor_scan_export', {eventSlug: event.path}) }}">{% trans %}Télécharger en CSV{% endtrans %}</a>
 
             <dl>
                 {% for scan in scans %}
                     <dt><strong>{{ scan.prenom }} {{ scan.nom }}</strong></dt>
                     <dd class="mbs">
                         {{ scan.email }}<br />
-                        {{ scan.created_on|date('d/m/Y H:i')}} - <a href="#">{% trans %}Supprimer{% endtrans %}</a>
+                        {{ scan.created_on|date('d/m/y H:i')}} - <a href="#" onclick="confirmDelete(
+                            '{{ url('sponsor_scan_delete', {eventSlug: event.path, scanId: scan.id}) }}',
+                            '{{ scan.prenom|replace({"'": " "}) }}',
+                            '{{ scan.nom|replace({"'": " "}) }}'
+                        )">{% trans %}Supprimer{% endtrans %}</a>
                     </dd>
                 {% endfor %}
             </dl>
         </div>
     </div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script type="application/javascript">
+        function confirmDelete(url, prenom, nom) {
+            let text = "{% trans %}Confirmez-vous la suppression du QR Code de #prenom# #nom# ?{% endtrans %}";
+            text = text.replace("#prenom#", prenom).replace("#nom#", nom);
+            if (confirm(text) === true) {
+                window.location = url;
+            }
+        }
+    </script>
 {% endblock %}

--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -116,6 +116,10 @@ sponsor_scan_flash:
   path: /{eventSlug}/sponsor/scan/flash/{code}
   defaults: {_controller: AppBundle:SponsorScan:flash}
 
+sponsor_scan_delete:
+  path: /{eventSlug}/sponsor/scan/delete/{scanId}
+  defaults: {_controller: AppBundle:SponsorScan:delete}
+
 speaker-infos:
   path: /{eventSlug}/speaker-infos
   defaults: {_controller: AppBundle\Controller\Event\SpeakerPageAction }

--- a/sources/AppBundle/Controller/SponsorScanController.php
+++ b/sources/AppBundle/Controller/SponsorScanController.php
@@ -154,7 +154,7 @@ class SponsorScanController extends EventBaseController
         $this->checkEventSlug($eventSlug);
         try {
             $sponsorTicket = $this->checkSponsorTicket($request);
-        } catch (\Exception $e) {
+        } catch (InvalidSponsorTokenException $e) {
             $this->addFlash('error', $e->getMessage());
             return $this->redirectToRoute('sponsor_ticket_home', ['eventSlug' => $eventSlug]);
         }

--- a/sources/AppBundle/Controller/SponsorScanController.php
+++ b/sources/AppBundle/Controller/SponsorScanController.php
@@ -149,6 +149,29 @@ class SponsorScanController extends EventBaseController
         return $response;
     }
 
+    public function deleteAction(Request $request, $eventSlug, $scanId)
+    {
+        $this->checkEventSlug($eventSlug);
+        try {
+            $sponsorTicket = $this->checkSponsorTicket($request);
+        } catch (\Exception $e) {
+            $this->addFlash('error', $e->getMessage());
+            return $this->redirectToRoute('sponsor_ticket_home', ['eventSlug' => $eventSlug]);
+        }
+
+        /** @var SponsorScanRepository $scanRepository */
+        $scanRepository = $this->get('ting')->get(SponsorScanRepository::class);
+        $scan = $scanRepository->getOneBy(['sponsorTicketId' => $sponsorTicket->getId(), 'id' => $scanId]);
+
+        if ($scan instanceof SponsorScan) {
+            $scan->setDeletedOn(new \DateTime('now'));
+            $scanRepository->save($scan);
+            $this->addFlash('success', "QR Code supprimé !");
+        }
+
+        return $this->redirectToRoute('sponsor_scan', ['eventSlug' => $eventSlug]);
+    }
+
     private function checkSponsorTicket(Request $request)
     {
         if ($request->getSession()->has('sponsor_ticket_id') === false) {


### PR DESCRIPTION
### Scan de QR Codes pour les sponsors du forum

Partie 5 : pouvoir supprimer un qr code si une personne demande finalement à ne plus être dans le fichier du sponsor.