### PR TITLE
corrige l'enregistrement des venues speakers

### DIFF
--- a/sources/AppBundle/Event/Speaker/SpeakerPage.php
+++ b/sources/AppBundle/Event/Speaker/SpeakerPage.php
@@ -94,8 +94,8 @@ class SpeakerPage
 
         if ($shouldDisplaySpeakersDinerForm && $speakersDinerType->isValid()) {
             $speakersDinerData = $speakersDinerType->getData();
-            $speaker->setWillAttendSpeakersDiner($speakersDinerData['will_attend']);
-            $speaker->setHasSpecialDiet($speakersDinerData['has_special_diet']);
+            $speaker->setWillAttendSpeakersDiner($speakersDinerData['will_attend'] === 1);
+            $speaker->setHasSpecialDiet($speakersDinerData['has_special_diet'] === 1);
             $speaker->setSpecialDietDescription($speakersDinerData['special_diet_description']);
             $this->speakerRepository->save($speaker);
             $this->flashBag->add('notice', 'Informations sur votre venue au restaurant des speakers enregistrées');

--- a/tests/behat/features/EventPages/SpeakerInfos.feature
+++ b/tests/behat/features/EventPages/SpeakerInfos.feature
@@ -20,7 +20,11 @@ Feature: Event > Profil speaker
     Then I fill in "speakers_diner[special_diet_description]" with "Je suis végétarien"
     And I press "Enregistrer mes préférences pour le restaurant"
     Then I should see "Informations sur votre venue au restaurant des speakers enregistrées"
-    Then I should see "Je suis végétarien"
+    And the "speakers_diner_will_attend_0" checkbox should be checked
+    And the "speakers_diner_will_attend_1" checkbox should be unchecked
+    And the "speakers_diner_has_special_diet_0" checkbox should be unchecked
+    And the "speakers_diner_has_special_diet_1" checkbox should be checked
+    And I should see "Je suis végétarien"
 
     When I check "hotel_reservation_nights_0"
     And I press "Enregistrer les nuitées"


### PR DESCRIPTION
Un speaker à remonter un problème lié à l'enregistrement de ses préférences pour sa venus :

> quand on renseigne sa venue au restaurant et qu’on clique sur “enregistrer”, on a bien le message “Informations sur votre venue au restaurant des speakers enregistrées” mais dans le BO, on n’a aucune info qui apparait en page “venue speakers” et le questionnaire est également vide quand on retourne sur le profil du speaker.

Le problème est lié au typehint des champs `Speaker->willAttendSpeakersDiner` et `Speaker->hasSpecialDiet`.

J'ai aussi amélioré le test behat.