### PR TITLE
Correction du typage pour mktime

### DIFF
--- a/htdocs/pages/administration/forum_planning.php
+++ b/htdocs/pages/administration/forum_planning.php
@@ -102,8 +102,8 @@ if ($action == 'lister') {
         if ($id == 0) {
             $planning_id = $forum_appel->ajouterSessionDansPlanning($valeurs['id_forum'],
                 $valeurs['id_session'],
-                mktime($valeurs['debut']['H'], $valeurs['debut']['i'], 0, $valeurs['debut']['M'], $valeurs['debut']['d'], $valeurs['debut']['Y']),
-                mktime($valeurs['fin']['H'], $valeurs['fin']['i'], 0, $valeurs['fin']['M'], $valeurs['fin']['d'], $valeurs['fin']['Y']),
+                mktime((int) $valeurs['debut']['H'], (int) $valeurs['debut']['i'], 0, (int) $valeurs['debut']['M'], (int) $valeurs['debut']['d'], (int) $valeurs['debut']['Y']),
+                mktime((int) $valeurs['fin']['H'], (int) $valeurs['fin']['i'], 0, (int) $valeurs['fin']['M'], (int) $valeurs['fin']['d'], (int) $valeurs['fin']['Y']),
                 $valeurs['id_salle']);
 
             $ok = (bool) $planning_id;


### PR DESCRIPTION
>  2025-02-19T20:44:44.733Z request.CRITICAL: Uncaught PHP Exception Symfony\Component\Debug\Exception\FatalThrowableError: "Type error: mktime() expects parameter 1 to be int, string given" at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/htdocs/pages/administration/forum_planning.php line 105 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Type error: mktime() expects parameter 1 to be int, string given at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/htdocs/pages/administration/forum_planning.php:105)"} []

Suite à cette erreur, on corrige le typage pour `mktime()`
