### PR TITLE
Passage au niveau 2 de PHPStan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,6 @@
 parameters:
     phpVersion: 70400 # PHP 7.4
-    level: 1
+    level: 2
     paths:
         - sources
     scanFiles:
@@ -14,6 +14,10 @@ parameters:
             # Ces fichiers utilisent des alias de classes
             - sources/AppBundle/Twig/AssetsExtension.php
             - sources/AppBundle/Twig/TwigExtension.php
+
+    stubFiles:
+            - tests/stubs/Ting/Repository/Repository.php.stub
+            - tests/stubs/Ting/Repository/RepositoryFactory.php.stub
 
     ignoreErrors:
         -

--- a/sources/Afup/Association/Cotisations.php
+++ b/sources/Afup/Association/Cotisations.php
@@ -617,7 +617,7 @@ class Cotisations
 
     /**
      * @param array $cotisation from Afup_Personnes_Physiques::obtenirDerniereCotisation
-     * @return DateTime: Date of end of next subscription
+     * @return DateTime Date of end of next subscription
      */
     public function finProchaineCotisation($cotisation)
     {

--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -316,8 +316,8 @@ class Forum
         $aHeures = explode("-", $heures);
         $aDebut = explode(":", $aHeures[0]);
         $aFin = explode(":", $aHeures[1]);
-        $iDebut = ($aDebut[0] * 60) + $aDebut[1];
-        $iFin = ($aFin[0] * 60) + $aFin[1];
+        $iDebut = ((int)$aDebut[0] * 60) + (int)$aDebut[1];
+        $iFin = ((int)$aFin[0] * 60) + (int)$aFin[1];
         $duree = ($iFin - $iDebut) / 5;
         return $duree;
     }

--- a/sources/AppBundle/Association/Form/UserEditFormData.php
+++ b/sources/AppBundle/Association/Form/UserEditFormData.php
@@ -15,8 +15,8 @@ class UserEditFormData
 {
     public $companyId;
     /**
-     * @var Assert\NotBlank()
-     * @var Assert\Choice(choices={"M.", "Mme"}, strict=true)
+     * @Assert\NotBlank()
+     * @Assert\Choice(choices={"M.", "Mme"}, strict=true)
      */
     public $civility = 'M.';
     /**

--- a/sources/AppBundle/Association/Model/GeneralMeetingQuestion.php
+++ b/sources/AppBundle/Association/Model/GeneralMeetingQuestion.php
@@ -163,10 +163,7 @@ class GeneralMeetingQuestion implements NotifyPropertyInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getStatus()
+    public function getStatus(): string
     {
         if (null !== $this->getClosedAt()) {
             return self::STATUS_CLOSED;
@@ -179,22 +176,25 @@ class GeneralMeetingQuestion implements NotifyPropertyInterface
         return self::STATUS_WAITING;
     }
 
-    public function hasStatusWaiting()
+    public function hasStatusWaiting(): bool
     {
         return self::STATUS_WAITING === $this->getStatus();
     }
 
-    public function hasStatusOpened()
+    public function hasStatusOpened(): bool
     {
         return self::STATUS_OPENED === $this->getStatus();
     }
 
-    public function hasStatusClosed()
+    public function hasStatusClosed(): bool
     {
         return self::STATUS_CLOSED === $this->getStatus();
     }
 
-    public function hasVotes($results)
+    /**
+     * @param array<string, int> $results
+     */
+    public function hasVotes(array $results): bool
     {
         return 0 > $results[GeneralMeetingVote::VALUE_YES] + $results[GeneralMeetingVote::VALUE_NO] + $results[GeneralMeetingVote::VALUE_ABSTENTION];
     }

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingQuestionRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingQuestionRepository.php
@@ -45,6 +45,9 @@ SQL;
         return $collection->first();
     }
 
+    /**
+     * @return iterable<GeneralMeetingQuestion>
+     */
     public function loadClosedQuestions(\DateTimeInterface $generalMeetingDate)
     {
         $sql = <<<SQL
@@ -61,14 +64,16 @@ SQL;
             'general_meeting_date' => $generalMeetingDate->format('U'),
         ];
 
