### PR TITLE
on loggue les dépréciations lors des tests fonctionnels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,13 @@ jobs:
 
       - name: Tests - Functional
         run: make test-functional
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Functional tests - deprecated log - full
+          path: var/logs/test.deprecations.log
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Functional tests - deprecated log - report
+          path: var/logs/test.deprecations_grouped.log

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ behat:
 test-functional: data config htdocs/uploads tmp
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) stop dbtest apachephptest mailcatcher
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) up -d dbtest apachephptest mailcatcher
+	make clean-test-deprecated-log
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm cliphp ./bin/behat
+	make var/logs/test.deprecations_grouped.log
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) stop dbtest apachephptest mailcatcher
 
 ### Analyse PHPStan
@@ -161,3 +163,9 @@ db-migrations:
 
 db-seed:
 	php bin/phinx seed:run
+
+clean-test-deprecated-log:
+	rm -f var/logs/test.deprecations.log
+
+var/logs/test.deprecations_grouped.log:
+	cat var/logs/test.deprecations.log | cut -d "]" -f 2 | awk '{$$1=$$1};1' | sort | uniq -c | sort -nr > var/logs/test.deprecations_grouped.log

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -34,3 +34,16 @@ services:
 
 ewz_recaptcha:
     enabled: false
+
+
+monolog:
+    handlers:
+        deprecation_stream:
+            type: stream
+            path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+
+        deprecation_filter:
+            type: filter
+            handler: deprecation_stream
+            max_level: info
+            channels: ["php"]


### PR DESCRIPTION
Cela permet de voir le type de dépréciation qui sont levées lors des tests fonctionnels afin de pouvoir les corriger avant de passer des mises à jour.

Cela rajouter des artefacts sur les tests fonctionnels : 
![Capture d’écran du 2025-02-09 13-49-15](https://github.com/user-attachments/assets/8d5efcf8-c2af-4a61-ae65-40840640757e)

Dont un qui liste les dépréciations les plus fréquentes : 

![Capture d’écran du 2025-02-09 13-48-54](https://github.com/user-attachments/assets/333106eb-50a9-4d56-b9b2-97e7719c433b)
