### PR TITLE
Corrections suite à la PR #1609

### DIFF
--- a/sources/Afup/Association/Cotisations.php
+++ b/sources/Afup/Association/Cotisations.php
@@ -268,7 +268,7 @@ class Cotisations
             $date_fin_precedente = $cotisation === false ? 0 : $cotisation['date_fin'];
 
             if ($date_fin_precedente > 0) {
-                $date_debut = strtotime('+1day', $date_fin_precedente);
+                $date_debut = strtotime('+1day', (int) $date_fin_precedente);
             }
 
             $date_fin = $this->finProchaineCotisation($cotisation)->format('U');

--- a/sources/Afup/Corporate/Article.php
+++ b/sources/Afup/Corporate/Article.php
@@ -182,7 +182,10 @@ class Article
         $requete = 'SELECT *
                     FROM afup_site_article
                     WHERE id = ' . $this->bdd->echapper($this->id);
-        $this->remplir($this->bdd->obtenirEnregistrement($requete));
+        $data = $this->bdd->obtenirEnregistrement($requete);
+        if ($data) {
+            $this->remplir($data);
+        }
     }
 
     public function chargerDepuisRaccourci($raccourci): void
@@ -190,7 +193,10 @@ class Article
         $requete = 'SELECT *
                     FROM afup_site_article
                     WHERE CONCAT(id, "-", raccourci) = ' . $this->bdd->echapper($raccourci);
-        $this->remplir($this->bdd->obtenirEnregistrement($requete));
+        $data = $this->bdd->obtenirEnregistrement($requete);
+        if ($data) {
+            $this->remplir($data);
+        }
     }
 
     public function charger_dernier_depuis_rubrique(): void
@@ -199,7 +205,10 @@ class Article
                     FROM afup_site_article
                     WHERE id_site_rubrique = ' . $this->bdd->echapper($this->id_site_rubrique) .
             ' ORDER BY date DESC LIMIT 1';
-        $this->remplir($this->bdd->obtenirEnregistrement($requete));
+        $data = $this->bdd->obtenirEnregistrement($requete);
+        if ($data) {
+            $this->remplir($data);
+        }
     }
 
     public function remplir(array $article): void

--- a/sources/PlanetePHP/FeedCrawler.php
+++ b/sources/PlanetePHP/FeedCrawler.php
@@ -32,6 +32,10 @@ class FeedCrawler
         foreach ($feeds as $feed) {
             echo $feed->getFeed() . ' : début...<br />', PHP_EOL;
             $rss = fetch_rss($feed->getFeed());
+            if (!$rss->items) {
+                echo $feed->getFeed(), ' : vide fin !<br /><br/>', PHP_EOL, PHP_EOL;
+                continue;
+            }
             $rss->items = array_reverse($rss->items);
             foreach ($rss->items as $item) {
                 if (empty($item['id'])) {


### PR DESCRIPTION
Corrige des erreurs suite à la PR #1609.
Ça corrige aussi l'erreur de paiement survenu ce matin à 11h45.
```
2025-02-09T21:00:02.715Z (bas) CMDOUT (PHP Fatal error:  Uncaught Symfony\Component\Debug\Exception\FatalThrowableError: Type error: array_reverse() expects parameter 1 to be array, null given in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/PlanetePHP/FeedCrawler.php:35)
2025-02-09T22:00:01.044Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: Argument 1 passed to Afup\Site\Corporate\Article::remplir() must be of the type array, bool given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Article.php on line 193" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Article.php line 205 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: Argument 1 passed to Afup\\Site\\Corporate\\Article::remplir() must be of the type array, bool given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Article.php on line 193 at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Corporate/Article.php:205)"} []
2025-02-10T10:45:33.723Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: strtotime() expects parameter 2 to be int, string given" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Association/Cotisations.php line 271 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: strtotime() expects parameter 2 to be int, string given at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/Afup/Association/Cotisations.php:271)"} []
```