### PR TITLE
on enlève la condition de redirection en https 

### DIFF
--- a/htdocs/.htaccess
+++ b/htdocs/.htaccess
@@ -39,8 +39,6 @@ RewriteRule ^enquete$ "https://docs.google.com/forms/d/e/1FAIpQLSdtPRqp7AL73RhUS
 
 # If the requested filename exists, simply serve it.
 # We only want to let Apache serve files and not directories.
-RewriteCond %{HTTPS} off
-RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301]
 
 RewriteCond %{HTTP_HOST} ^www\.(.*)$ [NC]
 RewriteRule ^(.*)$ https://%1/$1 [R=301,L]

--- a/htdocs/pages/.htaccess
+++ b/htdocs/pages/.htaccess
@@ -1,8 +1,5 @@
 RewriteEngine On
 
-RewriteCond %{HTTPS} off
-RewriteRule .* https://%{HTTP_HOST}%{REQUEST_URI} [L,R=302]
-
 RewriteCond %{HTTP_HOST} ^www\.(.*)$ [NC]
 RewriteRule ^(.*)$ https://%1/$1 [R=301,L]
 


### PR DESCRIPTION
celle-ci sera gérée par clever cloud en forçant la redirection dans la config, et pose actuellement problème où on a une redirection
en boucle.

sur le site actuel, la configuration a été modifiée pour qu'elle soit gérée dans le vhost.