+        /** @var iterable<GeneralMeetingQuestion> */
         return $this->getPreparedQuery($sql)->setParams($params)->query($this->getCollection(new HydratorSingleObject()));
     }
 
     /**
-     * @return \CCMBenchmark\Ting\Repository\CollectionInterface
+     * @return iterable<GeneralMeetingQuestion>
      */
     public function loadByDate(\DateTimeInterface $generalMeetingDate)
     {
+        /** @var iterable<GeneralMeetingQuestion> */
         return $this->getBy([
             'date' => $generalMeetingDate->format('U'),
         ]);

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
@@ -19,7 +19,10 @@ class GeneralMeetingVoteRepository extends Repository implements MetadataInitial
         ]);
     }
 
-    public function getResultsForQuestionId($questionId)
+    /**
+     * @return array<string, int>
+     */
+    public function getResultsForQuestionId(int $questionId): array
     {
         $results = [
             GeneralMeetingVote::VALUE_YES => 0,

--- a/sources/AppBundle/Command/QrCodesGeneratorCommand.php
+++ b/sources/AppBundle/Command/QrCodesGeneratorCommand.php
@@ -60,11 +60,14 @@ class QrCodesGeneratorCommand extends ContainerAwareCommand
 
             $io->progressStart(count($tickets));
             foreach ($tickets as $ticket) {
-                if (null !== ($inscriptionIdMin = $input->getOption('inscription-id-min')) && $inscriptionIdMin > $ticket->getId()) {
+                $inscriptionIdMin = (int) $input->getOption('inscription-id-min');
+                $inscriptionIdMax = (int) $input->getOption('inscription-id-max');
+
+                if ($inscriptionIdMin > $ticket->getId()) {
                     continue;
                 }
 
-                if (null !== ($inscriptionIdMax = $input->getOption('inscription-id-max')) && $inscriptionIdMax < $ticket->getId()) {
+                if ($inscriptionIdMax < $ticket->getId()) {
                     continue;
                 }
 

--- a/sources/AppBundle/Controller/Admin/Event/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ListAction.php
@@ -5,6 +5,7 @@ namespace AppBundle\Controller\Admin\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Twig\Environment;
 
@@ -19,7 +20,7 @@ class ListAction
      */
     private $twig;
     /**
-     * @var SessionInterface
+     * @var SessionInterface&Session
      */
     private $session;
 

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
@@ -56,7 +56,7 @@ class ReportsAction
         // add
         $form = $this->buildForm();
         if ($form->handleRequest($request) && $form->isValid()) {
-            /** @var UploadedFile $uploadedFile */
+            /** @var UploadedFile $reportFile */
             $reportFile = $form->get('file')->getData();
             if ($reportFile->move($basePath, $reportFile->getClientOriginalName())) {
                 $this->flashBag->add('notice', 'Le compte rendu a correctement été ajouté.');

--- a/sources/AppBundle/Controller/MemberShipController.php
+++ b/sources/AppBundle/Controller/MemberShipController.php
@@ -651,8 +651,10 @@ class MemberShipController extends SiteBaseController
             throw $this->createNotFoundException('Vote manquant');
         }
 
-        /** @var $question GeneralMeetingQuestion */
-        if (null === ($question = $generalMeetingQuestionRepository->get($questionId))) {
+        /** @var GeneralMeetingQuestion $question */
+        $question = $generalMeetingQuestionRepository->get($questionId);
+
+        if (null === $question) {
             throw $this->createNotFoundException('QuestionId missing');
         }
 

--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -15,6 +15,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Speaker>
+ */
 class SpeakerRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -524,7 +524,7 @@ class Speaker implements NotifyPropertyInterface
      * @param UploadedFile|null $photoFile
      * @return Speaker
      */
-    public function setPhotoFile(UploadedFile $photoFile)
+    public function setPhotoFile(?UploadedFile $photoFile)
     {
         $this->photoFile = $photoFile;
         return $this;

--- a/sources/AppBundle/Security/LegacyAuthenticator.php
+++ b/sources/AppBundle/Security/LegacyAuthenticator.php
@@ -6,6 +6,8 @@ use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Association\Model\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -74,7 +76,9 @@ class LegacyAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $request->getSession()->getFlashBag()->add('error', "Utilisateur et/ou mot de passe incorrect");
+        /** @var SessionInterface&Session $session */
+        $session = $request->getSession();
+        $session->getFlashBag()->add('error', "Utilisateur et/ou mot de passe incorrect");
 
         return null;
     }

--- a/sources/AppBundle/Security/LegacyHashAuthenticator.php
+++ b/sources/AppBundle/Security/LegacyHashAuthenticator.php
@@ -7,6 +7,8 @@ use AppBundle\Association\Model\User;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -66,7 +68,9 @@ class LegacyHashAuthenticator extends AbstractGuardAuthenticator
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        $request->getSession()->getFlashBag()->add('error', "Utilisateur et/ou mot de passe incorrect");
+        /** @var SessionInterface&Session $session */
+        $session = $request->getSession();
+        $session->getFlashBag()->add('error', "Utilisateur et/ou mot de passe incorrect");
 
         return null;
     }

--- a/sources/AppBundle/Security/TalkVoter.php
+++ b/sources/AppBundle/Security/TalkVoter.php
@@ -5,7 +5,6 @@ namespace AppBundle\Security;
 
 use AppBundle\Event\Model\GithubUser;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
-use AppBundle\Event\Model\Speaker;
 use AppBundle\Event\Model\Talk;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
@@ -48,9 +47,6 @@ class TalkVoter extends Voter
 
         // All speakers associated to a talk can edit the talk
         foreach ($speakers as $speaker) {
-            /**
-             * @var $speaker Speaker
-             */
             if ($speaker->getUser() === $user->getId()) {
                 return true;
             }

--- a/sources/AppBundle/TechLetter/HtmlParser.php
+++ b/sources/AppBundle/TechLetter/HtmlParser.php
@@ -11,7 +11,7 @@ class HtmlParser
     private $dom;
 
     /**
-     * @var \DOMNodeList
+     * @var \DOMNodeList&iterable<\DOMElement>
      */
     private $meta;
 
@@ -57,9 +57,6 @@ class HtmlParser
     private function getOpenGraphMeta($property)
     {
         foreach ($this->meta as $meta) {
-            /**
-             * @var $meta \DOMElement
-             */
             if ($meta->hasAttribute('property') === true) {
                 if ($meta->getAttribute('property') === self::OPEN_GRAPH_PREFIX . ':' . $property) {
                     return $meta->getAttribute('content');
@@ -72,9 +69,6 @@ class HtmlParser
     private function getTwitterMeta($name)
     {
         foreach ($this->meta as $meta) {
-            /**
-             * @var $meta \DOMElement
-             */
             if ($meta->hasAttribute('name') === true) {
                 if ($meta->getAttribute('name') === self::TWITTER_PREFIX . ':' . $name) {
                     return $meta->getAttribute('content');
@@ -91,9 +85,6 @@ class HtmlParser
     private function getStandardMeta($name)
     {
         foreach ($this->meta as $meta) {
-            /**
-             * @var $meta \DOMElement
-             */
             if ($meta->hasAttribute('name') === true) {
                 if ($meta->getAttribute('name') === $name) {
                     return $meta->getAttribute('content');

--- a/tests/stubs/Ting/Repository/Repository.php.stub
+++ b/tests/stubs/Ting/Repository/Repository.php.stub
@@ -1,0 +1,7 @@
+<?php
+namespace CCMBenchmark\Ting\Repository;
+
+/**
+ * @template T
+ */
+abstract class Repository {}

--- a/tests/stubs/Ting/Repository/RepositoryFactory.php.stub
+++ b/tests/stubs/Ting/Repository/RepositoryFactory.php.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace CCMBenchmark\Ting\Repository;
+
+class RepositoryFactory
+{
+    /**
+     * @param class-string<R> $repositoryName
+     * @return R
+     * @template T of object
+     * @template R of Repository<T>
+     */
+    public function get($repositoryName) {}
+}


### PR DESCRIPTION
Grâce à la migration sur Clever Cloud et au passage à PHP 7.4 il y a des erreurs PHPStan qui sont devenu possibles à corriger.

Et donc on peut passer au niveau 2 minimum.

À savoir que j'ai dû ajouter des stubs pour surcharger des annotation de Ting qui sont incomplètes.

J'ai fait [une PR](https://github.com/ccmbenchmark/ting/pull/102) sur Ting qui a été merge mais la dernière version a besoin de PHP 8 au minimum donc en attendant on a besoin des stubs.