### PR TITLE
Simplification du docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ docker-down:
 
 ### Démarrer un bash dans le container PHP
 console:
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --rm cliphp bash
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) exec -u localUser -it apachephp bash
 
 ##@ Quality
 
@@ -85,7 +85,7 @@ test-functional: data config htdocs/uploads tmp
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) stop dbtest apachephptest mailcatcher
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) up -d dbtest apachephptest mailcatcher
 	make clean-test-deprecated-log
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm cliphp ./bin/behat
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm -u localUser apachephp ./bin/behat
 	make var/logs/test.deprecations_grouped.log
 	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) stop dbtest apachephptest mailcatcher
 
@@ -110,12 +110,12 @@ hooks: .git/hooks/pre-commit .git/hooks/post-checkout
 
 .git/hooks/pre-commit: Makefile
 	echo "#!/bin/sh" > .git/hooks/pre-commit
-	echo "docker compose run --rm  cliphp make test" >> .git/hooks/pre-commit
+	echo "docker compose run --rm -u localUser apachephp make test" >> .git/hooks/pre-commit
 	chmod +x .git/hooks/pre-commit
 
 .git/hooks/post-checkout: Makefile
 	echo "#!/bin/sh" > .git/hooks/post-checkout
-	echo "docker compose run --rm  cliphp make vendor" >> .git/hooks/post-checkout
+	echo "docker compose run --rm -u localUser apachephp make vendor" >> .git/hooks/post-checkout
 	chmod +x .git/hooks/post-checkout
 
 
@@ -145,12 +145,12 @@ composer.phar:
 
 init-db:
 	make reset-db
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --rm cliphp make db-migrations
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --rm cliphp make db-seed
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --rm -u localUser apachephp make db-migrations
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --rm -u localUser apachephp make db-seed
 
 config:
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm cliphp make vendors
-	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm cliphp make assets
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm -u localUser apachephp make vendors
+	CURRENT_UID=$(CURRENT_UID) $(DOCKER_COMPOSE_BIN) run --no-deps --rm -u localUser apachephp make assets
 
 data:
 	mkdir data

--- a/compose.yml
+++ b/compose.yml
@@ -64,28 +64,6 @@ services:
       dbtest:
         condition: service_healthy
 
-  cliphp:
-    build:
-      context: ./docker/dockerfiles/apachephp
-      args:
-        uid: ${CURRENT_UID:-1001}
-        gid: "1001"
-        ENABLE_XDEBUG: ${ENABLE_XDEBUG:-false}
-    env_file:
-      .env
-    user: localUser
-    volumes:
-      - ./data/composer:/home/localUser/.composer
-      - ./:/var/www/html
-    links:
-      - db
-      - apachephp
-      - mailcatcher
-      - apachephptest
-      - dbtest
-      - statictestresources
-    command: "false"
-
   mailcatcher:
     image: dockage/mailcatcher:0.9.0
 

--- a/docker/bin/bash
+++ b/docker/bin/bash
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker compose run --rm cliphp /bin/bash
+docker compose exec -u localUser -it apachephp bash


### PR DESCRIPTION
Suppression du container `cliphp` qui ne sert à rien.

On utilise maintenant le container `apachephp` pour la console.