### PR TITLE
Change le namespace de Twig

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Symfony\Set\SymfonySetList;
+use Rector\Symfony\Set\TwigSetList;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -26,5 +27,6 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_44,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
+        TwigSetList::TWIG_UNDERSCORE_TO_NAMESPACE
     ])
 ;

--- a/sources/Afup/Utils/Mail.php
+++ b/sources/Afup/Utils/Mail.php
@@ -7,8 +7,8 @@ namespace Afup\Site\Utils;
 use AppBundle\Email\Mailer\Adapter\PhpMailerAdapter;
 use AppBundle\Email\Mailer\Mailer;
 use Psr\Log\NullLogger;
+use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
-use Twig_Environment;
 
 class Mail
 {
@@ -20,7 +20,7 @@ class Mail
 
         return new Mailer(
             new NullLogger(),
-            new Twig_Environment(new FilesystemLoader(self::PROJECT_DIR . '/app/Resources/views/')),
+            new Environment(new FilesystemLoader(self::PROJECT_DIR . '/app/Resources/views/')),
             PhpMailerAdapter::createFromConfiguration($configuration),
             $configuration
         );

--- a/sources/AppBundle/Controller/Event/CFP/EditAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/EditAction.php
@@ -29,12 +29,12 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Translation\TranslatorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class EditAction
 {
     private UrlGeneratorInterface $urlGenerator;
-    private \Twig_Environment $twig;
+    private Environment $twig;
     private SpeakerFactory $speakerFactory;
     private FormFactoryInterface $formFactory;
     private TranslatorInterface $translator;
@@ -52,7 +52,7 @@ class EditAction
     public function __construct(
         EventActionHelper $eventActionHelper,
         UrlGeneratorInterface $urlGenerator,
-        Twig_Environment $twig,
+        Environment $twig,
         FormFactoryInterface $formFactory,
         TalkRepository $talkRepository,
         TalkInvitationRepository $talkInvitationRepository,

--- a/sources/AppBundle/Controller/Event/CFP/IndexAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/IndexAction.php
@@ -17,14 +17,14 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class IndexAction
 {
     const MAX_EVENTS_HISTORY = 50;
     private TalkRepository $talkRepository;
     private UrlGeneratorInterface $urlGenerator;
-    private \Twig_Environment $twig;
+    private Environment $twig;
     private SpeakerFactory $speakerFactory;
     private PhotoStorage $photoStorage;
     private SidebarRenderer $sidebarRenderer;
@@ -36,7 +36,7 @@ class IndexAction
         EventRepository $eventRepository,
         TalkRepository $talkRepository,
         UrlGeneratorInterface $urlGenerator,
-        Twig_Environment $twig,
+        Environment $twig,
         SpeakerFactory $speakerFactory,
         PhotoStorage $photoStorage,
         SidebarRenderer $sidebarRenderer

--- a/sources/AppBundle/Controller/Event/CFP/ProposeAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/ProposeAction.php
@@ -17,12 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class ProposeAction
 {
     private UrlGeneratorInterface $urlGenerator;
-    private \Twig_Environment $twig;
+    private Environment $twig;
     private SpeakerFactory $speakerFactory;
     private FormFactoryInterface $formFactory;
     private TranslatorInterface $translator;
@@ -33,7 +33,7 @@ class ProposeAction
 
     public function __construct(
         UrlGeneratorInterface $urlGenerator,
-        Twig_Environment $twig,
+        Environment $twig,
         FormFactoryInterface $formFactory,
         TalkFormHandler $talkFormHandler,
         SpeakerFactory $speakerFactory,

--- a/sources/AppBundle/Controller/Event/CFP/SidebarRenderer.php
+++ b/sources/AppBundle/Controller/Event/CFP/SidebarRenderer.php
@@ -8,18 +8,18 @@ use AppBundle\CFP\SpeakerFactory;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use DateTime;
-use Twig_Environment;
+use Twig\Environment;
 
 class SidebarRenderer
 {
     private TalkRepository $talkRepository;
     private SpeakerFactory $speakerFactory;
-    private \Twig_Environment $twig;
+    private Environment $twig;
 
     public function __construct(
         TalkRepository $talkRepository,
         SpeakerFactory $speakerFactory,
-        Twig_Environment $twig
+        Environment $twig
     ) {
         $this->talkRepository = $talkRepository;
         $this->speakerFactory = $speakerFactory;

--- a/sources/AppBundle/Controller/Event/CFP/SpeakerAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/SpeakerAction.php
@@ -19,12 +19,12 @@ use Symfony\Component\HttpFoundation\Session\Flash\FlashBagInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 class SpeakerAction
 {
     private UrlGeneratorInterface $urlGenerator;
-    private \Twig_Environment $twig;
+    private Environment $twig;
     private SpeakerFactory $speakerFactory;
     private PhotoStorage $photoStorage;
     private SpeakerRepository $speakerRepository;
@@ -38,7 +38,7 @@ class SpeakerAction
     public function __construct(
         EventActionHelper $eventActionHelper,
         UrlGeneratorInterface $urlGenerator,
-        Twig_Environment $twig,
+        Environment $twig,
         FormFactoryInterface $formFactory,
         SpeakerFactory $speakerFactory,
         SpeakerRepository $speakerRepository,

--- a/sources/AppBundle/Controller/Website/MemberController.php
+++ b/sources/AppBundle/Controller/Website/MemberController.php
@@ -61,7 +61,7 @@ class MemberController extends AbstractController
 
         if ($hasGeneralMeetingPlanned
             && null !== $latestDate
-            && ($latestDate->format('Y-m-d') == (new \DateTime('-1 day'))->format('Y-m-d'))
+            && ($latestDate->format('Y-m-d') === (new \DateTime('-1 day'))->format('Y-m-d'))
             && count($generalMeetingQuestionRepository->loadByDate($latestDate)) > 0
         ) {
             $displayLinkToGeneralMeetingVote = true;

--- a/sources/AppBundle/Email/Mailer/Mailer.php
+++ b/sources/AppBundle/Email/Mailer/Mailer.php
@@ -7,7 +7,7 @@ namespace AppBundle\Email\Mailer;
 use Afup\Site\Utils\Configuration;
 use AppBundle\Email\Mailer\Adapter\MailerAdapter;
 use Psr\Log\LoggerInterface;
-use Twig_Environment;
+use Twig\Environment;
 
 /**
  * Send emails
@@ -15,7 +15,7 @@ use Twig_Environment;
 class Mailer
 {
     private LoggerInterface $logger;
-    private \Twig_Environment $twig;
+    private Environment $twig;
     private MailerAdapter $adapter;
     /** @var string|null */
     private $forcedRecipient;
@@ -24,7 +24,7 @@ class Mailer
 
     public function __construct(
         LoggerInterface $logger,
-        Twig_Environment $twig,
+        Environment $twig,
         MailerAdapter $adapter,
         Configuration $configuration
     ) {

--- a/sources/AppBundle/Offices/OfficeFinder.php
+++ b/sources/AppBundle/Offices/OfficeFinder.php
@@ -148,10 +148,10 @@ class OfficeFinder
     private function haversineGreatCircleDistance(float $latitudeFrom, float $longitudeFrom, float $latitudeTo, float $longitudeTo, int $earthRadius = 6371000): float
     {
         // convert from degrees to radians
-        $latFrom = deg2rad((float) $latitudeFrom);
-        $lonFrom = deg2rad((float) $longitudeFrom);
-        $latTo = deg2rad((float) $latitudeTo);
-        $lonTo = deg2rad((float) $longitudeTo);
+        $latFrom = deg2rad($latitudeFrom);
+        $lonFrom = deg2rad($longitudeFrom);
+        $latTo = deg2rad($latitudeTo);
+        $lonTo = deg2rad($longitudeTo);
 
         $latDelta = $latTo - $latFrom;
         $lonDelta = $lonTo - $lonFrom;

--- a/sources/AppBundle/Twig/AssetsExtension.php
+++ b/sources/AppBundle/Twig/AssetsExtension.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 
 namespace AppBundle\Twig;
 
-class AssetsExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
+use Twig\Extension\AbstractExtension;
+use Twig\Extension\GlobalsInterface;
+use Twig\TwigFunction;
+
+class AssetsExtension extends AbstractExtension implements GlobalsInterface
 {
     private $kernelRootDir;
 
@@ -20,7 +24,7 @@ class AssetsExtension extends \Twig_Extension implements \Twig_Extension_Globals
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('asset_md5_start', function (string $url) {
+            new TwigFunction('asset_md5_start', function (string $url) {
                 $path = $this->kernelRootDir . '/../htdocs/' . $url;
 
                 return substr(md5_file($path), 0, 8);

--- a/sources/AppBundle/Twig/OfficesExtension.php
+++ b/sources/AppBundle/Twig/OfficesExtension.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace AppBundle\Twig;
 
 use AppBundle\Offices\OfficesCollection;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
-class OfficesExtension extends \Twig_Extension
+class OfficesExtension extends AbstractExtension
 {
     /**
      * {@inheritdoc}
@@ -14,15 +16,15 @@ class OfficesExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('office_name', function ($code) {
+            new TwigFunction('office_name', function ($code) {
                 $collection = new OfficesCollection();
                 return $collection->findByCode($code)['label'];
             }),
-            new \Twig_SimpleFunction('office_logo', function ($code) {
+            new TwigFunction('office_logo', function ($code) {
                 $collection = new OfficesCollection();
                 return $collection->findByCode($code)['logo_url'];
             }),
-            new \Twig_SimpleFunction('office_meetup_urlname', function ($code) {
+            new TwigFunction('office_meetup_urlname', function ($code) {
                 $collection = new OfficesCollection();
                 return $collection->findByCode($code)['meetup_urlname'];
             }),


### PR DESCRIPTION
On utilise le bon namespace pour Twig.

Utilisation de rector : `TwigSetList::TWIG_UNDERSCORE_TO_NAMESPACE`.