### PR TITLE
Suppression des dépréciations pour les Command

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -26,6 +26,17 @@ services:
               lock_mode: !php/const Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::LOCK_NONE
 
 
+    AppBundle\Command\:
+        resource: '../../sources/AppBundle/Command/*'
+        autowire: true
+        autoconfigure: true
+
+    AppBundle\Command\UpdateMailchimpMembersCommand:
+        arguments:
+            - '@Mailchimp\Mailchimp'
+            - '@CCMBenchmark\TingBundle\Repository\RepositoryFactory'
+            - "%mailchimp_members_list%"
+
     AppBundle\Controller\:
         resource: '../../sources/AppBundle/Controller/*'
         autowire: true
@@ -124,18 +135,6 @@ services:
         autowire: true
         arguments:
             $backOfficePages: '%app.pages_backoffice%'
-
-    AppBundle\Command\GeneralMeetupNotificationCommand:
-        autowire: true
-        autoconfigure: true
-
-    AppBundle\Command\IndexTalksCommand:
-        autowire: true
-        autoconfigure: true
-
-    AppBundle\Command\QrCodesGeneratorCommand:
-        autowire: true
-        autoconfigure: true
 
     AppBundle\GeneralMeeting\GeneralMeetingRepository:
         autowire: true

--- a/sources/AppBundle/Command/CfpNotificationCommand.php
+++ b/sources/AppBundle/Command/CfpNotificationCommand.php
@@ -11,12 +11,12 @@ use AppBundle\Event\Model\Repository\TalkToSpeakersRepository;
 use AppBundle\Notifier\SlackNotifier;
 use AppBundle\Slack\MessageFactory;
 use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CfpNotificationCommand extends ContainerAwareCommand
+class CfpNotificationCommand extends Command
 {
     private MessageFactory $messageFactory;
     private SlackNotifier $slackNotifier;
@@ -29,22 +29,16 @@ class CfpNotificationCommand extends ContainerAwareCommand
         $this->messageFactory = $messageFactory;
         $this->slackNotifier = $slackNotifier;
         $this->ting = $ting;
+        parent::__construct();
     }
