### PR TITLE
correction modification de session suite au changement de bdd

### DIFF
--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -431,8 +431,10 @@ class AppelConferencier
         $requete .= ' titre = ' . $this->_bdd->echapper($titre) . ', ';
         $requete .= ' abstract = ' . $this->_bdd->echapper($abstract) . ', ';
         $requete .= ' genre = ' . $this->_bdd->echapper($genre) . ', ';
-        if ($joindin !== null) {
+        if (strlen(trim($joindin)) > 0) {
             $requete .= ' joindin = ' . $this->_bdd->echapper($joindin) . ', ';
+        } else {
+            $requete .= ' joindin = NULL, ';
         }
         if ($youtubeId !== null) {
             $requete .= ' youtube_id = ' . $this->_bdd->echapper($youtubeId) . ', ';


### PR DESCRIPTION
Depuis le passage de mariadb `10.0.28-MariaDB-1~jessie` à MySQL 5.7, la modification de session ne fonctionne plus, il y a une erreur 500.

Voici le message d'erreur :
```
Uncaught PHP Exception RuntimeException: "Incorrect integer value: '' for column 'joindin' at row 1" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Utils/Base_De_Donnees.php line 238
```

On corrige la requête de modification afin de ne pas mettre une chaine dans un champ en INT NULLABLE et ainsi éviter une erreur 500.