### PR TITLE
correction stockage montant cotisation

### DIFF
--- a/db/migrations/20240918112441_cotisation_type.php
+++ b/db/migrations/20240918112441_cotisation_type.php
@@ -1,0 +1,12 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CotisationType extends AbstractMigration
+{
+    public function change()
+    {
+        // avant on était en float(5,2) unsigned
+        $this->execute("ALTER TABLE afup_cotisations MODIFY montant float(6,2) unsigned NOT NULL DEFAULT '0.00'");
+    }
+}


### PR DESCRIPTION
Si on a des personnes morales avec 18 membres on a une cotisation en de 1080€ TTC.

Or le stockage est en float(5,2), c'est donc 999,99 qui était stocké en base.

Le paiement était fait avec la bonne somme, mais l'édition de la facture était à 1000€ TTC et non 1080€.

On augmente la taille du champ pour pouvoir gérer ce cas.