### PR TITLE
on corrige le schéma de compte pour pouvoir importer le journal

### DIFF
--- a/db/migrations/20241201133731_compta_id_clef.php
+++ b/db/migrations/20241201133731_compta_id_clef.php
@@ -1,0 +1,12 @@
+<?php
+
+
+use Phinx\Migration\AbstractMigration;
+
+class ComptaIdClef extends AbstractMigration
+{
+    public function change()
+    {
+        $this->execute("ALTER TABLE compta MODIFY COLUMN idclef varchar(20) NOT NULL DEFAULT ''");
+    }
+}


### PR DESCRIPTION
suite au https://github.com/afup/web/pull/1560

le fichier peux bien être uploadé, mais on a cette erreur :

```
Field 'idclef' doesn't have a default value" string(43) "Field 'idclef' doesn't have a default value" string(43) "Field 'idclef' doesn't have a default value"
```

Cela car on a pas de valeur par défaut sur le champ.

Ce champ est tout le temps vide :
```
MariaDB [afup]> select distinct idclef from compta;
+--------+
| idclef |
+--------+
|        |
+--------+
1 row in set (0.05 sec)
```

dans l'idée on pourrait potentiellement le supprimer, mais le plus simple dans l'immédiat vu qu'on doit importer le journal est de reproduire le comportement que l'on avait avant en ajoutant une valeur par défaut sur le champ.