### PR TITLE
Corrige amélioration indexation Google

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -8,7 +8,9 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge">
         {% endblock %}
         {% block canonical %}
+            {% if app.request.attributes.get('_route') %}
             <link rel="canonical" href="{{ url(app.request.attributes.get('_route'), app.request.attributes.get('_route_params')) }}" />
+            {% endif %}
         {% endblock %}
         <title>{% block title %}Afup{% endblock %}</title>
         {% block stylesheets %}


### PR DESCRIPTION
Depuis la dernière MEP, nous avons des erreurs en PROD : 

> Exception thrown when handling an exception (Twig\Error\RuntimeError: An exception has been thrown during the rendering of a template ("Unable to generate a URL for the named route "" as such route does not exist."). at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/app/Resources/views/base.html.twig line 11)

Cette MR corrige le problème.