### PR TITLE
afup#1602 corrige le test flaky

### DIFF
--- a/db/seeds/Event.php
+++ b/db/seeds/Event.php
@@ -13,7 +13,10 @@ class Event extends AbstractSeed
         $now = time();
         $oneDayInSeconds = 60*60*24;
         $oneMonthInSeconds = $oneDayInSeconds*30;
-        $event = $now + $oneMonthInSeconds * 5;
+
+        $event = new DateTime('@' . ($now + $oneMonthInSeconds * 5));
+        $event->setTime(0, 0, 0);
+        $event = $event->getTimestamp();
 
         $data = [
             [


### PR DESCRIPTION
Corrige cette issue : https://github.com/afup/web/issues/1602

On impose l'heure du début de l’évènement à 00:00:00 ce qui permet de ne plus être impacté par l'heure d’exécution des tests pour le calcul du nombre de jours restant.