### PR TITLE
Gestion de l'absence de racine

### DIFF
--- a/sources/Afup/Corporate/Branche.php
+++ b/sources/Afup/Corporate/Branche.php
@@ -59,6 +59,10 @@ class Branche
                     AND etat = 1';
         $racine = $this->bdd->obtenirEnregistrement($requete);
 
+        if ($racine === false) {
+            return '';
+        }
+
         $feuilles = $this->extraireFeuilles($id, $profondeur);
         if ($feuilles !== '' && $feuilles !== '0') {
             $navigation = '<ul id="' . $identification . '" class="' . Site::raccourcir($racine['nom']) . '">' . $feuilles . '</ul>';


### PR DESCRIPTION
Certaines pages du BO (notamment la tréso) ne fonctionnent plus à cause de ça.