### PR TITLE
correction affichage du planning

### DIFF
--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -44,7 +44,7 @@
                                 {% for room in rooms %}
                                     {% if slot[room.id] is defined %}
                                         {% set rows = slot[room.id] %}
-                                        {% set numberOfRowForThisSlot = rows|length %}
+                                        {% set numberOfRowForThisSlot = rows[0].length / prevision %}
 
                                         {% set hasConf = hasConf|merge({(room.name|trim):numberOfRowForThisSlot}) %}
                                         {# Boucle pour afficher chaque événement dans la salle #}

--- a/app/Resources/views/blog/planning.html.twig
+++ b/app/Resources/views/blog/planning.html.twig
@@ -44,7 +44,7 @@
                                 {% for room in rooms %}
                                     {% if slot[room.id] is defined %}
                                         {% set rows = slot[room.id] %}
-                                        {% set numberOfRowForThisSlot = rows[0].length / prevision %}
+                                        {% set numberOfRowForThisSlot = rows|first.length / prevision %}
 
                                         {% set hasConf = hasConf|merge({(room.name|trim):numberOfRowForThisSlot}) %}
                                         {# Boucle pour afficher chaque événement dans la salle #}


### PR DESCRIPTION
avec https://github.com/afup/web/pull/1537/files?diff=split&w=1

on perdait la hauteur des sessions,

on retourne donc sur le calcul de la hauteur de la session.

sans cela le rendu était comme cela:
![Screenshot 2024-09-19 at 13-32-34 Planning – Forum PHP 2024 – Cycles de conférences AFUP](https://github.com/user-attachments/assets/c8830e20-9d46-41b7-9bcc-8e35d2266c57)
