### PR TITLE
on affiche le numéro de TVA intercommunautaire sur les devis

### DIFF
--- a/sources/Afup/Comptabilite/Facture.php
+++ b/sources/Afup/Comptabilite/Facture.php
@@ -355,7 +355,9 @@ class Facture
             utf8_decode($coordonnees['adresse']) . "\n" .
             utf8_decode($coordonnees['code_postal']) . " " .
             utf8_decode($coordonnees['ville']) . "\n" .
-            utf8_decode($pays->obtenirNom($coordonnees['id_pays'])));
+            utf8_decode($pays->obtenirNom($coordonnees['id_pays'])) .
+            ($coordonnees['tva_intra'] ? ("\n" . utf8_decode('N° TVA Intracommunautaire : ' . $coordonnees['tva_intra'])) : null)
+        );
 
         $pdf->Ln(10);
         $pdf->SetFont('Arial', 'BU', 10);


### PR DESCRIPTION
Quand on avait saisi un numéro de TVA intercommunautaire sur un devis celui-ci n'était pas affiché, c'est maintenant le cas.