### PR TITLE
[Planete PHP] Correction d'un header et ajout d'un autre

### DIFF
--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -28,7 +28,7 @@ final class ArticlesController
             $page = 1;
         }
 
-        $totalCount = $this->feedArticleRepository->count();
+        $totalCount = $this->feedArticleRepository->countRelevant();
         $articles = $this->feedArticleRepository->findLatest($page - 1, DATE_RSS, $perPage);
 
         $data = [];

--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -54,6 +54,7 @@ final class ArticlesController
                 'Content-Type' => 'application/json',
                 'X-Pagination-Total' => $totalCount,
                 'X-Pagination-Per-Page' => $perPage,
+                'X-Pagination-Has-Next-Page' => json_encode($totalCount > $page * $perPage),
             ]
         );
     }

--- a/sources/PlanetePHP/FeedArticleRepository.php
+++ b/sources/PlanetePHP/FeedArticleRepository.php
@@ -31,6 +31,15 @@ class FeedArticleRepository
         return intval($query->fetchColumn());
     }
 
+    public function countRelevant(): int
+    {
+        $query = $this->connection->prepare('SELECT COUNT(b.id) FROM afup_planete_billet b WHERE b.etat = :status');
+        $query->bindValue('status', self::RELEVANT);
+        $query->execute();
+
+        return intval($query->fetchColumn());
+    }
+
     /**
      * @param string $sort
      * @param string $direction

--- a/tests/behat/features/Api/PlanetePHPApi.feature
+++ b/tests/behat/features/Api/PlanetePHPApi.feature
@@ -6,6 +6,7 @@ Feature: PlanetePHP API routes
     And the response header "Content-Type" should equal "application/json"
     And the response header "X-Pagination-Total" should equal 22
     And the response header "X-Pagination-Per-Page" should equal 20
+    And the response header "X-Pagination-Has-Next-Page" should equal true
     And the json response has the key "title" with value "Un titre"
     And the json response has the key "url" with value "https:\/\/afup.org\/url.html"
     And the json response has the key "author" with value "Un super auteur"
@@ -17,6 +18,7 @@ Feature: PlanetePHP API routes
     And the response header "Content-Type" should equal "application/json"
     And the response header "X-Pagination-Total" should equal 22
     And the response header "X-Pagination-Per-Page" should equal 20
+    And the response header "X-Pagination-Has-Next-Page" should equal false
     And the json response has the key "title" with value "Un titre 18"
     And the json response has the key "url" with value "https:\/\/afup.org\/url-18.html"
     And the json response has the key "author" with value "Un super auteur 18"

--- a/tests/behat/features/Api/PlanetePHPApi.feature
+++ b/tests/behat/features/Api/PlanetePHPApi.feature
@@ -4,7 +4,7 @@ Feature: PlanetePHP API routes
     Given I am on "/planete-php-api/articles"
     Then the response status code should be 200
     And the response header "Content-Type" should equal "application/json"
-    And the response header "X-Pagination-Total" should equal 23
+    And the response header "X-Pagination-Total" should equal 22
     And the response header "X-Pagination-Per-Page" should equal 20
     And the json response has the key "title" with value "Un titre"
     And the json response has the key "url" with value "https:\/\/afup.org\/url.html"
@@ -15,7 +15,7 @@ Feature: PlanetePHP API routes
     Given I am on "/planete-php-api/articles?page=2"
     Then the response status code should be 200
     And the response header "Content-Type" should equal "application/json"
-    And the response header "X-Pagination-Total" should equal 23
+    And the response header "X-Pagination-Total" should equal 22
     And the response header "X-Pagination-Per-Page" should equal 20
     And the json response has the key "title" with value "Un titre 18"
     And the json response has the key "url" with value "https:\/\/afup.org\/url-18.html"


### PR DESCRIPTION
### Correction du header `X-Pagination-Total`
Il ne faut compter que les articles ayant le status `RELEVANT` car ce sont les seuls affichés.

### Ajout du header `X-Pagination-Has-Next-Page`
Ce header permet de conditioner la présence d'un bouton pour voir la page suivante des articles.

see #1422