### PR TITLE
correction calcul ttc quand le prix ht n'est pas un entier

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
@@ -157,7 +157,7 @@ class InvoiceRepository extends Repository implements MetadataInitializer
             ->addField([
                 'columnName' => 'montant',
                 'fieldName' => 'amount',
-                'type' => 'int'
+                'type' => 'float'
             ])
             ->addField([
                 'columnName' => 'type_reglement',


### PR DESCRIPTION
nous avons dans la tarification quelques tarifs qui ne sont pas des entiers comme 272.73 €, qui doit donner 300€ en TTC.

Il était demandé de payer 299,2€ et pas 300€.

Cela car le ttc était calculé sur 272€ et non 272,73 car l'orm passait en int. On corrige cela en prenant bien en compte les 0,73 manquant.

avant:
![Screenshot 2024-05-23 at 21-46-46 Billetterie - Afup](https://github.com/afup/web/assets/320372/6ce78f42-3f78-4358-8fee-07f9a8b16ee4)


après:
![Screenshot 2024-05-23 at 21-50-35 Billetterie - Afup](https://github.com/afup/web/assets/320372/36a3abd0-54aa-4903-8296-a85743791bc3)
