### PR TITLE
correction 500 sur demande de sponsoring

### DIFF
--- a/sources/AppBundle/Controller/LeadController.php
+++ b/sources/AppBundle/Controller/LeadController.php
@@ -36,8 +36,8 @@ class LeadController extends EventBaseController
         $leadForm->handleRequest($request);
 
         if ($leadForm->isSubmitted() && $leadForm->isValid()) {
-            $repository = $this->get(\AppBundle\Event\Model\Repository\LeadRepository::class);
-            $repository->save($lead);
+            //$repository = $this->get(\AppBundle\Event\Model\Repository\LeadRepository::class);
+            //$repository->save($lead);
 
             $sponsorshipLeadMail = $this->get(\AppBundle\Event\Sponsorship\SponsorshipLeadMail::class);
             $this->get('event_dispatcher')->addListener(KernelEvents::TERMINATE, function () use ($lead, $sponsorshipLeadMail) {


### PR DESCRIPTION
On avait cette erreur sur la demande de dossier de sponsoring :
```
May 23 19:22:37 afupsvr01 [3278]: request.CRITICAL: Uncaught PHP Exception Trello\Exception\RuntimeException: "Unauthorized for read-only workspace" at /home/sources/web/releases/20240523084005/vendor/cdaguerre/php-trello-api/lib/Trello/HttpClient/HttpClient.php line 152 {"exception":"[object] (Trello\\Exception\\RuntimeException(code: 401): Unauthorized for read-only workspace at /home/sources/web/releases/20240523084005/vendor/cdaguerre/php-trello-api/lib/Trello/HttpClient/HttpClient.php:152, Trello\\Exception\\PermissionDeniedException(code: 401): Unauthorized for read-only workspace at /home/sources/web/releases/20240523084005/vendor/cdaguerre/php-trello-api/lib/Trello/HttpClient/Listener/ErrorListener.php:30)"} []
```

Ici on fait un correctif rapide (et un peu moche) pour que ça marche, à terme il faudra traiter le https://github.com/afup/web/issues/1242 pour une meilleure correction.