### PR TITLE
CFP vote ajout du message d'avertissement

### DIFF
--- a/app/Resources/views/event/vote/sidebar.html.twig
+++ b/app/Resources/views/event/vote/sidebar.html.twig
@@ -11,9 +11,18 @@
     </ul>
 
     <div style="padding: 10px">
-        <b>Quelle influence ont les votes sur le programme ?</b>
+        <p><strong>Quelle influence ont les votes sur le programme ?</strong></p>
 
-        À la fin de l’appel à conférences, l’équipe de programmation se réunit et sélectionne les propositions qui seront intégrées au programme. L’équipe ne choisit pas forcément les propositions les mieux notées : les votes n’ont pas de pouvoir décisionnaire. Ils nous permettent cependant de dégager des tendances, de comprendre quels sont les sujets intéressants pour le public, de mettre en évidence certaines propositions ou de confirmer l’intérêt que l’équipe ressent pour une soumission. Vous pouvez trouver plus d’informations sur le processus de sélection sur <a href="https://event.afup.org/processus-de-selection/">cette page</a>.
+        <p>
+            À la fin de l’appel à conférences, l’équipe de programmation se réunit et sélectionne les propositions qui seront intégrées au programme.
+            L’équipe ne choisit pas forcément les propositions les mieux notées : les votes n’ont pas de pouvoir décisionnaire.
+            Ils nous permettent cependant de dégager des tendances, de comprendre quels sont les sujets intéressants pour le public,
+            de mettre en évidence certaines propositions ou de confirmer l’intérêt que l’équipe ressent pour une soumission.
+        </p>
+        <p>
+            Vous pouvez trouver plus d’informations sur le processus de sélection sur
+            <a href="https://event.afup.org/processus-de-selection/">cette page</a>.
+        </p>
     </div>
 
 </div>

--- a/app/Resources/views/event/vote/talk.html.twig
+++ b/app/Resources/views/event/vote/talk.html.twig
@@ -15,6 +15,8 @@
     <div class="event--vote-form">
         {{ form_start(talk.form) }}
             {{ form_row(talk.form.comment) }}
+
+
             <div class="event--vote-stars">
                 <div style="display: inline-block">
                     <div class="stars stars-editable">
@@ -26,6 +28,11 @@
                     </div>
                 </div>
             </div>
+
+        <p class="event--vote-warning">
+            Attention, le <a href="http://coc.afup.org/">code de conduite de l’AFUP</a> s’applique à cet espace de votes.<br />
+            Les personnes soumettant les sujets ont accès aux notes et aux commentaires.
+        </p>
 
             {{ form_rest(talk.form) }}
         {{ form_end(talk.form) }}

--- a/htdocs/css/stars.css
+++ b/htdocs/css/stars.css
@@ -1,6 +1,6 @@
 #svg-star, a.star svg, span.star svg {
-    width: 1em;
-    height: 1em;
+    width: 2em;
+    height: 2em;
     fill: white;
     pointer-events: none;
 }

--- a/htdocs/css/vote.css
+++ b/htdocs/css/vote.css
@@ -780,6 +780,10 @@ a {
 div.event--vote-form form{
     width: auto;
 }
+div.event--vote-form textarea{
+    width: 100%;
+    font-size: 13px;
+}
 div.event--vote-form label{
     min-width: 150px;
     display:block
@@ -806,6 +810,11 @@ div.event--vote-abstract{
 }
 div.event--vote-abstract h1{
     font-size:1.9em;
+}
+.event--vote-warning {
+    padding: 10px;
+    border: 1px solid #ccc;
+    background-color: #fae8cc;
 }
 
 @media (max-width: 767px) {
@@ -838,6 +847,7 @@ button[type=submit] {
     background-color: #3e3d40 !important;
     color: white;
     font-weight: bold;
+    width: 100%;
 }
 
 button[type=submit].error {
@@ -1022,10 +1032,6 @@ div.photo-container{
     }
 
     div.event--vote-details {
-        width: 100%;
-    }
-
-    .event--vote-form textarea {
         width: 100%;
     }
 }


### PR DESCRIPTION
Suite à la réunion pour le forum, on ajoute un texte pour avertir le votant que sont message sera accessible au speaker.

<img width="1407" alt="Capture d’écran 2024-06-05 à 20 46 40" src="https://github.com/afup/web/assets/83301974/b014ba4c-54a6-436b-bac0-67ad4c3d1738">
