### PR TITLE
Rangement des controllers et amélioration de l'extension Twig

### DIFF
--- a/app/Resources/views/admin/association/membership/_company_menu.html.twig
+++ b/app/Resources/views/admin/association/membership/_company_menu.html.twig
@@ -7,17 +7,17 @@
         },
         {
             "nom" : "Coordonnées",
-            "lien": path('admin_company'),
+            "lien": path('member_company'),
             'is_active': current == "contact",
         },
         {
             "nom": "Membres",
-            "lien": path('admin_company_members'),
+            "lien": path('member_company_members'),
             "is_active": current == "members",
         },
         {
             "nom": "Profil public",
-            "lien": path('admin_company_public_profile'),
+            "lien": path('member_company_public_profile'),
             "is_active": current == "public_profile",
         },
     ]

--- a/app/Resources/views/admin/association/membership/register.html.twig
+++ b/app/Resources/views/admin/association/membership/register.html.twig
@@ -4,7 +4,7 @@
 
 {% block submenu %}
     {{ render(controller(
-        'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+        'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
         { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_ASSOCIATION') }
     )) }}
 {% endblock %}

--- a/app/Resources/views/site/base.html.twig
+++ b/app/Resources/views/site/base.html.twig
@@ -79,7 +79,7 @@
                         </div>
                         <div class="col-md-6 tablet-hidden">
                             <label class="pre-footer-newsletter-title" for="subscriber_email">Inscription à la newsletter</label>
-                            {{ render(controller('AppBundle:Newsletter:subscribeForm')) }}
+                            {{ render(controller('AppBundle:Website\\Newsletter:subscribeForm')) }}
                             <span class="pre-footer-newsletter-caption">Tous les trois mois, des nouvelles de L'AFUP</span>
                         </div>
                         <div class="col-md-1 pre-footer-icon">

--- a/app/Resources/views/site/become_member.html.twig
+++ b/app/Resources/views/site/become_member.html.twig
@@ -10,7 +10,7 @@
 
 {% block content %}
 {{ render(controller(
-    'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+    'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
     { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_ASSOCIATION') }
 )) }}
 <div class="mw1400p center" id="container">

--- a/app/Resources/views/site/cms_page/display.html.twig
+++ b/app/Resources/views/site/cms_page/display.html.twig
@@ -9,7 +9,7 @@
 
 {% block content %}
 {{ render(controller(
-    'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+    'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
     { 'feuille_id': rubrique.feuille_associee }
 )) }}
 <div class="mw1400p center" id="container">

--- a/app/Resources/views/site/company_membership/adhesion_entreprise.html.twig
+++ b/app/Resources/views/site/company_membership/adhesion_entreprise.html.twig
@@ -4,7 +4,7 @@
 
 {% block submenu %}
     {{ render(controller(
-        'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+        'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
         { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_ASSOCIATION') }
     )) }}
 {% endblock %}

--- a/app/Resources/views/site/meetups/list.html.twig
+++ b/app/Resources/views/site/meetups/list.html.twig
@@ -26,7 +26,7 @@
 
 {% block content %}
     {{ render(controller(
-        'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+        'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
         { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_ANTENNES') }
     )) }}
 

--- a/app/Resources/views/site/member/index.html.twig
+++ b/app/Resources/views/site/member/index.html.twig
@@ -181,7 +181,7 @@
         <div class="container">
             <div class="col-md-6 col-sm-12">
                 <div class="member-index-item">
-                    {% set href = path('admin_company') %}
+                    {% set href = path('member_company') %}
                     <a href="{{ href }}">
                         <i class="fa fa-building"></i>
                     </a>
@@ -195,21 +195,21 @@
 
             <div class="col-md-6 col-sm-12">
                 <div class="member-index-item">
-                    {% set href = path('admin_company_members') %}
+                    {% set href = path('member_company_members') %}
                     <a href="{{ href }}">
                         <i class="fa fa-users"></i>
                     </a>
                     <span class="member-index-item--title">Personnes rattachées</span>
                     <div class="member-index-item--link">
                         <a class="button-inverted button__medium" title="Modifier les personnes rattachées"
-                           href="{{ path('admin_company_members') }}">Modifier</a>
+                           href="{{ path('member_company_members') }}">Modifier</a>
                     </div>
                 </div>
             </div>
 
             <div class="col-md-6 col-sm-12">
                 <div class="member-index-item">
-                    {% set href = path('admin_company_public_profile') %}
+                    {% set href = path('member_company_public_profile') %}
                     <a href="">
                         <i class="fa fa-address-card"></i>
                     </a>

--- a/app/Resources/views/site/news/list.html.twig
+++ b/app/Resources/views/site/news/list.html.twig
@@ -30,7 +30,7 @@
                     {% endif %}
 
                     {{ render(controller(
-                        'AppBundle\\Controller\\PagerController::displayAction',
+                        'AppBundle\\Controller\\Website\\PagerController::displayAction',
                         {
                             'total_items': total_items,
                             'current_page': current_page,

--- a/app/Resources/views/site/offices.html.twig
+++ b/app/Resources/views/site/offices.html.twig
@@ -289,7 +289,7 @@
 
 {% block content %}
 {{ render(controller(
-    'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+    'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
     { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_ANTENNES') }
 )) }}
 <div class="mw1400p center" id="container">

--- a/app/Resources/views/site/techletter/index.html.twig
+++ b/app/Resources/views/site/techletter/index.html.twig
@@ -10,7 +10,7 @@
 
 {% block content %}
 {{ render(controller(
-    'AppBundle\\Controller\\SecondaryMenuController::displayAction',
+    'AppBundle\\Controller\\Website\\SecondaryMenuController::displayAction',
     { 'feuille_id': constant('Afup\\Site\\Corporate\\Feuille::ID_FEUILLE_NOS_ACTIONS') }
 )) }}
 

--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -67,7 +67,7 @@ company_public_profile_list:
 
 feed_rss:
     path: /rss.xml
-    defaults: { _controller: AppBundle\Controller\RssFeedController }
+    defaults: { _controller: AppBundle\Controller\Website\RssFeedController }
 
 presta_sitemap:
     resource: "@PrestaSitemapBundle/Resources/config/routing.yml"

--- a/app/config/routing/admin.yml
+++ b/app/config/routing/admin.yml
@@ -4,7 +4,7 @@ admin_home:
 
 admin_vote:
   path: /vote/
-  defaults: {_controller: AppBundle:Vote:admin}
+  defaults: {_controller: AppBundle:Admin\Vote:admin}
 
 admin_relances:
   path: /association/relances/{page}
@@ -44,10 +44,6 @@ admin_speaker_routes:
 admin_planete_routes:
   resource: "admin_planete.yml"
   prefix: /planete
-
-member_slack_invite:
-  path: /member/slack-invite
-  defaults: {_controller: AppBundle:MemberShip:slackInviteRequest}
 
 admin_members_reporting:
   path: /members/reporting

--- a/app/config/routing/blog.yml
+++ b/app/config/routing/blog.yml
@@ -4,16 +4,16 @@
 
 program:
   path: /{eventSlug}/program
-  defaults: {_controller: AppBundle:Blog:program}
+  defaults: {_controller: AppBundle:Event\Blog:program}
 
 speakers:
   path: /{eventSlug}/speakers
-  defaults: {_controller: AppBundle:Blog:speakers}
+  defaults: {_controller: AppBundle:Event\Blog:speakers}
 
 planning:
   path: /{eventSlug}/planning
-  defaults: {_controller: AppBundle:Blog:planning}
+  defaults: {_controller: AppBundle:Event\Blog:planning}
 
 talk_widget:
   path: /talk_widget
-  defaults: {_controller: AppBundle:Blog:talkWidget}
+  defaults: {_controller: AppBundle:Event\Blog:talkWidget}

--- a/app/config/routing/cms_page.yml
+++ b/app/config/routing/cms_page.yml
@@ -1,3 +1,3 @@
 cms_page_display:
   path: /{code}
-  defaults: {_controller: AppBundle:CmsPage:display}
+  defaults: { _controller: AppBundle:Website\CmsPage:display }

--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -1,149 +1,149 @@
 event_index:
   path: /
-  defaults: {_controller: AppBundle:Event:index}
+  defaults: { _controller: AppBundle:Event\Event:index }
   options:
     sitemap: true
 
 event_index_speaker_infos:
   path: /speaker-infos
-  defaults: {_controller: AppBundle:Event:speakerInfosIndex}
+  defaults: { _controller: AppBundle:Event\Event:speakerInfosIndex }
 
 event:
   path: /{eventSlug}
-  defaults: {_controller: AppBundle:Event:event}
+  defaults: { _controller: AppBundle:Event\Event:event }
 
 vote_index:
   path: /{eventSlug}/vote
-  defaults: {_controller: AppBundle:Vote:index, all: false, page: 1}
+  defaults: { _controller: AppBundle:Admin\Vote:index, all: false, page: 1 }
 
 vote_index_paginated:
   path: /{eventSlug}/vote/{page}
-  defaults: {_controller: AppBundle:Vote:index, all: false}
+  defaults: { _controller: AppBundle:Admin\Vote:index, all: false }
   requirements:
     page: '\d+'
 
 vote_all:
   path: /{eventSlug}/vote-all
-  defaults: {_controller: AppBundle:Vote:index, all: true, page: 1}
+  defaults: { _controller: AppBundle:Admin\Vote:index, all: true, page: 1 }
 
 speaker-suggestion:
   path: /{eventSlug}/speaker-suggestion
-  defaults: {_controller: AppBundle:SpeakerSuggestion:index }
+  defaults: { _controller: AppBundle:Event\SpeakerSuggestion:index }
 
 vote_all_paginated:
   path: /{eventSlug}/vote-all/{page}
-  defaults: {_controller: AppBundle:Vote:index, all: true}
+  defaults: { _controller: AppBundle:Admin\Vote:index, all: true }
   requirements:
     page: '\d+'
 
 vote_new:
   path: /{eventSlug}/vote/new/{talkId}
-  defaults: {_controller: AppBundle:Vote:new}
-  methods:  [POST]
+  defaults: { _controller: AppBundle:Event\Vote:new }
+  methods: [ POST ]
   requirements:
     talkId: '\d+'
 
 cfp:
   path: /{eventSlug}/cfp
-  defaults: {_controller: AppBundle\Controller\Event\CFP\IndexAction}
+  defaults: { _controller: AppBundle\Controller\Event\CFP\IndexAction }
 
 cfp_speaker:
   path: /{eventSlug}/cfp/speaker
-  defaults: {_controller: AppBundle\Controller\Event\CFP\SpeakerAction}
+  defaults: { _controller: AppBundle\Controller\Event\CFP\SpeakerAction }
 
 cfp_propose:
   path: /{eventSlug}/cfp/propose
-  defaults: {_controller: AppBundle\Controller\Event\CFP\ProposeAction}
+  defaults: { _controller: AppBundle\Controller\Event\CFP\ProposeAction }
 
 cfp_edit:
   path: /{eventSlug}/cfp/{talkId}
-  defaults: {_controller: AppBundle\Controller\Event\CFP\EditAction}
+  defaults: { _controller: AppBundle\Controller\Event\CFP\EditAction }
   requirements:
     talkId: '\d+'
 
 cfp_invite:
   path: /{eventSlug}/cfp/invite/{talkId}-{token}
-  defaults: {_controller: AppBundle\Controller\Event\CFP\InviteAction}
+  defaults: { _controller: AppBundle\Controller\Event\CFP\InviteAction }
   requirements:
     talkId: '\d+'
     token: '.+'
 
 sponsor_ticket_home:
   path: /{eventSlug}/tickets/sponsor
-  defaults: {_controller: AppBundle:Ticket:sponsorTicket}
+  defaults: { _controller: AppBundle:Event\Ticket:sponsorTicket }
 
 sponsor_ticket_form:
   path: /{eventSlug}/tickets/sponsor-form
-  defaults: {_controller: AppBundle:Ticket:sponsorTicketForm}
+  defaults: { _controller: AppBundle:Event\Ticket:sponsorTicketForm }
 
 ticket:
   path: /{eventSlug}/tickets
-  defaults: {_controller: AppBundle:Ticket:ticket}
+  defaults: { _controller: AppBundle:Event\Ticket:ticket }
 
 ticket_payment:
   path: /{eventSlug}/tickets/payment
-  defaults: {_controller: AppBundle:Ticket:payment}
+  defaults: { _controller: AppBundle:Event\Ticket:payment }
 
 ticket_paybox_callback:
   path: /{eventSlug}/tickets/paybox-callback
-  defaults: {_controller: AppBundle:Ticket:payboxCallback}
+  defaults: { _controller: AppBundle:Event\Ticket:payboxCallback }
 
 ticket_paybox_redirect:
   path: /{eventSlug}/tickets/paybox-redirect
-  defaults: {_controller: AppBundle:Ticket:payboxRedirect}
+  defaults: { _controller: AppBundle:Event\Ticket:payboxRedirect }
 
 sponsor_leads:
   path: /{eventSlug}/sponsor/become-sponsor
-  defaults: {_controller: AppBundle:Lead:becomeSponsor}
+  defaults: { _controller: AppBundle:Event\Lead:becomeSponsor }
 
 sponsor_leads_post:
   path: /{eventSlug}/sponsor/thank-you
-  defaults: {_controller: AppBundle:Lead:postLead}
+  defaults: { _controller: AppBundle:Event\Lead:postLead }
 
 sponsor_scan:
   path: /{eventSlug}/sponsor/scan
-  defaults: {_controller: AppBundle:SponsorScan:index}
+  defaults: { _controller: AppBundle:Event\SponsorScan:index }
 
 sponsor_scan_export:
   path: /{eventSlug}/sponsor/scan/export
-  defaults: {_controller: AppBundle:SponsorScan:export}
+  defaults: { _controller: AppBundle:Event\SponsorScan:export }
 
 sponsor_scan_new:
   path: /{eventSlug}/sponsor/scan/new
-  defaults: {_controller: AppBundle:SponsorScan:new}
+  defaults: { _controller: AppBundle:Event\SponsorScan:new }
 
 sponsor_scan_flash:
   path: /{eventSlug}/sponsor/scan/flash/{code}
-  defaults: {_controller: AppBundle:SponsorScan:flash}
+  defaults: { _controller: AppBundle:Event\SponsorScan:flash }
 
 sponsor_scan_delete:
   path: /{eventSlug}/sponsor/scan/delete/{scanId}
-  defaults: {_controller: AppBundle:SponsorScan:delete}
+  defaults: { _controller: AppBundle:Event\SponsorScan:delete }
 
 speaker-infos:
   path: /{eventSlug}/speaker-infos
-  defaults: {_controller: AppBundle\Controller\Event\SpeakerPageAction }
+  defaults: { _controller: AppBundle\Controller\Event\SpeakerPageAction }
 
 speaker-infos-files:
   path: /{eventSlug}/speaker-infos/files/{speakerId}/{filename}
-  defaults: {_controller: AppBundle\Controller\Event\SpeakerFilesAction }
+  defaults: { _controller: AppBundle\Controller\Event\SpeakerFilesAction }
 
 planning_ics:
   path: /{eventSlug}/planning.ics
-  defaults: {_controller: AppBundle:Event:planningIcs}
+  defaults: { _controller: AppBundle:Event\Event:planningIcs }
 
 event_calendar_latest:
   path: /latest/calendar
-  defaults: {_controller: AppBundle:Event:calendarLatest}
+  defaults: { _controller: AppBundle:Event\Event:calendarLatest }
 
 event_calendar:
   path: /{eventSlug}/calendar
-  defaults: {_controller: AppBundle:Event:calendar}
+  defaults: { _controller: AppBundle:Event\Event:calendar }
 
 planning_json:
   path: /{eventSlug}/planning.json
-  defaults: {_controller: AppBundle:Event:planningJson}
+  defaults: { _controller: AppBundle:Event\Event:planningJson }
 
 openfeedback_json:
   path: /{eventSlug}/openfeedback.json
-  defaults: {_controller: AppBundle:Event:openfeedbackJson}
+  defaults: { _controller: AppBundle:Event\Event:openfeedbackJson }

--- a/app/config/routing/global.yml
+++ b/app/config/routing/global.yml
@@ -1,15 +1,15 @@
 home:
   path: /home
-  defaults: {_controller: AppBundle:Home:display}
+  defaults: { _controller: AppBundle:Website\Home:display }
   options:
     sitemap: true
 
 become_sponsor_latest:
   path: /become-sponsor
-  defaults: {_controller: AppBundle:Lead:becomeSponsorLatest}
+  defaults: { _controller: AppBundle:Event\Lead:becomeSponsorLatest }
 
 sitemap:
   path: /plan-du-site
-  defaults: { _controller: AppBundle:HtmlSitemap:display }
+  defaults: { _controller: AppBundle:Website\HtmlSitemap:display }
   options:
     sitemap: true

--- a/app/config/routing/meetups.yml
+++ b/app/config/routing/meetups.yml
@@ -1,5 +1,5 @@
 meetups_list:
   path: /
-  defaults: {_controller: AppBundle:Meetups:list}
+  defaults: { _controller: AppBundle:Website\Meetups:list }
   options:
     sitemap: true

--- a/app/config/routing/member.yml
+++ b/app/config/routing/member.yml
@@ -1,56 +1,60 @@
 member_index:
   path: /
-  defaults: {_controller: AppBundle:Member:index}
+  defaults: { _controller: AppBundle:Website\Member:index }
 
 member_contact:
   path: /contact
-  defaults: {_controller: AppBundle:MemberShip:contactDetails}
+  defaults: { _controller: AppBundle:Website\MemberShip:contactDetails }
 
 member_membership_fee:
   path: /membership-fee
-  defaults: {_controller: AppBundle:MemberShip:membershipFee}
+  defaults: { _controller: AppBundle:Website\MemberShip:membershipFee }
 
 member_membership_fee_download:
   path: /membership-fee/download
-  defaults: {_controller: AppBundle:MemberShip:membershipFeeDownload}
+  defaults: { _controller: AppBundle:Website\MemberShip:membershipFeeDownload }
 
 member_membership_fee_send_mail:
   path: /membership-fee/send-mail
-  defaults: {_controller: AppBundle:MemberShip:membershipFeeSendMail}
+  defaults: { _controller: AppBundle:Website\MemberShip:membershipFeeSendMail }
 
 member_general_meeting:
   path: /general-meeting
-  defaults: {_controller: AppBundle:MemberShip:generalMeeting}
+  defaults: { _controller: AppBundle:Website\MemberShip:generalMeeting }
 
 member_general_meeting_vote:
   path: /general-meeting/vote
-  defaults: {_controller: AppBundle:MemberShip:generalMeetingVote}
+  defaults: { _controller: AppBundle:Website\MemberShip:generalMeetingVote }
 
 member_general_meeting_reports_download:
   path: /general-meeting-report-download/{filename}
-  defaults: {_controller: AppBundle:MemberShip:generalMettingDownloadReport}
+  defaults: { _controller: AppBundle:Website\MemberShip:generalMettingDownloadReport }
 
 member_techletter:
   path: /techletter
-  defaults: {_controller: AppBundle:MemberShip:techletter}
+  defaults: { _controller: AppBundle:Website\MemberShip:techletter }
 
 member_techletter_unsubscribe:
   path: /techletter-unsubscribe
-  defaults: {_controller: AppBundle:MemberShip:techletterUnsubscribe}
+  defaults: { _controller: AppBundle:Website\MemberShip:techletterUnsubscribe }
 
 member_techletter_subscribe:
   path: /techletter-subscribe
-  defaults: {_controller: AppBundle:MemberShip:techletterSubscribe}
-  methods: ["POST"]
+  defaults: { _controller: AppBundle:Website\MemberShip:techletterSubscribe }
+  methods: [ "POST" ]
 
-admin_company:
+member_slack_invite:
+  path: /slack-invite
+  defaults: {_controller: AppBundle:Website\MemberShip:slackInviteRequest}
+
+member_company:
   path: /company
-  defaults: {_controller: AppBundle\Controller\Admin\Membership\CompanyAction}
+  defaults: { _controller: AppBundle\Controller\Website\Member\CompanyController }
 
-admin_company_members:
+member_company_members:
   path: /company/members/{id}
-  defaults: {_controller: AppBundle\Controller\Admin\Membership\MembersAction, id: ~}
+  defaults: { _controller: AppBundle\Controller\Website\Member\MembersController, id: ~ }
 
-admin_company_public_profile:
+member_company_public_profile:
   path: /company/public_profile
-  defaults: {_controller: AppBundle:Website\Member\CompanyPublicProfile:index }
+  defaults: { _controller: AppBundle:Website\Member\CompanyPublicProfile:index }

--- a/app/config/routing/news.yml
+++ b/app/config/routing/news.yml
@@ -1,10 +1,10 @@
 news_list:
   path: /
-  defaults: {_controller: AppBundle:News:list}
+  defaults: { _controller: AppBundle:Website\News:list }
   options:
     sitemap: true
 
 news_display:
   path: /{code}
-  defaults: {_controller: AppBundle:News:display}
+  defaults: { _controller: AppBundle:Website\News:display }
 

--- a/app/config/routing/site.yml
+++ b/app/config/routing/site.yml
@@ -1,70 +1,70 @@
 become_member:
   path: /devenir-membre
-  defaults: {_controller: AppBundle:MemberShip:becomeMember}
+  defaults: { _controller: AppBundle:Website\MemberShip:becomeMember }
   options:
     sitemap: true
 
 company_membership:
   path: /adherer/entreprise
-  defaults: {_controller: AppBundle:MemberShip:company}
+  defaults: { _controller: AppBundle:Website\MemberShip:company }
   options:
     sitemap: true
 
 member_membership:
   path: /adherer/particulier
-  defaults: {_controller: AppBundle:MemberShip:member}
+  defaults: { _controller: AppBundle:Website\MemberShip:member }
   options:
     sitemap: true
 
 company_membership_payment:
   path: /adherer/entreprise/paiement-{invoiceNumber}-{token}
-  defaults: {_controller: AppBundle:MemberShip:payment}
+  defaults: { _controller: AppBundle:Website\MemberShip:payment }
   requirements:
     invoiceNumber: 'COTIS-[0-9]{4}-[0-9]+'
     token: '.+'
 
 company_membership_invoice:
   path: /adherer/entreprise/invoice-{invoiceNumber}-{token}
-  defaults: {_controller: AppBundle:MemberShip:invoice}
+  defaults: { _controller: AppBundle:Website\MemberShip:invoice }
   requirements:
     invoiceNumber: 'COTIS-[0-9]{4}-[0-9]+'
     token: '.+'
 
 company_invitation:
   path: /adherer/invitation/{invitationId}-{token}
-  defaults: {_controller: AppBundle:MemberShip:memberInvitation}
+  defaults: { _controller: AppBundle:Website\MemberShip:memberInvitation }
   requirements:
     invitationId: '\d+'
     token: '.+'
 
 offices:
   path: /antennes
-  defaults: {_controller: AppBundle:Static:offices}
+  defaults: { _controller: AppBundle:Website\Static:offices }
   options:
     sitemap: true
 
 superapero:
   path: /super-apero
-  defaults: {_controller: AppBundle:Static:superApero}
+  defaults: { _controller: AppBundle:Website\Static:superApero }
   options:
     sitemap: true
 
 void:
   path: /void-route
-  defaults: {_controller: AppBundle:Static:void}
+  defaults: { _controller: AppBundle:Website\Static:void }
 
 newsletter_subscribe:
   path: /newsletter-subscribe
-  defaults: {_controller: AppBundle:Newsletter:subscribe}
+  defaults: { _controller: AppBundle:Website\Newsletter:subscribe }
 
 membership_payment:
   path: /paybox-callback
-  defaults: {_controller: AppBundle:MemberShip:payboxCallback}
+  defaults: { _controller: AppBundle:Website\MemberShip:payboxCallback }
 
 membership_payment_redirect:
   path: /paybox-redirect/{type}
   defaults:
-    _controller: AppBundle\Controller\PayboxRedirectAction:index
+    _controller: AppBundle:Website\PayboxRedirect:index
     type: success
   requirements:
     type: success|error|canceled|refused
@@ -72,11 +72,11 @@ membership_payment_redirect:
 
 techletter:
   path: /techletter
-  defaults: {_controller: AppBundle:Techletter:index}
+  defaults: { _controller: AppBundle:Website\Techletter:index }
   options:
     sitemap: true
 
 techletter_webhook:
   path: /techletter/webhook
-  defaults: {_controller: AppBundle:Techletter:webhook }
-  methods: ["GET", "POST"]
+  defaults: { _controller: AppBundle:Website\Techletter:webhook }
+  methods: [ "GET", "POST" ]

--- a/app/config/routing/talks.yml
+++ b/app/config/routing/talks.yml
@@ -1,6 +1,6 @@
 talks_list:
   path: /
-  defaults: {_controller: AppBundle:Talks:list}
+  defaults: { _controller: AppBundle:Website\Talks:list }
   options:
     sitemap:
       section: talks
@@ -8,8 +8,8 @@ talks_list:
 
 talks_show:
   path: /{id}-{slug}
-  defaults: {_controller: AppBundle:Talks:show}
+  defaults: { _controller: AppBundle:Website\Talks:show }
 
 talks_joindin:
   path: /{id}-{slug}/joindin
-  defaults: {_controller: AppBundle:Talks:joindin}
+  defaults: { _controller: AppBundle:Website\Talks:joindin }

--- a/app/config/routing/techletter.yml
+++ b/app/config/routing/techletter.yml
@@ -1,3 +1,3 @@
 calendar:
   path: /calendar
-  defaults: {_controller: AppBundle:TechnoWatch:calendar}
+  defaults: { _controller: AppBundle:Website\TechnoWatch:calendar }

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -43,6 +43,11 @@ services:
         autowire: true
         autoconfigure: true
 
+    AppBundle\Controller\Website\:
+        resource: '../../sources/AppBundle/Controller/Website/*'
+        autowire: true
+        autoconfigure: true
+
     AppBundle\Command\GeneralMeetupNotificationCommand:
         autowire: true
         autoconfigure: true
@@ -99,24 +104,10 @@ services:
         arguments:
           $backOfficePages: '%app.pages_backoffice%'
 
-    AppBundle\Controller\BlocksHandler: ~
-
     AppBundle\Security\MyGithubAuthenticator:
         autowire: true
 
     AppBundle\Security\TestGithubAuthenticator:
-        autowire: true
-
-    AppBundle\Controller\LeadController:
-        autowire: true
-
-    AppBundle\Controller\HtmlSitemapController:
-        autowire: true
-
-    AppBundle\Controller\SpeakerSuggestionController:
-        autowire: true
-
-    AppBundle\Controller\PayboxRedirectAction:
         autowire: true
 
     AppBundle\Controller\Admin\TechLetter\TechLetterGenerateController:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -21,7 +21,7 @@ parameters:
 
     ignoreErrors:
         -
-            message: '#^Method AppBundle\\Controller\\SiteBaseController\:\:render\(\) overrides @final method Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller\:\:render\(\)\.$#'
+            message: '#^Method AppBundle\\Controller\\Website\\SiteBaseController\:\:render\(\) overrides @final method Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller\:\:render\(\)\.$#'
             identifier: method.parentMethodFinalByPhpDoc
             count: 1
-            path: sources/AppBundle/Controller/SiteBaseController.php
+            path: sources/AppBundle/Controller/Website/SiteBaseController.php

--- a/sources/AppBundle/Controller/Admin/LoginAction.php
+++ b/sources/AppBundle/Controller/Admin/LoginAction.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Controller\Admin;
 
-use AppBundle\Controller\BlocksHandler;
+use AppBundle\Controller\Website\BlocksHandler;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;

--- a/sources/AppBundle/Controller/Admin/LostPasswordAction.php
+++ b/sources/AppBundle/Controller/Admin/LostPasswordAction.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Controller\Admin;
 
 use AppBundle\Association\UserMembership\UserService;
-use AppBundle\Controller\BlocksHandler;
+use AppBundle\Controller\Website\BlocksHandler;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/sources/AppBundle/Controller/Admin/Site/AddRubriqueAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/AddRubriqueAction.php
@@ -3,10 +3,10 @@
 namespace AppBundle\Controller\Admin\Site;
 
 use Afup\Site\Logger\DbLoggerTrait;
-use AppBundle\Controller\SiteBaseController;
 use AppBundle\Site\Form\RubriqueType;
 use AppBundle\Site\Model\Repository\RubriqueRepository;
 use AppBundle\Site\Model\Rubrique;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,7 +14,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
-class AddRubriqueAction extends SiteBaseController
+class AddRubriqueAction extends Controller
 {
     use DbLoggerTrait;
 

--- a/sources/AppBundle/Controller/Admin/Site/EditRubriqueAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/EditRubriqueAction.php
@@ -3,9 +3,9 @@
 namespace AppBundle\Controller\Admin\Site;
 
 use Afup\Site\Logger\DbLoggerTrait;
-use AppBundle\Controller\SiteBaseController;
 use AppBundle\Site\Form\RubriqueType;
 use AppBundle\Site\Model\Repository\RubriqueRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
-class EditRubriqueAction extends SiteBaseController
+class EditRubriqueAction extends Controller
 {
     use DbLoggerTrait;
 

--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Controller\Admin\TechLetter;
 
 use AppBundle\Association\Model\Repository\TechletterSubscriptionsRepository;
-use AppBundle\Controller\SiteBaseController;
 use AppBundle\Email\Mailer\Mailer;
 use AppBundle\Email\Mailer\MailUser;
 use AppBundle\Email\Mailer\Message;
@@ -11,6 +10,7 @@ use AppBundle\TechLetter\DataExtractor;
 use AppBundle\TechLetter\Form\SendingType;
 use AppBundle\TechLetter\Model as Techletter;
 use AppBundle\TechLetter\Model\Repository\SendingRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class TechLetterGenerateController extends SiteBaseController
+class TechLetterGenerateController extends Controller
 {
     /** @var SendingRepository */
     private $sendingRepository;

--- a/sources/AppBundle/Controller/Admin/VoteController.php
+++ b/sources/AppBundle/Controller/Admin/VoteController.php
@@ -1,9 +1,9 @@
 <?php
 
-
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Admin;
 
 use AppBundle\Controller\Event\EventActionHelper;
+use AppBundle\Controller\Event\EventBaseController;
 use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\VoteType;
 use AppBundle\Event\Model\Repository\TalkRepository;

--- a/sources/AppBundle/Controller/Event/BlogController.php
+++ b/sources/AppBundle/Controller/Event/BlogController.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Event\Model\Planning;
 use AppBundle\Event\Model\Repository\SpeakerRepository;

--- a/sources/AppBundle/Controller/Event/EventBaseController.php
+++ b/sources/AppBundle/Controller/Event/EventBaseController.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;

--- a/sources/AppBundle/Controller/Event/EventController.php
+++ b/sources/AppBundle/Controller/Event/EventController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Calendar\IcsPLanningGenerator;
 use AppBundle\Calendar\JsonPlanningGenerator;

--- a/sources/AppBundle/Controller/Event/LeadController.php
+++ b/sources/AppBundle/Controller/Event/LeadController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Email\Mailer\Mailer;
 use AppBundle\Email\Mailer\MailUserFactory;

--- a/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
+++ b/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Email\Mailer\Mailer;
 use AppBundle\Email\Mailer\MailUserFactory;

--- a/sources/AppBundle/Controller/Event/SponsorScanController.php
+++ b/sources/AppBundle/Controller/Event/SponsorScanController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Controller\Exception\InvalidSponsorTokenException;
 use AppBundle\Event\Form\SponsorScanType;

--- a/sources/AppBundle/Controller/Event/TicketController.php
+++ b/sources/AppBundle/Controller/Event/TicketController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Event;
 
 use Afup\Site\Forum\Facturation;
 use Afup\Site\Utils\Utils;

--- a/sources/AppBundle/Controller/Website/BlocksHandler.php
+++ b/sources/AppBundle/Controller/Website/BlocksHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 class BlocksHandler
 {

--- a/sources/AppBundle/Controller/Website/CmsPageController.php
+++ b/sources/AppBundle/Controller/Website/CmsPageController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Corporate\Article;
 use Afup\Site\Corporate\Rubrique;

--- a/sources/AppBundle/Controller/Website/CompanyPublicProfileController.php
+++ b/sources/AppBundle/Controller/Website/CompanyPublicProfileController.php
@@ -5,7 +5,6 @@ namespace AppBundle\Controller\Website;
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
 use AppBundle\Association\UserMembership\BadgesComputer;
-use AppBundle\Controller\SiteBaseController;
 use AppBundle\Offices\OfficesCollection;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 

--- a/sources/AppBundle/Controller/Website/CompanyPublicProfileListController.php
+++ b/sources/AppBundle/Controller/Website/CompanyPublicProfileListController.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller\Website;
 
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
-use AppBundle\Controller\SiteBaseController;
 
 class CompanyPublicProfileListController extends SiteBaseController
 {

--- a/sources/AppBundle/Controller/Website/HomeController.php
+++ b/sources/AppBundle/Controller/Website/HomeController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Corporate\Articles;
 use Afup\Site\Corporate\Branche;

--- a/sources/AppBundle/Controller/Website/HtmlSitemapController.php
+++ b/sources/AppBundle/Controller/Website/HtmlSitemapController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Corporate\Branche;
 use Afup\Site\Corporate\Feuille;

--- a/sources/AppBundle/Controller/Website/MeetupsController.php
+++ b/sources/AppBundle/Controller/Website/MeetupsController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Symfony\Component\HttpFoundation\Request;
 

--- a/sources/AppBundle/Controller/Website/Member/CompanyController.php
+++ b/sources/AppBundle/Controller/Website/Member/CompanyController.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace AppBundle\Controller\Admin\Membership;
+namespace AppBundle\Controller\Website\Member;
 
 use AppBundle\Association\Form\AdminCompanyMemberType;
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
 use AppBundle\Association\Model\User;
-use AppBundle\Controller\BlocksHandler;
+use AppBundle\Controller\Website\BlocksHandler;
 use Assert\Assertion;
 use Exception;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -19,7 +19,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Security;
 use Twig\Environment;
 
-class CompanyAction
+class CompanyController
 {
     /** @var CompanyMemberRepository */
     private $companyMemberRepository;
@@ -77,7 +77,7 @@ class CompanyAction
                 $this->flashBag->add('error', 'Une erreur est survenue. Merci de nous contacter.');
             }
 
-            return new RedirectResponse($this->urlGenerator->generate('admin_company'));
+            return new RedirectResponse($this->urlGenerator->generate('member_company'));
         }
 
         return new Response($this->twig->render('admin/association/membership/company.html.twig', [

--- a/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
+++ b/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
@@ -5,7 +5,7 @@ namespace AppBundle\Controller\Website\Member;
 use AppBundle\Association\Form\CompanyPublicProfile;
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
-use AppBundle\Controller\SiteBaseController;
+use AppBundle\Controller\Website\SiteBaseController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -75,7 +75,7 @@ class CompanyPublicProfileController extends SiteBaseController
             $companyRepository->save($companyMember);
 
             $this->addFlash('success', 'Modifications enregistrées');
-            return $this->redirectToRoute('admin_company_public_profile');
+            return $this->redirectToRoute('member_company_public_profile');
         }
 
         return $this->render(

--- a/sources/AppBundle/Controller/Website/Member/MembersController.php
+++ b/sources/AppBundle/Controller/Website/Member/MembersController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller\Admin\Membership;
+namespace AppBundle\Controller\Website\Member;
 
 use AppBundle\Association\CompanyMembership\InvitationMail;
 use AppBundle\Association\CompanyMembership\UserCompany;
@@ -11,7 +11,7 @@ use AppBundle\Association\Model\Repository\CompanyMemberInvitationRepository;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
 use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Association\Model\User;
-use AppBundle\Controller\BlocksHandler;
+use AppBundle\Controller\Website\BlocksHandler;
 use AppBundle\Model\CollectionFilter;
 use Assert\Assertion;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 
-class MembersAction
+class MembersController
 {
     /** @var CompanyMemberRepository */
     private $companyMemberRepository;
@@ -124,7 +124,7 @@ class MembersAction
                 } else {
                     $this->flashBag->add('error', 'Vous avez atteint le nombre maximum de membres');
                 }
-            } elseif (!$this->csrfTokenManager->isTokenValid(new CsrfToken('admin_company_members', $request->request->get('token')))) {
+            } elseif (!$this->csrfTokenManager->isTokenValid(new CsrfToken('member_company_members', $request->request->get('token')))) {
                 $this->flashBag->add('error', 'Erreur lors de la soumission du formulaire (jeton CSRF invalide). Merci de réessayer.');
             } elseif ($request->request->has('delete_invitation')) {
                 $this->removeInvitation($request->request->get('delete_invitation'), $pendingInvitations);
@@ -138,7 +138,7 @@ class MembersAction
                 $this->removeUser($request->request->get('remove'), $users);
             }
 
-            return new RedirectResponse($this->urlGenerator->generate('admin_company_members', [
+            return new RedirectResponse($this->urlGenerator->generate('member_company_members', [
                 'id' => $this->security->isGranted('ROLE_SUPER_ADMIN') ? $companyId : null,
             ]));
         }
@@ -150,7 +150,7 @@ class MembersAction
             'formInvitation' => $invitationForm->createView(),
             'company' => $company,
             'canAddUser' => $canAddUser,
-            'token' => $this->csrfTokenManager->getToken('admin_company_members'),
+            'token' => $this->csrfTokenManager->getToken('member_company_members'),
         ] + $this->blocksHandler->getDefaultBlocks()));
     }
 

--- a/sources/AppBundle/Controller/Website/MemberController.php
+++ b/sources/AppBundle/Controller/Website/MemberController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Association\Model\Repository\GeneralMeetingQuestionRepository;
 use AppBundle\Association\Model\Repository\TechletterSubscriptionsRepository;

--- a/sources/AppBundle/Controller/Website/MemberShipController.php
+++ b/sources/AppBundle/Controller/Website/MemberShipController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Association\Cotisations;
 use Afup\Site\Logger\DbLoggerTrait;

--- a/sources/AppBundle/Controller/Website/NewsController.php
+++ b/sources/AppBundle/Controller/Website/NewsController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Site\Form\NewsFiltersType;

--- a/sources/AppBundle/Controller/Website/NewsletterController.php
+++ b/sources/AppBundle/Controller/Website/NewsletterController.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Mailchimp\Mailchimp;
 use AppBundle\Mailchimp\SubscriberType;

--- a/sources/AppBundle/Controller/Website/PagerController.php
+++ b/sources/AppBundle/Controller/Website/PagerController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;

--- a/sources/AppBundle/Controller/Website/PayboxRedirectController.php
+++ b/sources/AppBundle/Controller/Website/PayboxRedirectController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Payment\PayboxResponseFactory;
 use Symfony\Component\HttpFoundation\Request;
 
-class PayboxRedirectAction extends SiteBaseController
+class PayboxRedirectController extends SiteBaseController
 {
-    public function index(Request $request, $type = 'success')
+    public function indexAction(Request $request, $type = 'success')
     {
         $payboxResponse = PayboxResponseFactory::createFromRequest($request);
 

--- a/sources/AppBundle/Controller/Website/RssFeedController.php
+++ b/sources/AppBundle/Controller/Website/RssFeedController.php
@@ -1,12 +1,13 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Site\Model\Article;
 use AppBundle\Site\Model\Repository\ArticleRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
 
-class RssFeedController extends SiteBaseController
+class RssFeedController extends Controller
 {
     public function __invoke()
     {

--- a/sources/AppBundle/Controller/Website/SecondaryMenuController.php
+++ b/sources/AppBundle/Controller/Website/SecondaryMenuController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Corporate\Branche;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;

--- a/sources/AppBundle/Controller/Website/SiteBaseController.php
+++ b/sources/AppBundle/Controller/Website/SiteBaseController.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Utils\Configuration;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;

--- a/sources/AppBundle/Controller/Website/SiteControllerInterface.php
+++ b/sources/AppBundle/Controller/Website/SiteControllerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use Afup\Site\Utils\Configuration;
 

--- a/sources/AppBundle/Controller/Website/StaticController.php
+++ b/sources/AppBundle/Controller/Website/StaticController.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Offices\OfficesCollection;
 use Symfony\Component\HttpFoundation\Request;

--- a/sources/AppBundle/Controller/Website/TalksController.php
+++ b/sources/AppBundle/Controller/Website/TalksController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Event\Model\Repository\PlanningRepository;

--- a/sources/AppBundle/Controller/Website/TechletterController.php
+++ b/sources/AppBundle/Controller/Website/TechletterController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Association\Model\Repository\TechletterUnsubscriptionsRepository;
 use Symfony\Component\HttpFoundation\Request;

--- a/sources/AppBundle/Controller/Website/TechnoWatchController.php
+++ b/sources/AppBundle/Controller/Website/TechnoWatchController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Controller;
+namespace AppBundle\Controller\Website;
 
 use AppBundle\Calendar\TechnoWatchCalendarGenerator;
 use Symfony\Component\HttpFoundation\Request;

--- a/sources/AppBundle/Listener/LegacySiteListener.php
+++ b/sources/AppBundle/Listener/LegacySiteListener.php
@@ -4,8 +4,8 @@
 namespace AppBundle\Listener;
 
 use Afup\Site\Corporate\Page;
-use AppBundle\Controller\BlocksHandler;
-use AppBundle\Controller\SiteControllerInterface;
+use AppBundle\Controller\Website\BlocksHandler;
+use AppBundle\Controller\Website\SiteControllerInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\Security\Core\Security;
 

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -5,45 +5,30 @@ namespace AppBundle\Twig;
 
 use AppBundle\Routing\LegacyRouter;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\DependencyInjection\Container;
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
-class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
-    /**
-     * @var LegacyRouter
-     */
-    private $legacyRouter;
-
-    /**
-     * @var \Parsedown
-     */
-    private $parsedown;
-
-    /**
-     * @var Container
-     */
-    private $container;
-
-    /**
-     * @var \Parsedown
-     */
-    private $emailParsedown;
+    private LegacyRouter $legacyRouter;
+    private \Parsedown $parsedown;
+    private \Parsedown $emailParsedown;
+    private ContainerInterface $container;
 
     public function __construct(LegacyRouter $legacyRouter, \Parsedown $parsedown, \Parsedown $emailParsedown, ContainerInterface $container)
     {
         $this->legacyRouter = $legacyRouter;
         $this->parsedown = $parsedown;
-        $this->container = $container;
         $this->emailParsedown = $emailParsedown;
+        $this->container = $container;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('render_curl', function ($url) {
+            new TwigFunction('render_curl', function ($url) {
                 $ch = curl_init($url);
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
                 $response = curl_exec($ch);
@@ -56,15 +41,15 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
         ];
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
-            new \Twig_SimpleFilter('markdown', fn ($text) => $this->parsedown->text($text), ['is_safe' => ['html']]),
-            new \Twig_SimpleFilter('markdown_email', fn ($text) => $this->emailParsedown->text($text), ['is_safe' => ['html']]),
+            new TwigFilter('markdown', fn ($text) => $this->parsedown->text($text), ['is_safe' => ['html']]),
+            new TwigFilter('markdown_email', fn ($text) => $this->emailParsedown->text($text), ['is_safe' => ['html']]),
         ];
     }
 
-    public function getGlobals()
+    public function getGlobals(): array
     {
         return [
             'legacy_router' => $this->legacyRouter,
@@ -73,12 +58,7 @@ class TwigExtension extends \Twig_Extension implements \Twig_Extension_GlobalsIn
         ];
     }
 
-    /**
-     * Returns the name of the extension.
-     *
-     * @return string The extension name
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'app';
     }


### PR DESCRIPTION
On fait du rangement dans les contrôleurs pour préparer la suppression du `SiteBaseController`.
Effectivement, `SiteBaseController` n'est pas compatible avec SF 4.4 du fait de la surcharge de la fonction `render()`.
Cela permet aussi d'activer l'autowirering sur ces contrôleurs.

On revoit aussi l'extention twig en supprimant des deprecated.
