### PR TITLE
Correction 500 sur inscription si on ne cocher pas la case "citer société"

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -294,7 +294,8 @@ class TicketRepository extends Repository implements MetadataInitializer
             ->addField([
                 'columnName' => 'citer_societe',
                 'fieldName' => 'companyCitation',
-                'type' => 'string'
+                'type' => 'bool',
+                'serializer' => Boolean::class
             ])
             ->addField([
                 'columnName' => 'newsletter_afup',


### PR DESCRIPTION
Suite à la migration et au changement de version SBGD on avait cette erreur :

```
2024-12-03T18:56:37.367Z request.CRITICAL: Uncaught PHP Exception CCMBenchmark\Ting\Driver\QueryException: "Incorrect integer value: '' for column 'citer_societe' at row 1" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/vendor/ccmbenchmark/ting/src/Ting/Driver/Mysqli/Statement.php line 118 {"exception":"[object] (CCMBenchmark\\Ting\\Driver\\QueryException(code: 1366): Incorrect integer value: '' for column 'citer_societe' at row 1 at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/vendor/ccmbenchmark/ting/src/Ting/Driver/Mysqli/Statement.php:118)"} []
```

si on ne cochait pas la case "J'accepte que ma société soit citée comme participant à la conférence".

Ce changement devrait corriger le souci en appliquant le même mapping que l'acceptation de la newsletter.