### PR TITLE
ajout du bouton d'export des justificatifs depuis le journal

### DIFF
--- a/htdocs/templates/administration/compta_banque.html
+++ b/htdocs/templates/administration/compta_banque.html
@@ -36,10 +36,6 @@
                 <i class="icon file excel"></i>
                 Export XLSX
             </a>
-            <a href="index.php?id_periode={$smarty.get.id_periode}&amp;page=compta_banque&amp;compte={$compte_id}&amp;action=download_attachments" class="item">
-                <i class="icon file zip"></i>
-                Télécharger les justificatifs triés par mois
-            </a>
         </div>
 
         <table class="ui table striped compact celled">

--- a/htdocs/templates/administration/compta_journal.html
+++ b/htdocs/templates/administration/compta_journal.html
@@ -59,6 +59,10 @@
             <i class="icon file"></i>
             Exporter la période en CSV
         </a>
+        <a href="index.php?page=compta_banque&amp;action=download_attachments&amp;id_periode={$smarty.get.id_periode}" class="item">
+            <i class="icon file zip"></i>
+            Télécharger les justificatifs groupés par mois
+        </a>
     </div>
 
     <div class="ui top attached tabular menu">


### PR DESCRIPTION
On avait un bouton d'export des justificatifs sur la page des comptes. Il était mal nommé et passait en paramètre l'id du compte, mais sans l'utiliser Cela est plus logique de l'avoir sur la page journal, non filtrée sur un compte, et plus utilisée. On le déplace donc en le renommant et supprimant le paramètre compte non utilisé.