### PR TITLE
Correction suite à #1609

### DIFF
--- a/sources/Afup/Corporate/Rubrique.php
+++ b/sources/Afup/Corporate/Rubrique.php
@@ -184,7 +184,7 @@ class Rubrique
             'raccourci' => $this->raccourci,
             'descriptif' => $this->descriptif,
             'contenu' => $this->contenu,
-            'date' => date('Y-m-d', $this->date),
+            'date' => date('Y-m-d', (int) $this->date),
             'etat' => $this->etat,
             'feuille_associee' => $this->feuille_associee,
         ];

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -793,6 +793,9 @@ class Talk implements NotifyPropertyInterface
 
     public function getTweetsHasArray(): array
     {
+        if (!$this->getTweets()) {
+            return [];
+        }
         $explodedTweets = explode(PHP_EOL, $this->getTweets());
         $returnedTweets = [];
         foreach ($explodedTweets as $explodedTweet) {


### PR DESCRIPTION
On corrige des erreurs de PROD : 
```
2025-02-09T17:43:59.823Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: date() expects parameter 2 to be int, string given" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Rubrique.php line 187 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: date() expects parameter 2 to be int, string given at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Rubrique.php:187)"} []
2025-02-09T17:58:05.715Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: date() expects parameter 2 to be int, string given" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Rubrique.php line 187 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: date() expects parameter 2 to be int, string given at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Rubrique.php:187)"} []
2025-02-09T17:58:28.963Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: explode() expects parameter 2 to be string, null given" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Event/Model/Talk.php line 796 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: explode() expects parameter 2 to be string, null given at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Event/Model/Talk.php:796)"} []
2025-02-09T18:00:03.470Z (bas) CMDOUT (PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: array_reverse() expects parameter 1 to be array, null given in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/PlanetePHP/FeedCrawler.php:35)
```