### PR TITLE
Installation de composer via Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,15 +133,11 @@ compose.override.yml:
 
 vendors: vendor node_modules
 
-vendor: composer.phar composer.lock
-	php composer.phar install --no-scripts
+vendor: composer.lock
+	composer install --no-scripts
 
 node_modules:
 	npm install --legacy-peer-deps
-
-composer.phar:
-    # You may replace the commit hash by whatever the last commit hash is on https://github.com/composer/getcomposer.org/commits/main
-	curl https://raw.githubusercontent.com/composer/getcomposer.org/46c42b8248e157b4f77acf5150dacba6aeb60901/web/installer | php -- --2.2
 
 init-db:
 	make reset-db

--- a/clevercloud/scripts/change_composer_version.sh
+++ b/clevercloud/scripts/change_composer_version.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Cela permer d'éviter cette erreur
-# Composer 2.3.0 dropped support for PHP <7.2.5 and you are running 7.0.33, please upgrade PHP or use Composer 2.2 LTS via "composer self-update --2.2". Aborting.
-# une fois migré sur une version >7.2 on pourra supprimer cela
-
-curl https://getcomposer.org/download/2.2.22/composer.phar -o /usr/bin/composer.phar

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -51,3 +51,6 @@ RUN sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apa
     a2ensite 000-default && \
     a2enmod rewrite ssl && \
     echo "date.timezone=Europe/Paris" >> "/usr/local/etc/php/php.ini"
+
+# Installing Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
Maintenant que le projet est en PHP 7.4, il n'y a plus besoin d'installer une ancienne version de composer explicitement.

Et cela permet aussi de simplifier le dev, on peut directement utiliser la commande `composer` sans avoir à faire `php composer.phar`.