### PR TITLE
Suppression du préfixe `@` s'il est présent

### DIFF
--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -493,6 +493,10 @@ class Speaker implements NotifyPropertyInterface
     {
         if ($bluesky !== null) {
             $bluesky = str_replace('https://bsky.app/profile/', '', $bluesky);
+
+            if (substr($bluesky, 0, 1) === '@') {
+                $bluesky = substr($bluesky, 1);
+            }
         }
 
         $this->propertyChanged('bluesky', $this->bluesky, $bluesky);


### PR DESCRIPTION
Il est rajouté automatiquement lors de l'affichage donc ne doit pas être présent en base.