-    /**
-     * @see Command
-     */
+
     protected function configure(): void
     {
         $this
             ->setName('cfp-stats-notification')
-            ->addOption('display-diff', null, InputOption::VALUE_NONE)
-
-        ;
+            ->addOption('display-diff', null, InputOption::VALUE_NONE);
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $eventRepository = $this->ting->get(EventRepository::class);

--- a/sources/AppBundle/Command/CleanThrottlingCommand.php
+++ b/sources/AppBundle/Command/CleanThrottlingCommand.php
@@ -5,30 +5,26 @@ declare(strict_types=1);
 namespace AppBundle\Command;
 
 use AppBundle\Security\ActionThrottling\ActionThrottling;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CleanThrottlingCommand extends ContainerAwareCommand
+class CleanThrottlingCommand extends Command
 {
     private ActionThrottling $actionThrottling;
+
     public function __construct(ActionThrottling $actionThrottling)
     {
         $this->actionThrottling = $actionThrottling;
+        parent::__construct();
     }
-    /**
-     * @see Command
-     */
+
     protected function configure(): void
     {
         $this
-            ->setName('throttling:clean')
-        ;
+            ->setName('throttling:clean');
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->actionThrottling->clearOldLogs();

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -5,15 +5,13 @@ declare(strict_types=1);
 namespace AppBundle\Command;
 
 use function GuzzleHttp\Psr7\parse_query;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DevCallBackPayboxCotisationCommand extends ContainerAwareCommand
+class DevCallBackPayboxCotisationCommand extends Command
 {
-    /**
-     * @see Command
-     */
     protected function configure(): void
     {
         $help = <<<EOF
@@ -24,14 +22,10 @@ EOF;
 
         $this
             ->setName('dev:callback-paybox-cotisation')
-            ->addArgument('url_paiement_effectue')
-            ->setHelp($help)
-        ;
+            ->addArgument('url_paiement_effectue', InputArgument::REQUIRED)
+            ->setHelp($help);
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $parsedUrl = parse_url($input->getArgument('url_paiement_effectue'));

--- a/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
+++ b/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
@@ -36,17 +36,11 @@ class GeneralMeetupNotificationCommand extends Command
         $this->urlGenerator = $urlGenerator;
     }
 
-    /**
-     * @see Command
-     */
     protected function configure(): void
     {
         $this->setName('general-meeting-notification');
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if ($this->generalMeetingRepository->hasGeneralMeetingPlanned()) {

--- a/sources/AppBundle/Command/IndexTalksCommand.php
+++ b/sources/AppBundle/Command/IndexTalksCommand.php
@@ -15,7 +15,7 @@ class IndexTalksCommand extends Command
 
     public function __construct(Runner $runner)
     {
-        parent::__construct(null);
+        parent::__construct();
         $this->runner = $runner;
     }
 

--- a/sources/AppBundle/Command/QrCodesGeneratorCommand.php
+++ b/sources/AppBundle/Command/QrCodesGeneratorCommand.php
@@ -6,26 +6,26 @@ namespace AppBundle\Command;
 
 use AppBundle\Event\Model\Repository\TicketRepository;
 use AppBundle\Event\Ticket\QrCodeGenerator;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class QrCodesGeneratorCommand extends ContainerAwareCommand
+class QrCodesGeneratorCommand extends Command
 {
     private QrCodeGenerator $qrCodeGenerator;
+    private RepositoryFactory $ting;
 
-    public function __construct(QrCodeGenerator $qrCodeGenerator, string $name = null)
+    public function __construct(QrCodeGenerator $qrCodeGenerator,
+                                RepositoryFactory $ting)
     {
-        parent::__construct($name);
+        parent::__construct();
         $this->qrCodeGenerator = $qrCodeGenerator;
+        $this->ting = $ting;
     }
 
-    /**
-     * @see Command
-     */
     protected function configure(): void
     {
         $this
@@ -50,7 +50,7 @@ class QrCodesGeneratorCommand extends ContainerAwareCommand
 
         try {
             /** @var TicketRepository $ticketRepository */
-            $ticketRepository = $this->getContainer()->get('ting')->get(TicketRepository::class);
+            $ticketRepository = $this->ting->get(TicketRepository::class);
             $tickets = $ticketRepository->getByEmptyQrCodes();
 
             if (count($tickets) === 0) {

--- a/sources/AppBundle/Command/RegistrationsExporterCommand.php
+++ b/sources/AppBundle/Command/RegistrationsExporterCommand.php
@@ -6,16 +6,24 @@ namespace AppBundle\Command;
 
 use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Event\Ticket\RegistrationsExportGenerator;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class RegistrationsExporterCommand extends ContainerAwareCommand
+class RegistrationsExporterCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private EventRepository $eventRepository;
+    private RegistrationsExportGenerator $exportGenerator;
+
+    public function __construct(EventRepository $eventRepository,
+                                RegistrationsExportGenerator $exportGenerator)
+    {
+        parent::__construct();
+        $this->eventRepository = $eventRepository;
+        $this->exportGenerator = $exportGenerator;
+    }
+
     protected function configure(): void
     {
         $this
@@ -24,21 +32,16 @@ class RegistrationsExporterCommand extends ContainerAwareCommand
         ;
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $container = $this->getContainer();
-
-        if (null === ($event = $container->get(EventRepository::class)->getNextEvent())) {
+        if (null === ($event = $this->eventRepository->getNextEvent())) {
             $output->writeln('No event found');
             return 0;
         }
 
         $file = new \SplFileObject($input->getArgument('file'), 'w+');
 
-        $container->get(RegistrationsExportGenerator::class)->export($event, $file);
+        $this->exportGenerator->export($event, $file);
 
         return 0;
     }

--- a/sources/AppBundle/Command/SlackMemberNotificationCommand.php
+++ b/sources/AppBundle/Command/SlackMemberNotificationCommand.php
@@ -7,11 +7,11 @@ namespace AppBundle\Command;
 use AppBundle\Notifier\SlackNotifier;
 use AppBundle\Slack\MessageFactory;
 use AppBundle\Slack\UsersChecker;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SlackMemberNotificationCommand extends ContainerAwareCommand
+class SlackMemberNotificationCommand extends Command
 {
     private UsersChecker $usersChecker;
     private MessageFactory $messageFactory;
@@ -21,10 +21,9 @@ class SlackMemberNotificationCommand extends ContainerAwareCommand
         $this->usersChecker = $usersChecker;
         $this->messageFactory = $messageFactory;
         $this->slackNotifier = $slackNotifier;
+        parent::__construct();
     }
-    /**
-     * @see Command
-     */
+
     protected function configure(): void
     {
         $this
@@ -32,15 +31,12 @@ class SlackMemberNotificationCommand extends ContainerAwareCommand
         ;
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $results = $this->usersChecker->checkUsersValidity();
 
         if (($nbResults = count($results)) > 0) {
-            $message = $this->messageFactory->createMessageForMemberNotification($nbResults);
+            $message = $this->messageFactory->createMessageForMemberNotification((string) $nbResults);
             $this->slackNotifier->sendMessage($message);
         }
 

--- a/sources/AppBundle/Command/SubscriptionReminderCommand.php
+++ b/sources/AppBundle/Command/SubscriptionReminderCommand.php
@@ -17,17 +17,22 @@ use AppBundle\Association\UserMembership\ReminderDDay;
 use AppBundle\Association\UserMembership\UserReminderFactory;
 use AppBundle\Email\Mailer\Mailer;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SubscriptionReminderCommand extends ContainerAwareCommand
+class SubscriptionReminderCommand extends Command
 {
     private Mailer $mailer;
-    public function __construct(Mailer $mailer)
+    private RepositoryFactory $ting;
+
+    public function __construct(Mailer $mailer, RepositoryFactory $ting)
     {
         $this->mailer = $mailer;
+        $this->ting = $ting;
+        parent::__construct();
     }
     /**
      * @inheritDoc
@@ -47,16 +52,16 @@ class SubscriptionReminderCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $mailer = $this->mailer;
-        $factory = new UserReminderFactory($mailer, $this->getContainer()->get('ting')->get(SubscriptionReminderLogRepository::class));
+        $factory = new UserReminderFactory($mailer, $this->ting->get(SubscriptionReminderLogRepository::class));
         $companyFactory = new CompanyReminderFactory(
             $mailer,
-            $this->getContainer()->get('ting')->get(SubscriptionReminderLogRepository::class)
+            $this->ting->get(SubscriptionReminderLogRepository::class)
         );
 
         /**
          * @var UserRepository $repository
          */
-        $repository = $this->getContainer()->get('ting')->get(UserRepository::class);
+        $repository = $this->ting->get(UserRepository::class);
 
         $dryRun = $input->getOption('dry-run');
 

--- a/sources/AppBundle/Command/SynchMembersCommand.php
+++ b/sources/AppBundle/Command/SynchMembersCommand.php
@@ -4,30 +4,33 @@ declare(strict_types=1);
 
 namespace AppBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use AppBundle\Mailchimp\MailchimpMembersAutoListSynchronizer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SynchMembersCommand extends ContainerAwareCommand
+class SynchMembersCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private MailchimpMembersAutoListSynchronizer $synchronizer;
+    private LoggerInterface $logger;
+
+    public function __construct(MailchimpMembersAutoListSynchronizer $synchronizer, LoggerInterface $logger)
+    {
+        $this->synchronizer = $synchronizer;
+        $this->logger = $logger;
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this->setName('sync-members');
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $container = $this->getContainer();
-
-        $container
-           ->get('app.mailchimp_members_auto_synchronizer')
-           ->setLogger($container->get('logger'))
+        $this->synchronizer
+           ->setLogger($this->logger)
            ->synchronize()
         ;
 

--- a/sources/AppBundle/Command/SynchTechLetterCommand.php
+++ b/sources/AppBundle/Command/SynchTechLetterCommand.php
@@ -4,30 +4,33 @@ declare(strict_types=1);
 
 namespace AppBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use AppBundle\TechLetter\MailchimpSynchronizer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class SynchTechLetterCommand extends ContainerAwareCommand
+class SynchTechLetterCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private MailchimpSynchronizer $synchronizer;
+    private LoggerInterface $logger;
+
+    public function __construct(MailchimpSynchronizer $synchronizer, LoggerInterface $logger)
+    {
+        $this->synchronizer = $synchronizer;
+        $this->logger = $logger;
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this->setName('sync-techletter');
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $container = $this->getContainer();
-
-        $container
-           ->get('app.techletter_mailchimp_synchronizer')
-           ->setLogger($container->get('logger'))
+        $this->synchronizer
+           ->setLogger($this->logger)
            ->synchronize()
         ;
 

--- a/sources/AppBundle/Command/TicketStatsNotificationCommand.php
+++ b/sources/AppBundle/Command/TicketStatsNotificationCommand.php
@@ -10,21 +10,29 @@ use AppBundle\Event\Model\Repository\EventStatsRepository;
 use AppBundle\Event\Model\Repository\TicketTypeRepository;
 use AppBundle\Notifier\SlackNotifier;
 use AppBundle\Slack\MessageFactory;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class TicketStatsNotificationCommand extends ContainerAwareCommand
+class TicketStatsNotificationCommand extends Command
 {
     private MessageFactory $messageFactory;
     private EventStatsRepository $eventStatsRepository;
     private SlackNotifier $slackNotifier;
-    public function __construct(MessageFactory $messageFactory, EventStatsRepository $eventStatsRepository, SlackNotifier $slackNotifier)
+    private RepositoryFactory $ting;
+
+    public function __construct(MessageFactory $messageFactory,
+                                EventStatsRepository $eventStatsRepository,
+                                SlackNotifier $slackNotifier,
+                                RepositoryFactory $ting)
     {
         $this->messageFactory = $messageFactory;
         $this->eventStatsRepository = $eventStatsRepository;
         $this->slackNotifier = $slackNotifier;
+        $this->ting = $ting;
+        parent::__construct();
     }
     /**
      * @see Command
@@ -42,8 +50,8 @@ class TicketStatsNotificationCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $eventReposotory = $this->getContainer()->get('ting')->get(EventRepository::class);
-        $ticketRepository = $this->getContainer()->get('ting')->get(TicketTypeRepository::class);
+        $eventReposotory = $this->ting->get(EventRepository::class);
+        $ticketRepository = $this->ting->get(TicketTypeRepository::class);
 
         $date = null;
 

--- a/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
+++ b/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
@@ -6,30 +6,32 @@ namespace AppBundle\Command;
 
 use AppBundle\Association\Model\CompanyMember;
 use AppBundle\Association\Model\Repository\CompanyMemberRepository;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateCompanyMemberStateCommand extends ContainerAwareCommand
+class UpdateCompanyMemberStateCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private RepositoryFactory $ting;
+
+    public function __construct(RepositoryFactory $ting)
+    {
+        parent::__construct();
+        $this->ting = $ting;
+    }
+
     protected function configure(): void
     {
         $this
             ->setName('update-company-member-state')
-
         ;
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var CompanyMemberRepository $companyMemberRepository */
-        $companyMemberRepository = $this->getContainer()->get('ting')->get(CompanyMemberRepository::class);
+        $companyMemberRepository = $this->ting->get(CompanyMemberRepository::class);
 
         /** @var CompanyMember $companyMember */
         foreach ($companyMemberRepository->loadAll() as $companyMember) {

--- a/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
+++ b/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
@@ -26,6 +26,7 @@ class UpdateMailchimpMembersCommand extends ContainerAwareCommand
         $this->mailchimp = $mailchimp;
         $this->mailchimpMembersList = $mailchimpMembersList;
         $this->ting = $ting;
+        parent::__construct();
     }
     /**
      * @see Command

--- a/sources/AppBundle/Command/UpdateUserStateCommand.php
+++ b/sources/AppBundle/Command/UpdateUserStateCommand.php
@@ -6,30 +6,32 @@ namespace AppBundle\Command;
 
 use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Association\Model\User;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpdateUserStateCommand extends ContainerAwareCommand
+class UpdateUserStateCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private RepositoryFactory $ting;
+
+    public function __construct(RepositoryFactory $ting)
+    {
+        $this->ting = $ting;
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this
             ->setName('update-user-state')
-
         ;
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var UserRepository $userRepository */
-        $userRepository = $this->getContainer()->get('ting')->get(UserRepository::class);
+        $userRepository = $this->ting->get(UserRepository::class);
 
         foreach ($userRepository->loadAll() as $user) {
             $hasUptoDateMembershipFee = $user->hasUpToDateMembershipFee();

--- a/sources/AppBundle/Command/VideosDataCommand.php
+++ b/sources/AppBundle/Command/VideosDataCommand.php
@@ -9,16 +9,22 @@ use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Speaker;
 use AppBundle\Event\Model\Talk;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class VideosDataCommand extends ContainerAwareCommand
+class VideosDataCommand extends Command
 {
-    /**
-     * @see Command
-     */
+    private RepositoryFactory $ting;
+
+    public function __construct(RepositoryFactory $ting)
+    {
+        $this->ting = $ting;
+        parent::__construct();
+    }
+
     protected function configure(): void
     {
         $this
@@ -27,22 +33,13 @@ class VideosDataCommand extends ContainerAwareCommand
         ;
     }
 
-    /**
-     * @see Command
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $ting = $this->getContainer()->get('ting');
+        /** @var TalkRepository $talkRepository */
+        $talkRepository = $this->ting->get(TalkRepository::class);
 
-        /**
-         * @var TalkRepository $talkRepository
-         */
-        $talkRepository = $ting->get(TalkRepository::class);
-
-        /**
-         * @var EventRepository $eventRepository
-         */
-        $eventRepository = $ting->get(EventRepository::class);
+        /** @var EventRepository $eventRepository */
+        $eventRepository = $this->ting->get(EventRepository::class);
 
         $event = $eventRepository->getByPath($input->getArgument('path'));
 

--- a/sources/AppBundle/Slack/Field.php
+++ b/sources/AppBundle/Slack/Field.php
@@ -26,9 +26,9 @@ final class Field
         return $this->value;
     }
 
-    public function setValue(string $value): self
+    public function setValue($value): self
     {
-        $this->value = $value;
+        $this->value = (string) $value;
         return $this;
     }
 


### PR DESCRIPTION
On supprime les dépréciations lié aux `Command`: 
1. Dans service.yml on active l'autowire et l'autoconfigure.
2. On remplace `ContainerAwareCommand` par `Command` donc on injecte les services qui vont bien.

Toujours en préparation de la migration vers Symfony 4.4 : https://github.com/afup/web/issues/1616

(ça manque de tests pour être plus tranquille)