### PR TITLE
Mise à jour de l'encoding des tables

### DIFF
--- a/db/migrations/20250218154548_update_tables_engine_to_inno_db.php
+++ b/db/migrations/20250218154548_update_tables_engine_to_inno_db.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateTablesEngineToInnoDb extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->execute("ALTER TABLE `afup_conferenciers_sessions` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_conferenciers` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_contacts` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_cotisations` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_email` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_forum_planning` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_forum_salle` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_forum_sessions_commentaires` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_inscriptions_rappels` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_logs` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_oeuvres` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_pays` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_personnes_morales` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_personnes_physiques` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_planete_billet` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_planete_flux` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_presences_assemblee_generale` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_sessions_note` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_sessions_vote` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_sessions` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_site_article` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_site_feuille` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_site_rubrique` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_tags` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_votes_poids` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `afup_votes` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_ActiviteMembre` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_Activite` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_FormeJuridique` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_MembreAnnuaire_iso` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_MembreAnnuaire_seq` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_MembreAnnuaire` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_TailleSociete` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `annuairepro_Zone` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_categorie` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_evenement` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_operation` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_periode` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_reglement` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta_simulation` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `compta` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `rdv_afup` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `wikini_acls` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `wikini_links` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `wikini_pages` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `wikini_referrers` ENGINE=InnoDB;");
+        $this->execute("ALTER TABLE `wikini_users` ENGINE=InnoDB;");
+    }
+}

--- a/db/migrations/20250218154608_update_tables_encoding.php
+++ b/db/migrations/20250218154608_update_tables_encoding.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateTablesEncoding extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->execute("ALTER TABLE afup_antenne CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_assemblee_generale CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_assemblee_generale_question CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_badge CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_compta_facture CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_compta_facture_details CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_conferenciers CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_conferenciers_sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_contacts CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_cotisations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_email CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_facturation_forum CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_coupon CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_partenaires CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_planning CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_salle CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_sessions_commentaires CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_special_price CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_sponsor_scan CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_sponsors_tickets CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_tarif CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_forum_tarif_event CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_inscription_forum CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_inscriptions_rappels CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_logs CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_meetup CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_niveau_partenariat CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_oeuvres CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_pays CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_personnes_morales CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_personnes_morales_invitations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_personnes_physiques CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_personnes_physiques_badge CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_planete_billet CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_planete_flux CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_presences_assemblee_generale CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_sessions_invitation CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_sessions_note CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_sessions_vote CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_sessions_vote_github CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_site_article CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_site_feuille CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_site_rubrique CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_speaker_suggestion CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_subscription_reminder_log CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_tags CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_techletter CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_techletter_subscriptions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_techletter_unsubscriptions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_throttling CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_user_github CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_vote_assemblee_generale CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_votes CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE afup_votes_poids CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_Activite CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_ActiviteMembre CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_FormeJuridique CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_MembreAnnuaire CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_MembreAnnuaire_iso CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_TailleSociete CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE annuairepro_Zone CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_categorie CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_compte CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_evenement CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_operation CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_periode CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_regle CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_reglement CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE compta_simulation CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE rdv_afup CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE scan CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE sessions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE tweet CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE wikini_acls CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE wikini_links CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE wikini_pages CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE wikini_referrers CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+        $this->execute("ALTER TABLE wikini_users CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;");
+    }
+}

--- a/docker/dockerfiles/mysql/my.cnf
+++ b/docker/dockerfiles/mysql/my.cnf
@@ -4,3 +4,5 @@ skip-name-resolve
 innodb_file_per_table=1
 sql-mode="STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
 default-time-zone = "+00:00"
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci

--- a/docker/dockerfiles/mysqltest/my.cnf
+++ b/docker/dockerfiles/mysqltest/my.cnf
@@ -4,3 +4,5 @@ skip-name-resolve
 innodb_file_per_table=1
 sql-mode="STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION"
 default-time-zone = "+00:00"
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci

--- a/sources/Afup/Bootstrap/Http.php
+++ b/sources/Afup/Bootstrap/Http.php
@@ -76,5 +76,4 @@ $smarty->assign('url_base',          'https://' . $_SERVER['HTTP_HOST'] . '/');
 $smarty->assign('chemin_template',   $serveur . Site::WEB_PATH . 'templates/' . $sous_site . '/');
 $smarty->assign('chemin_javascript', $serveur . Site::WEB_PATH . 'javascript/');
 
-$GLOBALS['AFUP_DB']->executer("SET NAMES 'utf8'");
 require_once(__DIR__ . '/commonStart.php');

--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -239,7 +239,7 @@ SQL;
                 FROM afup_personnes_physiques app
                 LEFT JOIN afup_personnes_morales apm ON apm.id = app.id_personne_morale
                 LEFT JOIN afup_cotisations ac ON ac.type_personne = IF(apm.id IS NULL, 0, 1) AND ac.id_personne = IFNULL(apm.id, app.id)
-                WHERE app.email COLLATE latin1_swedish_ci = i.email
+                WHERE app.email = i.email
                 GROUP BY app.`id`
                 )
             END AS lastsubscription

--- a/sources/Afup/Utils/Logs.php
+++ b/sources/Afup/Utils/Logs.php
@@ -4,22 +4,24 @@ declare(strict_types=1);
 
 namespace Afup\Site\Utils;
 
+use Afup\Site\Corporate\_Site_Base_De_Donnees;
+
 /**
  * Classe de gestion des logs
  */
 class Logs
 {
-    // TODO : Utiliser une constante en PHP5
+    private _Site_Base_De_Donnees $_bdd;
+    private int $_id_utilisateur;
+    private int $_nombre_logs_par_page = 10;
 
     /**
      * Renvoit l'instance unique de la classe Afup\Site\Utils\Logs
      *
      * Cette fonction est une implémentation du pattern Singleton.
      * Cela permet d'appeller statiquement les méthodes de cette classe depuis n'importe où.
-     *
-     * @return object   Instance de la classe Afup\Site\Utils\Logs
      */
-    public static function &_obtenirInstance()
+    public static function &_obtenirInstance(): self
     {
         // TODO : Utiliser une propriété statique en PHP5
         if (!isset($GLOBALS['_afup_log'])) {
@@ -31,7 +33,7 @@ class Logs
     /**
      * Initialise les propriétés de la classe
      *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
+     * @param  _Site_Base_De_Donnees $bdd Instance de la couche d'abstraction à la base de données
      * @param  int $id_utilisateur Identifiant de l'utilisateur connecté
      */
     public static function initialiser(&$bdd, $id_utilisateur): void


### PR DESCRIPTION
On a souvent des erreurs dans les logs à cause de tables qui n'acceptent pas les emojis.

Au lieu de faire la chasse aux tables à chaque fois, ce commit met toute la base de données à jour en une seule fois.

On change aussi la valeur par défaut pour les futures colonnes et tables