### PR TITLE
quick fix affichage lien rapide de vote dans l'espace membres

### DIFF
--- a/sources/AppBundle/Controller/Website/MemberController.php
+++ b/sources/AppBundle/Controller/Website/MemberController.php
@@ -47,7 +47,7 @@ class MemberController extends Controller
 
         if ($hasGeneralMeetingPlanned
             && null !== $latestDate
-            && ($latestDate->format('Y-m-d') == (new \DateTime())->format('Y-m-d'))
+            && ($latestDate->format('Y-m-d') == (new \DateTime('-1 day'))->format('Y-m-d'))
             && count($generalMeetingQuestionRepository->loadByDate($latestDate)) > 0
         ) {
             $displayLinkToGeneralMeetingVote = true;


### PR DESCRIPTION
On a ce timestamp en base pour l'AG 1738969200

Il est récupéré coté PHP de cette façon : https://github.com/afup/web/blob/a5346935d2322fb0c2a366f1db7e663163d6eb2b/sources/AppBundle/GeneralMeeting/GeneralMeetingRepository.php#L44

Il a donc cette valeur :

```
var_dump(DateTimeImmutable::createFromFormat('U', '1738969200'));

object(DateTimeImmutable)#1 (3) {
  ["date"]=>
  string(26) "2025-02-07 23:00:00.000000"
  ["timezone_type"]=>
  int(1)
  ["timezone"]=>
  string(6) "+00:00"
}
```

Le comparatif à la date courante ne fonctionne pas (l'AG est le 8).

On a une PR pour un début de fix plus global : https://github.com/afup/web/pull/1612/files

Mais ici pour faire fonctionner sur le facile d'accès au vu du temps imparti sans trop cassé on doit faire un fix un peu moche.

Cela permet de faire fonctionne ce bandeau : 
![Screenshot 2025-02-08 at 08-47-03 Afup - Association française des utilisateurs de PHP](https://github.com/user-attachments/assets/58cb2609-f570-4bbc-9fde-fcc4ee015728)
