### PR TITLE
Correction des urls sans host des articles

### DIFF
--- a/db/seeds/FeedArticle.php
+++ b/db/seeds/FeedArticle.php
@@ -6,18 +6,29 @@ class FeedArticle extends AbstractSeed
 {
     public function run()
     {
-        $feed = [
-            'nom' => 'Un super site PHP',
-            'url' => 'https://afup.org',
-            'feed' => 'https://afup.org/rss.xml',
-            'etat' => 1,
-        ];
         $table = $this->table('afup_planete_flux');
         $table->truncate();
 
-        $table
-            ->insert($feed)
-            ->save();
+        $feeds = [
+            [
+                'nom' => 'Un super site PHP',
+                'url' => 'https://afup.org',
+                'feed' => 'https://afup.org/rss.xml',
+                'etat' => 1,
+            ],
+            [
+                'nom' => 'Exemple avec un / à la fin',
+                'url' => 'https://example.com/',
+                'feed' => 'https://example.com/rss.xml',
+                'etat' => 1,
+            ],
+        ];
+
+        foreach ($feeds as $feed) {
+            $table
+                ->insert($feed)
+                ->save();
+        }
 
         $data = [
             [
@@ -68,6 +79,54 @@ class FeedArticle extends AbstractSeed
                 'etat' => 1
             ];
         }
+
+        $data[] = [
+            'afup_planete_flux_id' => 1,
+            'clef' => '4d5cf2e2-78bd-11ee-b962-0242ac140000',
+            'titre' => 'Un article sans host et avec / au début de son url',
+            'url' => '/url-flux-1-avec-slash.html',
+            'maj' => time(),
+            'auteur' => 'Un super auteur',
+            'resume' => 'Un super article',
+            'contenu' => 'Le contenu du super article',
+            'etat' => 1
+        ];
+
+        $data[] = [
+            'afup_planete_flux_id' => 1,
+            'clef' => '4d5cf2e2-78bd-11ee-b962-0242ac140001',
+            'titre' => 'Un article sans host et sans / au début de son url',
+            'url' => 'url-flux-1-sans-slash.html',
+            'maj' => time(),
+            'auteur' => 'Un super auteur',
+            'resume' => 'Un super article',
+            'contenu' => 'Le contenu du super article',
+            'etat' => 1
+        ];
+
+        $data[] = [
+            'afup_planete_flux_id' => 2,
+            'clef' => '4d5cf2e2-78bd-11ee-b962-0242ac140002',
+            'titre' => 'Un article sans host et avec / au début de son url',
+            'url' => '/url-flux-2-avec-slash.html',
+            'maj' => time(),
+            'auteur' => 'Un super auteur',
+            'resume' => 'Un super article',
+            'contenu' => 'Le contenu du super article',
+            'etat' => 1
+        ];
+
+        $data[] = [
+            'afup_planete_flux_id' => 2,
+            'clef' => '4d5cf2e2-78bd-11ee-b962-0242ac140003',
+            'titre' => 'Un article sans host et sans / au début de son url',
+            'url' => '/url-flux-2-sans-slash.html',
+            'maj' => time(),
+            'auteur' => 'Un super auteur',
+            'resume' => 'Un super article',
+            'contenu' => 'Le contenu du super article',
+            'etat' => 1
+        ];
 
         $table = $this->table('afup_planete_billet');
         $table->truncate();

--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Planete;
 
+use PlanetePHP\DisplayableFeedArticle;
 use PlanetePHP\FeedArticleRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,7 +37,7 @@ final class ArticlesController
         foreach ($articles as $article) {
             $data[] = [
                 'title' => $article->getTitle(),
-                'url' => $article->getUrl(),
+                'url' => $this->getArticleUrl($article),
                 'date' => $article->getUpdate(),
                 'author' => $article->getAuthor(),
                 'content' => $article->getContent(),
@@ -57,5 +58,17 @@ final class ArticlesController
                 'X-Pagination-Has-Next-Page' => json_encode($totalCount > $page * $perPage),
             ]
         );
+    }
+
+    private function getArticleUrl(DisplayableFeedArticle $article): string
+    {
+        if (substr($article->getUrl(), 0, 4) !== 'http') {
+            $feedUrl = rtrim($article->getFeedUrl(), '/');
+            $articleUrl = ltrim($article->getUrl(), '/');
+
+            return implode('/', [$feedUrl, $articleUrl]);
+        }
+
+        return $article->getUrl();
     }
 }

--- a/tests/behat/features/Api/PlanetePHPApi.feature
+++ b/tests/behat/features/Api/PlanetePHPApi.feature
@@ -4,7 +4,7 @@ Feature: PlanetePHP API routes
     Given I am on "/planete-php-api/articles"
     Then the response status code should be 200
     And the response header "Content-Type" should equal "application/json"
-    And the response header "X-Pagination-Total" should equal 22
+    And the response header "X-Pagination-Total" should equal 26
     And the response header "X-Pagination-Per-Page" should equal 20
     And the response header "X-Pagination-Has-Next-Page" should equal true
     And the json response has the key "title" with value "Un titre"
@@ -16,13 +16,17 @@ Feature: PlanetePHP API routes
     Given I am on "/planete-php-api/articles?page=2"
     Then the response status code should be 200
     And the response header "Content-Type" should equal "application/json"
-    And the response header "X-Pagination-Total" should equal 22
+    And the response header "X-Pagination-Total" should equal 26
     And the response header "X-Pagination-Per-Page" should equal 20
     And the response header "X-Pagination-Has-Next-Page" should equal false
     And the json response has the key "title" with value "Un titre 18"
     And the json response has the key "url" with value "https:\/\/afup.org\/url-18.html"
     And the json response has the key "author" with value "Un super auteur 18"
     And the json response has the key "content" with value "Le contenu du super article 18"
+    And the json response has the key "url" with value "https:\/\/afup.org\/url-flux-1-avec-slash.html"
+    And the json response has the key "url" with value "https:\/\/afup.org\/url-flux-1-sans-slash.html"
+    And the json response has the key "url" with value "https:\/\/example.com\/url-flux-2-avec-slash.html"
+    And the json response has the key "url" with value "https:\/\/example.com\/url-flux-2-sans-slash.html"
 
   Scenario: Get the list of feeds
     Given I am on "/planete-php-api/feeds"


### PR DESCRIPTION
Certains flux ont des articles pour lesquels l'url ne contient pas le host (`/foo` au lieu de `https://a.com/foo`).

Ce changement permet de s'assurer de toujours avoir une url contenant le host, en utilisant l'url du feed.

C'est le cas par exemple pour eleven-labs.com