### PR TITLE
Optimisations pour la google search console video

### DIFF
--- a/app/Resources/views/event/calendar.html.twig
+++ b/app/Resources/views/event/calendar.html.twig
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,follow">
     <title>Planning {{ event.title }}</title>
 
     <!-- Bootstrap -->

--- a/app/Resources/views/site/become_member.html.twig
+++ b/app/Resources/views/site/become_member.html.twig
@@ -136,13 +136,13 @@
 
         <p>
             Le paiement d'une adhésion professionnelle peut se faire soit par carte bancaire ou par virement. Pour les particuliers, seul le paiement par carte bancaire est disponible.<br />
-            L'adhésion nécessite l'acceptation pleine et sans réserve du <a href="/pages/site/?route=vie-associative-afup/21/reglement-interieur">règlement intérieur</a> et du <a href="/p/986-code-de-conduite">code de conduite</a>.
+            L'adhésion nécessite l'acceptation pleine et sans réserve du <a href="{{ path('cms_page_display', {code: '21-reglement-interieur'}) }}">règlement intérieur</a> et du <a href="{{ path('cms_page_display', {code: '986-code-de-conduite'}) }}">code de conduite</a>.
         </p>
         
         <h2>Questions</h2>
 
         <p>
-            Pour toutes questions, notre <a href="/p/1012-faq" title="FAQ">FAQ</a> est disponible.
+            Pour toutes questions, notre <a href="{{ path('cms_page_display', {code: '1012-faq'}) }}" title="FAQ">FAQ</a> est disponible.
         </p>
     </div>
 </div>

--- a/app/Resources/views/site/home.html.twig
+++ b/app/Resources/views/site/home.html.twig
@@ -52,7 +52,7 @@
                         {% endfor %}
                     </ul>
 
-                    <a href="/pages/site/?route=06-actualit/9" class="home-view-more" title="Voir plus : d'autres actualités">Voir plus <i class="fa fa-arrow-right"></i></a>
+                    <a href="{{ path('news_list')}}" class="home-view-more" title="Voir plus : d'autres actualités">Voir plus <i class="fa fa-arrow-right"></i></a>
                 </div>
 
                 <div class="col-md-6">

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -34,23 +34,25 @@
     </script>
 {% endblock %}
 
-{% block title %}{{ talk.title }} - {{ event.title }} - {{ parent() }}{% endblock %}
+{% block title %}{{ talk.title }} - {{ event.title }}{% endblock %}
 
 {% block metas %}
     {{ parent() }}
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="AFUP - {{ talk.title }}">
+    <meta name="twitter:title" content="{{ talk.title }}">
     <meta name="twitter:description" content="{{ talk.description|striptags|raw }}">
     {% if talk.hasYoutubeId %}
         <meta name="twitter:image:src" content="https://img.youtube.com/vi/{{ talk.getYoutubeId }}/hqdefault.jpg">
     {% endif %}
     <meta name="twitter:domain" content="afup.org">
 
-    <meta property="og:type" content="article" />
-    <meta property="og:title" content="AFUP - {{ talk.title }}" />
+    <meta property="og:title" content="{{ talk.title }}" />
     <meta property="og:url" content="{{ url('talks_show', {id: talk.id, slug: talk.slug }) }}" />
     {% if talk.hasYoutubeId %}
         <meta property="og:image" content="https://img.youtube.com/vi/{{ talk.getYoutubeId }}/hqdefault.jpg" />
+        <meta property="og:type" content="video.other" />
+    {% else %}
+        <meta property="og:type" content="article" />
     {% endif %}
     <meta property="og:description" content="{{ talk.description|striptags|raw }}" />
     <meta property="og:site_name" content="AFUP" />
@@ -62,10 +64,23 @@
             <div class="col-md-12 talk-title">
                 <h1>{{ talk.title }}</h1>
             </div>
-        </div>
 
-        <div class="container">
-            <div class="col-md-{% if talk.hasYoutubeId %}6{% else %}12"{% endif %}">
+            {% if talk.hasYoutubeId %}
+                <div class="col-md-6">
+                    <h2>Vidéo</h2>
+                    <div class="responsive-video-container">
+                        <div id="player">
+                            <iframe width="560" height="315" src="https://www.youtube.com/embed/{{ talk.youtubeId }}"
+                                    title="YouTube video player"
+                                    frameborder="0"
+                                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                                    referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+
+            <div class="col-md-{% if talk.hasYoutubeId %}6{% else %}12{% endif %}">
                 <div class="container">
                     <div class="col-md-12">
                         <h2>Description</h2>
@@ -78,7 +93,8 @@
                 </div>
                 <div class="container talk-date-container">
                     <div class="col-md-12">
