### PR TITLE
Deprecated isSubmitted() before isValid()

### DIFF
--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
@@ -53,7 +53,8 @@ class ReportsAction
 
         // add
         $form = $this->buildForm();
-        if ($form->handleRequest($request) && $form->isValid()) {
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
             /** @var UploadedFile $reportFile */
             $reportFile = $form->get('file')->getData();
             if ($reportFile->move($basePath, $reportFile->getClientOriginalName())) {

--- a/sources/AppBundle/Controller/Admin/Planete/FeedEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedEditAction.php
@@ -52,7 +52,7 @@ class FeedEditAction
         $data->status = $feed->getStatus();
         $form = $this->formFactory->create(FeedFormType::class, $data);
         $form->handleRequest($request);
-        if ($form->isValid() && $form->isSubmitted()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $ok = $this->feedRepository->update(
                 $id,
                 $data->name,

--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -60,7 +60,7 @@ class TechLetterGenerateController extends AbstractController
         $form = $this->formFactory->create(SendingType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $techletter = $form->getData();
             $this->sendingRepository->save($techletter);
 

--- a/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
+++ b/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
@@ -50,7 +50,7 @@ class SpeakerSuggestionController extends AbstractController
         $form = $this->createForm(SpeakerSuggestionType::class);
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $speakerSuggestion = $this->createSpeakerSuggestion($event, $form->getData());
 
             $this->repositoryFactory

--- a/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
+++ b/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
@@ -55,7 +55,7 @@ class CompanyPublicProfileController extends AbstractController
 
         $form->handleRequest($request);
 
-        if ($form->isValid()) {
+        if ($form->isSubmitted() && $form->isValid()) {
             $data = $form->getData();
 
             /** @var UploadedFile $uploadedFile */

--- a/sources/AppBundle/Event/Speaker/SpeakerPage.php
+++ b/sources/AppBundle/Event/Speaker/SpeakerPage.php
@@ -66,7 +66,7 @@ class SpeakerPage
         ];
         $speakersContactType = $this->formFactory->create(SpeakersContactType::class, $speakersContactDefaults);
         $speakersContactType->handleRequest($request);
-        if ($speakersContactType->isValid()) {
+        if ($speakersContactType->isSubmitted() && $speakersContactType->isValid()) {
             $speakersContactData = $speakersContactType->getData();
             $speaker->setPhoneNumber($speakersContactData['phone_number']);
             $this->speakerRepository->save($speaker);
@@ -123,7 +123,7 @@ class SpeakerPage
 
         $speakersExpensesType = $this->formFactory->create(SpeakersExpensesType::class);
         $speakersExpensesType->handleRequest($request);
-        if ($speakersExpensesType->isValid()) {
+        if ($speakersExpensesType->isSubmitted() && $speakersExpensesType->isValid()) {
             $speakersExpensesData = $speakersExpensesType->getData();
             foreach ($speakersExpensesData['files'] as $file) {
                 $this->speakersExpensesStorage->store($file, $speaker);


### PR DESCRIPTION
On avance sur #1616.

Suite à la remonté des logs deprecated : 
> User Deprecated: Call Form::isValid() with an unsubmitted form is deprecated since Symfony 3.2 and will throw an exception in 4.0. Use Form::isSubmitted() before Form::isValid() instead. {"exception":"[object

On vérifie que `isSubmitted()` soit bien appelé avant un `isValid()`.

Avant cette PR il y avait 64 logs maintenant il y en a 28. Cela semble provenir des vendors.