### PR TITLE
afupf#1180 allègement des requêtes SQL et ajout sitemap.xml

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -640,7 +640,7 @@ services:
         tags:
             - {name: form.type}
 
-    AppBundle\Subscriber\TalksSitemapSubscriber:
+    AppBundle\Subscriber\TalksAndNewsSitemapSubscriber:
         arguments:
             - "@router"
             - "@ting"

--- a/sources/AppBundle/Controller/HtmlSitemapController.php
+++ b/sources/AppBundle/Controller/HtmlSitemapController.php
@@ -79,25 +79,20 @@ class HtmlSitemapController extends SiteBaseController
 
     private function news(): array
     {
-        $itemPerPage = 100;
-        $page = 1;
-
         $repository = $this->get('ting')->get(ArticleRepository::class);
 
         $news = [];
-        do {
-            $newsList = $repository->findPublishedNews($page++, $itemPerPage, []);
-            foreach ($newsList as $newsItem) {
-                $url = $this->urlGenerator->generate('news_display', [
-                    'code' => $newsItem->getSlug(),
-                ]);
+        $newsList = $repository->findAllPublishedNews();
+        foreach ($newsList as $newsItem) {
+            $url = $this->urlGenerator->generate('news_display', [
+                'code' => $newsItem->getSlug(),
+            ]);
 
-                $news[] = [
-                    'name' => $newsItem->getTitle(),
-                    'url' => $url
-                ];
-            }
-        } while (count($newsList) >= $itemPerPage);
+            $news[] = [
+                'name' => $newsItem->getTitle(),
+                'url' => $url
+            ];
+        }
 
         return $news;
     }

--- a/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
+++ b/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
@@ -85,6 +85,15 @@ class ArticleRepository extends Repository implements MetadataInitializer
         return $query->query($this->getCollection(new HydratorSingleObject()));
     }
 
+    public function findAllPublishedNews(array $filters = [])
+    {
+        list($sql, $params) = $this->getSqlPublishedNews($filters);
+
+        return $this->getPreparedQuery($sql)
+            ->setParams($params)
+            ->query($this->getCollection(new HydratorSingleObject()));
+    }
+
     public function findPrevious(Article $article)
     {
         if (null === ($publishedAt = $article->getPublishedAt())) {

--- a/sources/AppBundle/Subscriber/TalksAndNewsSitemapSubscriber.php
+++ b/sources/AppBundle/Subscriber/TalksAndNewsSitemapSubscriber.php
@@ -4,6 +4,8 @@ namespace AppBundle\Subscriber;
 
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Talk;
+use AppBundle\Site\Model\Article;
+use AppBundle\Site\Model\Repository\ArticleRepository;
 use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
 use Presta\SitemapBundle\Event\SitemapPopulateEvent;
 use Presta\SitemapBundle\Service\UrlContainerInterface;
@@ -11,7 +13,7 @@ use Presta\SitemapBundle\Sitemap\Url\UrlConcrete;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class TalksSitemapSubscriber implements EventSubscriberInterface
+class TalksAndNewsSitemapSubscriber implements EventSubscriberInterface
 {
     /** @var RepositoryFactory */
     private $ting;
@@ -35,6 +37,7 @@ class TalksSitemapSubscriber implements EventSubscriberInterface
     public function populate(SitemapPopulateEvent $event)
     {
         $this->registerTalksUrls($event->getUrlContainer());
+        $this->registerNewsUrls($event->getUrlContainer());
     }
 
     public function registerTalksUrls(UrlContainerInterface $urls)
@@ -56,6 +59,26 @@ class TalksSitemapSubscriber implements EventSubscriberInterface
                     'talks'
                 );
             }
+        }
+    }
+
+    public function registerNewsUrls(UrlContainerInterface $urls)
+    {
+        $news = $this->ting->get(ArticleRepository::class)->findAllPublishedNews();
+
+        /** @var Article $article */
+        foreach ($news as $article) {
+            $urls->addUrl(
+                new UrlConcrete(
+                    $this->urlGenerator->generate(
+                        'news_display',
+                        ['code' => $article->getSlug(),],
+                        UrlGeneratorInterface::ABSOLUTE_URL
+                    ),
+                    $article->getPublishedAt()
+                ),
+                'news'
+            );
         }
     }
 }


### PR DESCRIPTION
J'ai réduit le nombre de requêtes SQL dans le plan du site version HTML en ajoutant une fonction qui permet de lister tous les articles en 1 fois.

J'ai également ajouté la liste des articles dans les sitemap.xml via le subscriber.