### PR TITLE
suppression du lien vers le blog de bordeaux

### DIFF
--- a/sources/AppBundle/Offices/OfficesCollection.php
+++ b/sources/AppBundle/Offices/OfficesCollection.php
@@ -15,7 +15,6 @@ class OfficesCollection
                 'meetup_id' => '18197674',
                 'logo_url' => '/images/offices/bordeaux.svg',
                 'twitter' => 'AFUP_Bordeaux',
-                'blog_url' => 'http://bordeaux.afup.org/',
                 'linkedin' => 'afup-bordeaux',
                 'bluesky' => 'bordeaux.afup.org',
                 'map' => [


### PR DESCRIPTION
On va rediriger bordeaux.afup.org vers la page meetup et donc supprimer le blog, on enlève donc le lien vers celui-ci depuis la page des antennes.