### PR TITLE
Feat planning allow multiple talks in the same slot

### DIFF
--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -28,11 +28,11 @@
                 {% for hour in hourMin..hourMax %}
                     {% set hour = "%02d"|format(hour) %}
                     {% set numberOfRows = 60/precision %}
-                    {% for rowIndex in 1..numberOfRows %}
-                        {% set minutes = "%02d"|format(precision*(rowIndex-1)) %}
+                    {% for _ in 1..numberOfRows %}
+                        {% set minutes = "%02d"|format(precision*(loop.index-1)) %}
                         {# On crée une ligne pour chaque espace de 5 minutes mais on affiche les heures que les 1/4h #}
                         <tr>
-                            {% if rowIndex == 1 %}
+                            {% if loop.index == 1 %}
                                 <td class="col_heure" rowspan="{{ 60 / precision }}" nowrap="nowrap">
                                     {{ hour }}h
                                 </td>
@@ -48,8 +48,8 @@
 
                                         {% set hasConf = hasConf|merge({(room.name|trim):numberOfRowForThisSlot}) %}
                                         {# Boucle pour afficher chaque événement dans la salle #}
-                                        {% for row in rows %}
-                                            <td rowspan="{{ numberOfRowForThisSlot }}" width="21%" class="conf {{ cycle(['conf_odd', 'conf_even'], loop.index0) }}">
+                                        <td rowspan="{{ numberOfRowForThisSlot }}" width="21%" class="conf {{ cycle(['conf_odd', 'conf_even'], loop.index0) }}">
+                                            {% for row in rows %}
                                                 <p>
                                                     <a href="{{ row.program_page_prefix }}#{{ row.talk.id }}" name="ag_sess_{{ row.talk.id }}">
                                                         {{ row.talk.title }}
@@ -64,8 +64,8 @@
                                                         </div>
                                                     </a>
                                                 </p>
-                                            </td>
-                                        {% endfor %}
+                                            {% endfor %}
+                                        </td>
                                     {% else %}
                                         {% if hasConf[room.name] is defined and hasConf[room.name] > 0 %}
                                             {% set numberOfRowForThisSlot = hasConf[room.name] - 1 %}

--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -1,29 +1,29 @@
 {% if not planningDisplayable %}
     Le planning est en cours d'élaboration, il sera dévoilé sous peu.
 {% else %}
-<script type="application/ld+json">
-    {{ jsonld|json_encode|raw }}
-</script>
+    <script type="application/ld+json">
+      {{ jsonld|json_encode|raw }}
+    </script>
 
-<div class="bloc_jour">
-    {% for date, planningForADay in planning %}
-        <table class="planning_agenda">
-            <caption>Jour {{ loop.index }} : {{ date }}</caption>
-            <thead>
-            <tr>
-                <th class="horaire" colspan="2">&nbsp;</th>
-                {% for room in rooms %}
-                    <th class="activite">{{ room.name }}</th>
-                {% endfor %}
-            </tr>
-            </thead>
-            <tbody>
+    <div class="bloc_jour">
+        {% for date, planningForADay in planning %}
+            <table class="planning_agenda">
+                <caption>Jour {{ loop.index }} : {{ date }}</caption>
+                <thead>
+                <tr>
+                    <th class="horaire" colspan="2">&nbsp;</th>
+                    {% for room in rooms %}
+                        <th class="activite">{{ room.name }}</th>
+                    {% endfor %}
+                </tr>
+                </thead>
+                <tbody>
                 {#
-                    Le tableau hasConf contiens pour chaque salle le nombre d'itérations à ignorer pour les td vides
-                    Ce tableau est indexé selon les *noms* des salles car si on l'index par id, le merge va réindexer
-                    les valeurs. Le merge étant le seul moyen de modifier l'entrée d'un tableau dans twig, ce tableau
-                    serait alors inutile
-                 #}
+                Le tableau hasConf contiens pour chaque salle le nombre d'itérations à ignorer pour les td vides
+                Ce tableau est indexé selon les *noms* des salles car si on l'index par id, le merge va réindexer
+                les valeurs. Le merge étant le seul moyen de modifier l'entrée d'un tableau dans twig, ce tableau
+                serait alors inutile
+                #}
                 {% set hasConf = {} %}
                 {% for hour in hourMin..hourMax %}
                     {% set hour = "%02d"|format(hour) %}
@@ -88,12 +88,11 @@
                         </tr>
                     {% endfor %}
                 {% endfor %}
-
-            </tbody>
-        </table>
-        <br class="page_break">
-    {% endfor %}
-</div>
+                </tbody>
+            </table>
+            <br class="page_break">
+        {% endfor %}
+    </div>
 
     {% for event in events %}
         <a class="planning-link" href="{{ app.request.getSchemeAndHttpHost() }}/event/{{ event.path }}/calendar">Créer mon planning personnalisé{% if events|length > 1 %} ({{ event.title }}){% endif %}</a>

--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -28,43 +28,44 @@
                 {% for hour in hourMin..hourMax %}
                     {% set hour = "%02d"|format(hour) %}
                     {% set numberOfRows = 60/precision %}
-                    {% for row in 1..numberOfRows %}
-                        {% set minutes = "%02d"|format(precision*loop.index0) %}
+                    {% for rowIndex in 1..numberOfRows %}
+                        {% set minutes = "%02d"|format(precision*(rowIndex-1)) %}
                         {# On crée une ligne pour chaque espace de 5 minutes mais on affiche les heures que les 1/4h #}
                         <tr>
-                            {% if loop.index0 * precision % 60 == 0 %}
+                            {% if rowIndex == 1 %}
                                 <td class="col_heure" rowspan="{{ 60 / precision }}" nowrap="nowrap">
-                                    {# @TODO Meilleur affichage heures et minutes #}
                                     {{ hour }}h
                                 </td>
                             {% endif %}
-                            <td class="col_heure">{{ "%02d"|format(precision*loop.index0) }}</td>
+                            <td class="col_heure">{{ minutes }}</td>
 
                             {% if planningForADay[date ~ " " ~ hour ~ ":" ~ minutes] is defined %}
                                 {% set slot = planningForADay[date ~ " " ~ hour ~ ":" ~ minutes] %}
                                 {% for room in rooms %}
                                     {% if slot[room.id] is defined %}
-                                        {% set row = slot[room.id] %}
-                                        {% set numberOfRowForThisSlot = row.length / precision %}
+                                        {% set rows = slot[room.id] %}
+                                        {% set numberOfRowForThisSlot = rows|length %}
 
                                         {% set hasConf = hasConf|merge({(room.name|trim):numberOfRowForThisSlot}) %}
-                                        <td rowspan="{{ numberOfRowForThisSlot }}" width="21%" class="conf {{ cycle(['conf_odd', 'conf_even'], loop.index0) }}">
-                                        <p>
-                                            <a href="{{ row.program_page_prefix }}#{{ row.talk.id }}" name="ag_sess_{{ row.talk.id }}">
-                                                {{ row.talk.title }}
-                                                <div class="conferencier">
-                                            {% for speaker in row[".aggregation"].speaker %}
-                                                {% if loop.index > 1 %} / {% endif %}
-                                                {{ speaker.label }}
-                                                {% if speaker.company %}
-                                                    - {{ speaker.company }}
-                                                {% endif %}
-                                            {% endfor %}
-                                                </div>
-                                            </a>
-                                        </p>
-
-                                        </td>
+                                        {# Boucle pour afficher chaque événement dans la salle #}
+                                        {% for row in rows %}
+                                            <td rowspan="{{ numberOfRowForThisSlot }}" width="21%" class="conf {{ cycle(['conf_odd', 'conf_even'], loop.index0) }}">
+                                                <p>
+                                                    <a href="{{ row.program_page_prefix }}#{{ row.talk.id }}" name="ag_sess_{{ row.talk.id }}">
+                                                        {{ row.talk.title }}
+                                                        <div class="conferencier">
+                                                            {% for speaker in row[".aggregation"].speaker %}
+                                                                {% if loop.index > 1 %} / {% endif %}
+                                                                {{ speaker.label }}
+                                                                {% if speaker.company %}
+                                                                    - {{ speaker.company }}
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </div>
+                                                    </a>
+                                                </p>
+                                            </td>
+                                        {% endfor %}
                                     {% else %}
                                         {% if hasConf[room.name] is defined and hasConf[room.name] > 0 %}
                                             {% set numberOfRowForThisSlot = hasConf[room.name] - 1 %}

--- a/sources/AppBundle/Controller/BlogController.php
+++ b/sources/AppBundle/Controller/BlogController.php
@@ -129,7 +129,7 @@ class BlogController extends EventBaseController
                 $defaultProgramPagePrefix = $request->query->get('program-page-prefix-' . $eventPath, '/' . $eventPath . '/programme/');
             }
             $talkWithData['program_page_prefix'] = $request->query->get('program-page-prefix', $defaultProgramPagePrefix);
-            $eventPlanning[$startDay][$start][$room->getId()] = $talkWithData;
+            $eventPlanning[$startDay][$start][$room->getId()][] = $talkWithData;
 
             if (isset($rooms[$room->getId()]) === false) {
                 $rooms[$room->getId()] = $room;


### PR DESCRIPTION
Solves #1536 

Je n'ai pour le moment pas réussi à trouver ce rendu sur la version de dev pour tester si complètement ok
![image](https://github.com/user-attachments/assets/d9d090c9-5806-47c6-abbe-3af2c7ee5861)

Cependant sur `/blog/forum/planning` (lié à `planningAction` du `BlogController`) voici les évolutions : 

Avant 1 seul évènement s'affichait quand il y en avait plusieurs sur la même salle à la même heure
![avant](https://github.com/user-attachments/assets/e3dcb0a0-dd71-4a7c-a3fc-540ac2956215)

Désormais plusieurs évents sont supportés
![après](https://github.com/user-attachments/assets/aef8c005-5e16-40c5-8cd8-e86d6ef6a405)


Je n'ai pas trouvé de tests et le code côté front et back et assez complexe. Si vous voulez je peux à l'occasion faire une refonte en TDD avec tests atoum + Behat. Côté front j'en ai profité pour ré-indenter et refaire 2/3 petits éléments en lien avec les index sur les slots.
