### PR TITLE
correction du réremplissage des informations des informations speakers

### DIFF
--- a/sources/AppBundle/Event/Form/SpeakerType.php
+++ b/sources/AppBundle/Event/Form/SpeakerType.php
@@ -99,7 +99,8 @@ class SpeakerType extends AbstractType
             $speaker = $formEvent->getData();
             $user = $this->tokenStorage->getToken()->getUser();
 
-            if ($speaker instanceof Speaker && $speaker->getId() === null && $user instanceof User) {
+            if ($speaker instanceof Speaker && $speaker->getId() === null && $user instanceof GithubUser) {
+
                 $previousSpeakerInfos = $this->speakerRepository->getFromLastEventAndUserId($speaker->getEventId(), $user->getId());
                 if ($previousSpeakerInfos instanceof Speaker) {
                     $speaker->setCivility($previousSpeakerInfos->getCivility());

--- a/sources/AppBundle/Event/Form/SpeakerType.php
+++ b/sources/AppBundle/Event/Form/SpeakerType.php
@@ -99,7 +99,6 @@ class SpeakerType extends AbstractType
             $user = $this->tokenStorage->getToken()->getUser();
 
             if ($speaker instanceof Speaker && $speaker->getId() === null && $user instanceof GithubUser) {
-
                 $previousSpeakerInfos = $this->speakerRepository->getFromLastEventAndUserId($speaker->getEventId(), $user->getId());
                 if ($previousSpeakerInfos instanceof Speaker) {
                     $speaker->setCivility($previousSpeakerInfos->getCivility());

--- a/sources/AppBundle/Event/Form/SpeakerType.php
+++ b/sources/AppBundle/Event/Form/SpeakerType.php
@@ -3,7 +3,6 @@
 
 namespace AppBundle\Event\Form;
 
-use AppBundle\Association\Model\User;
 use AppBundle\Event\Model\GithubUser;
 use AppBundle\Event\Model\Repository\GithubUserRepository;
 use AppBundle\Event\Model\Repository\SpeakerRepository;


### PR DESCRIPTION
dans la PR https://github.com/afup/web/pull/1152
on mettait en place un préremplissage du formulaire de création de speaker d'après les informations saisies sur les anciens CFP, mais il y avait un souci, cela ne fonctionnait pas, le test sur le type du user était problématique.

fixes #1504