### PR TITLE
Désactivation des logs des erreurs 404

### DIFF
--- a/app/config/config_prod.yml
+++ b/app/config/config_prod.yml
@@ -11,6 +11,7 @@ monolog:
     handlers:
         main:
             type:         fingers_crossed
+            excluded_http_codes: [404]
             action_level: error
             handler:      nested
         nested:


### PR DESCRIPTION
Ces erreurs peuvent être exclues depuis Symfony 4.1 et rendent la lecture des logs compliquée à cause des bots qui testent plein d'urls.

Blog : https://symfony.com/blog/new-in-symfony-4-1-ignore-specific-http-codes-from-logs

Doc : https://symfony.com/doc/current/logging/monolog_exclude_http_codes.html