### PR TITLE
Utilisation d'une autre action pour le cache Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('compose.yml') }}
 
       - name: Tests - Functional
         run: make test-functional


### PR DESCRIPTION
L'action `satackey/action-docker-layer-caching` n'est plus maintenue depuis 3 ans.

Et elle ne fonctionne plus :

<img width="467" alt="image" src="https://github.com/user-attachments/assets/650b103e-6df3-4179-8fd3-df6cad74eca6">

La nouvelle action met en cache les images directement.

Avec ce cache on gagne entre 5 et 7 minutes de build.