-                        Conférence donnée lors du <a href="{{ url('talks_list', {"fR": { "event.title" : [ event.title ]}}) }}">{{ event.title }}</a>, ayant eu lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }} et {{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM YYYY') }}.
+                        Conférence donnée lors du <a href="{{ url('talks_list', {"fR": { "event.title" : [ event.title ]}}) }}">{{ event.title }}</a>,
+                        ayant eu lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }} et{{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM YYYY') }}.
                     </div>
 
                 </div>
@@ -133,14 +149,6 @@
                 </div>
                 {% endif %}
             </div>
-            {% if talk.hasYoutubeId %}
-            <div class="col-md-6">
-                <h2>Vidéo</h2>
-                <div class="responsive-video-container">
-                    <div id="player"></div>
-                </div>
-            </div>
-            {% endif %}
         </div>
 
         <div class="container">
@@ -247,16 +255,16 @@
             <div class="col-md-12">
                 <div class="container comments-title-container">
                     <div class="col-md-12">
-                        <h2>Transcript</h2>
+                        <h2>Transcription de la vidéo</h2>
                     </div>
                 </div>
 
                 <div class="container">
                     <div class="col-md-12 talk-comment-container transcript">
-
-                    {% for cue in transcript %}
-                        <p data-cue-start="{{ cue.start }}" style="cursor:pointer;">{{ cue.text }}</p>
-                    {% endfor %}
+                        {% for cue in transcript %}
+                            <p data-cue-start="{{ cue.start }}" style="cursor:pointer;">{{ cue.text }}</p>
+                        {% endfor %}
+                    </div>
                 </div>
 
             </div>
@@ -279,7 +287,8 @@
 
                 </div>
             </div>
-            {% endif %}
+        </div>
+        {% endif %}
 
     </div>
 {% endblock %}

--- a/app/Resources/views/site/talks/show.html.twig
+++ b/app/Resources/views/site/talks/show.html.twig
@@ -94,9 +94,8 @@
                 <div class="container talk-date-container">
                     <div class="col-md-12">
                         Conférence donnée lors du <a href="{{ url('talks_list', {"fR": { "event.title" : [ event.title ]}}) }}">{{ event.title }}</a>,
-                        ayant eu lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }} et{{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM YYYY') }}.
+                        ayant eu lieu {% if event.dateStart == event.dateEnd %}le {{ event.dateStart|date('d') }}{% else %}les {{ event.dateStart|date('d') }} et {{ event.dateEnd|date('d') }}{% endif %} {{ event.dateEnd|localizeddate('none', 'none', 'fr', 'Europe/Paris', 'MMMM YYYY') }}.
                     </div>
-
                 </div>
 
                 {% if talk.hasSlidesUrl or talk.hasBlogPostUrl or talk.hasJoindinId or talk.getVideoHasEnSubtitles or talk.getVideoHasFrSubtitles or talk.hasOpenfeedbackPath %}
@@ -174,7 +173,9 @@
                     </div>
                     <div class="container">
                         <div class="col-md-2 speaker-photo-container">
-                            <img src="{{ photo_storage.getUrl(speaker) }}" class="speaker-photo" alt="" />
+                            {% if photo_storage.getUrl(speaker) %}
+                                <img src="{{ photo_storage.getUrl(speaker) }}" class="speaker-photo" alt="" />
+                            {% endif %}
                             <div class="speaker-talks-link">
                                 <a href="{{ url('talks_list', {"fR": { "speakers.label" : [ speaker.label ]}}) }}">Voir tous ses talks</a>
                             </div>

--- a/db/seeds/Session.php
+++ b/db/seeds/Session.php
@@ -30,15 +30,30 @@ class Session extends AbstractSeed
                 'plannifie' => 1,
                 'needs_mentoring' => 0,
                 'youtube_id' => 'MseSkWbhxV8',
-                'video_has_fr_subtitles' => 0,
-                'video_has_en_subtitles' => 0,
+                'video_has_fr_subtitles' => 1,
+                'video_has_en_subtitles' => 1,
                 'slides_url' => 'https://speakerdeck.com/caporaldead/jouons-tous-ensemble-a-un-petit-jeu',
-                'blog_post_url' => '',
+                'blog_post_url' => 'https://mon-blog.com/post/123',
+                'interview_url' => 'https://mon-blog.com/interview/456',
+                'openfeedback_url' => 'https://openfeedback.io/eaJnyMXD3oNfhrrnBYDT/2019-06-27/100',
                 'language_code' => 'fr',
                 'markdown' => 1,
                 'joindin' => 24041,
                 'date_publication' => null,
                 'has_allowed_to_sharing_with_local_offices' => 1,
+                'transcript' => <<<EOF
+                1
+                00:00:28,440 --> 00:00:29,900
+                Merci.
+                
+                2
+                00:00:29,920 --> 00:00:31,660
+                Merci.
+                
+                3
+                00:00:31,680 --> 00:00:33,340
+                Bonjour, bonjour à toutes et à tous.
+                EOF
             ],
             [
                 'session_id' => self::ID_SESSIONS[1],

--- a/db/seeds/Session.php
+++ b/db/seeds/Session.php
@@ -35,7 +35,7 @@ class Session extends AbstractSeed
                 'slides_url' => 'https://speakerdeck.com/caporaldead/jouons-tous-ensemble-a-un-petit-jeu',
                 'blog_post_url' => 'https://mon-blog.com/post/123',
                 'interview_url' => 'https://mon-blog.com/interview/456',
-                'openfeedback_url' => 'https://openfeedback.io/eaJnyMXD3oNfhrrnBYDT/2019-06-27/100',
+                'openfeedback_path' => 'eaJnyMXD3oNfhrrnBYDT/2019-06-27/100',
                 'language_code' => 'fr',
                 'markdown' => 1,
                 'joindin' => 24041,


### PR DESCRIPTION
1. On remonte la vidéo dans le code HTML pour indiquer que c'est une page de lecture de la vidéo et non une vidéo qui illustre un article.
On utilise aussi l'embed pour faciliter le crawl Google.

2. On désindexe les page de gestion de calendrier `{event}/calendar` qui n'ont aucun intérêt pour le référencement.


<img width="1068" alt="Capture d’écran 2025-02-23 à 18 22 37" src="https://github.com/user-attachments/assets/014f772c-aab3-4468-b832-e2e0af300654" />

