### PR TITLE
Optimisation du temps des tests fonctionnels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "ext-json": "*",
     "ext-libxml": "*",
     "ext-openssl": "*",
+    "ext-pdo": "*",
     "algolia/algoliasearch-client-php": "^3.4",
     "beberlei/assert": "^2.9",
     "captioning/captioning": "^2.6",
@@ -98,6 +99,7 @@
     "behat/mink-extension": "^2.3",
     "behat/mink-goutte-driver": "^1.2",
     "friendsofphp/php-cs-fixer": "~2",
+    "ifsnop/mysqldump-php": "^2.12",
     "rector/rector": "^2.0",
     "smalot/pdfparser": "^0.19.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "944cf166c0d3508556fbd3190eff658b",
+    "content-hash": "5bb2c3b4dc94b16cc8fb6c397743cc57",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -7512,6 +7512,65 @@
                 }
             ],
             "time": "2021-11-15T17:17:55+00:00"
+        },
+        {
+            "name": "ifsnop/mysqldump-php",
+            "version": "v2.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ifsnop/mysqldump-php.git",
+                "reference": "2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ifsnop/mysqldump-php/zipball/2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3",
+                "reference": "2d3a43fc0c49f23bf7dee392b0dd1f8c799f89d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.36",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ifsnop\\": "src/Ifsnop/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Diego Torres",
+                    "homepage": "https://github.com/ifsnop",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP version of mysqldump cli that comes with MySQL",
+            "homepage": "https://github.com/ifsnop/mysqldump-php",
+            "keywords": [
+                "PHP7",
+                "database",
+                "hhvm",
+                "mariadb",
+                "mysql",
+                "mysql-backup",
+                "mysqldump",
+                "pdo",
+                "php",
+                "php5",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/ifsnop/mysqldump-php/issues",
+                "source": "https://github.com/ifsnop/mysqldump-php/tree/v2.12"
+            },
+            "time": "2023-04-12T07:43:14+00:00"
         },
         {
             "name": "php-cs-fixer/diff",

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -9,17 +9,30 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ExpectationException;
 use Behat\MinkExtension\Context\MinkContext;
+use Ifsnop\Mysqldump\Mysqldump;
 use Smalot\PdfParser\Parser;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 
 class FeatureContext implements Context
 {
-    public const MAILCATCHER_URL = 'http://mailcatcher:1080';
+    private const MAILCATCHER_URL = 'http://mailcatcher:1080';
+    private const DB_NAME = 'web';
 
     private MinkContext $minkContext;
 
     private array $pdfPages = [];
+
+    private PDO $database;
+    private Mysqldump $dumper;
+    private string $dbDumpKey;
+
+    public function __construct()
+    {
+        $this->database = new PDO('mysql:host=dbtest;dbname=' . self::DB_NAME, 'root', 'root');
+        $this->dumper = new Mysqldump('mysql:host=dbtest;dbname=' . self::DB_NAME, 'root', 'root');
+        $this->dbDumpKey = $this->computeDbDumpKey();
+    }
 
     /**
      * @BeforeScenario
@@ -34,11 +47,19 @@ class FeatureContext implements Context
     /**
      * @BeforeScenario @reloadDbWithTestData
      */
-    public function beforeScenarioReloadDb(): void
+    public function beforeScenarioReloadDatabase(): void
     {
         $this->resetDb();
-        $this->migrateDb();
-        $this->seedRun();
+
+        $dbDumpFile = sprintf(__DIR__ . '/../../../var/cache/test/db_dump_%s.sql', $this->dbDumpKey);
+        if (!is_file($dbDumpFile)) {
+            $this->migrateDb();
+            $this->seedRun();
+
+            $this->dumper->start($dbDumpFile);
+        } else {
+            $this->restoreDb($dbDumpFile);
+        }
     }
 
     /**
@@ -59,11 +80,35 @@ class FeatureContext implements Context
         $filesystem->remove(Event::getSponsorFileDir());
     }
 
+    private function computeDbDumpKey(): string
+    {
+        $finder = new Symfony\Component\Finder\Finder();
+        $files = $finder->files()->in([
+            __DIR__ . '/../../../db/migrations/',
+            __DIR__ . '/../../../db/seeds/',
+        ]);
+
+        $key = '';
+        foreach ($files as $file) {
+            $key .= md5_file($file->getRealPath());
+        }
+
+        return md5($key);
+    }
+
+    private function restoreDb(string $dbDumpFile): void
+    {
+        if (false === $this->database->exec(file_get_contents($dbDumpFile))) {
+            throw new RuntimeException(implode(' ', $this->database->errorInfo()));
+        }
+    }
+
     private function resetDb(): void
     {
-        $pdo = new \PDO('mysql:host=dbtest', 'root', 'root');
-        $pdo->exec('DROP DATABASE IF EXISTS web');
-        $pdo->exec('CREATE DATABASE web');
+        $sql = sprintf('DROP DATABASE IF EXISTS %1$s; CREATE DATABASE %1$s; USE %1$s;', self::DB_NAME);
+        if (false === $this->database->exec($sql)) {
+            throw new RuntimeException(implode(' ', $this->database->errorInfo()));
+        }
     }
 
     private function migrateDb(): void
@@ -175,7 +220,7 @@ class FeatureContext implements Context
      * @Then The :field field should have the following selected value :expectedValue
      * @throws ExpectationException
      */
-    public function selectHasForCurrentSelectedValue(string $field, string $expectedValue) :void
+    public function selectHasForCurrentSelectedValue(string $field, string $expectedValue): void
     {
         $node = $this->minkContext->assertSession()->fieldExists($field);
         $options = $node->findAll('css', 'option');


### PR DESCRIPTION
On optimise le reset de la base de données pour les tests fonctionnels.

Sur une idée originale d'Adrien, au premier reset un fait un dump pour s'économiser l'éxécution de toutes les migrations + l'insertion des fixtures.
Ce dump contient une clé md5 basé sur l'ensemble des migrations + fixtures.

On est passé de  6m 28s à 5m 2s  sur le temps du job de test dans la CI.