### PR TITLE
Ajout de l'hébergement sur Clever Cloud dans le footer

### DIFF
--- a/app/Resources/views/site/base.html.twig
+++ b/app/Resources/views/site/base.html.twig
@@ -180,6 +180,10 @@
                     {% endfor %}
                 </div>
 
+                <div id="hosting">
+                    Hébergé sur <a href="https://www.clever-cloud.com/">Clever Cloud</a>
+                </div>
+
                 <div id="copyright">© AFUP 2003-{{ date()|date('Y') }}</div>
             </div>
         </footer>

--- a/htdocs/templates/site/css/styles-without-compass.css
+++ b/htdocs/templates/site/css/styles-without-compass.css
@@ -1,8 +1,2 @@
-#copyright {
-    text-align: center;
-    color: #999;
-    font-size: 0.8em;
-}
-
 #logo a { color: inherit; text-decoration: none; }
 header #espace-membre {z-index:1000;}

--- a/htdocs/templates/site/scss/base/layout.scss
+++ b/htdocs/templates/site/scss/base/layout.scss
@@ -134,3 +134,10 @@ a.evitement:focus {
     display: initial;
   }
 }
+
+#copyright, #hosting {
+  text-align: center;
+  color: #999;
+  font-size: 0.8em;
+  margin-bottom: 15px;
+}


### PR DESCRIPTION
En prévision de la migration sur Clever Cloud on l'ajoute dans le footer. Une fois la migration faite on pourra merger cette PR.

Voici le rendu : 
![Screenshot 2024-09-23 at 21-57-17 Afup - Association française des utilisateurs de PHP](https://github.com/user-attachments/assets/73a2a338-f4e7-4508-aae7-7ef4019e645b)
