### PR TITLE
correction de la modification d'inscription

### DIFF
--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -286,7 +286,7 @@ SQL;
         $requete .= '  facturation=' . $this->_bdd->echapper($facturation) . ',';
         $requete .= '  transport_mode=' . $this->_bdd->echapper($transportMode) . ',';
         $requete .= '  transport_distance=' . $this->_bdd->echapper($transportDistance);
-        $requete .= 'WHERE';
+        $requete .= ' WHERE';
         $requete .= '  id=' . $id;
 
         $this->modifierEtatInscription($reference, $etat);


### PR DESCRIPTION
Nous avions une erreur 500 lors de la modification d'une inscription.

Cela car il manquait un espace avant le where.

En effet, nous nous retrouvions avec une requête comme celui-ci :

```
 facturation='0', transport_mode=10, transport_distance=0WHERE id=16411
```

On corrige cela en ajoutant un espace.