### PR TITLE
on crée le dossier tmp à la racine du dossier APP_HOME

### DIFF
--- a/clevercloud/scripts/cc_pre_build_hook.sh
+++ b/clevercloud/scripts/cc_pre_build_hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+yarn install --ignore-engines
+
+mkdir $APP_HOME/tmp


### PR DESCRIPTION
Lors de l'upload du fichier de banque sur le journal on avait cette erreur :
```
Uncaught PHP Exception RuntimeException: "SplFileObject::__construct(/home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/htdocs/pages/administration/../../../tmp/banque.csv): failed to open stream: No such file or directory
```

Cela car le dossier tmp n'existait pas.

Dans la variable d'environnement `CC_PRE_BUILD_HOOK` on avait pour valeur  `yarn install --ignore-engines`, on crée un script pour avoir l'installation des dépendances node et pour créer le dossier tmp.

Il faudra remplacer la valeur de la variable `CC_PRE_BUILD_HOOK` par  `./clevercloud/scripts/cc_pre_build_hook.sh`.