### PR TITLE
correction chemins badges/logos entreprises/general meetings

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -46,12 +46,12 @@ services:
     AppBundle\Controller\Admin\Site\AddRubriqueAction:
         autowire: true
         arguments :
-            $storageDir: '%kernel.project_dir%/htdocs/templates/site/images'
+            $storageDir: '%kernel.project_dir%/../htdocs/templates/site/images'
 
     AppBundle\Controller\Admin\Site\EditRubriqueAction:
         autowire: true
         arguments :
-            $storageDir: '%kernel.project_dir%/htdocs/templates/site/images'
+            $storageDir: '%kernel.project_dir%/../htdocs/templates/site/images'
 
     AppBundle\Controller\Admin\Members\BadgeNewAction:
         autowire: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -6,9 +6,9 @@ parameters:
         oauth_access_token_secret: "%twitter_oauth_access_token_secret%"
         consumer_key: "%twitter_consumer_key%"
         consumer_secret: "%twitter_consumer_secret%"
-    app.badge_dir: "%kernel.project_dir%/htdocs/uploads/badges"
-    app.members_logo_dir: "%kernel.project_dir%/htdocs/uploads/members_logo"
-    app.general_meetings_dir: "%kernel.project_dir%/htdocs/uploads/general_meetings_reports"
+    app.badge_dir: "%kernel.project_dir%/../htdocs/uploads/badges"
+    app.members_logo_dir: "%kernel.project_dir%/../htdocs/uploads/members_logo"
+    app.general_meetings_dir: "%kernel.project_dir%/../htdocs/uploads/general_meetings_reports"
 
 services:
 #    service_name:


### PR DESCRIPTION
Les logos des entreprises, le listing des CR d'AG et certains badges (ceux uploadés dans l'admin) n'était plus affichés.

Logo des entreprises sur https://afup.org/profile/company
![Screenshot 2025-03-02 at 17-51-55 Les entreprises adhérentes à l'AFUP](https://github.com/user-attachments/assets/5f1fb05a-b621-4e76-bad0-84264df91fd9)


CR AG : https://afup.org/member/general-meeting
![Screenshot 2025-03-02 at 17-52-24 Afup - Association française des utilisateurs de PHP](https://github.com/user-attachments/assets/bce0a73d-4320-404d-8eb2-770093eb4f80)

badges manquants sur https://afup.org/member/
![Screenshot 2025-03-02 at 17-52-47 Afup - Association française des utilisateurs de PHP](https://github.com/user-attachments/assets/1beb69a1-f972-4ae2-80cd-0d44d5efb2c7)


Cela le kernel.project_dir renvoie vers le dossier app :

La valeur du paramètre en prod :
```
bas@b248cc15-f7fa-4b2c-ad51-9de51c661ae3 ~/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da $ php bin/console debug:container  --parameters | grep general_meetings_dir
  app.general_meetings_dir                                  /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/app/htdocs/uploads/general_meetings_reports
```

Le dossier du paramètre n'existe pas :
```
bas@b248cc15-f7fa-4b2c-ad51-9de51c661ae3 ~/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da $ ls -l /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/app/htdocs/uploads/general_meetings_reports
ls: cannot access '/home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/app/htdocs/uploads/general_meetings_reports': No such file or directory
```

En remontant d'un cran cela fonctionne :
```
bas@b248cc15-f7fa-4b2c-ad51-9de51c661ae3 ~/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da $ ls -l /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/app/../htdocs/uploads/general_meetings_reports
total 4528
-rwxr-x--- 1 bas bas  141444 Jul 29  2019 '2014-02-15_CR AG AFUP 2013-2014.pdf'
-rwxr-x--- 1 bas bas  100121 Jul 29  2019 '2014-02-15_CR AG Extra AFUP 2013-2014.pdf'
-rwxr-x--- 1 bas bas 2182951 Jul 29  2019 '2015-02-07_CR AG AFUP 2014-2015.pdf'
-rwxr-x--- 1 bas bas  140019 Jul 29  2019 '2017-02-11_CR AG AFUP 2016_2017.pdf'
-rwxr-x--- 1 bas bas  145625 Jul 29  2019 '2018-02-24_CR AG AFUP 2017-2018.pdf'
-rwxr-x--- 1 bas bas  177827 Jul 29  2019 '2019-02-23_CR AG AFUP 2018-2019.pdf'
-rwxr-x--- 1 bas bas  197450 Sep 18  2020 '2020-02-29_CR AG AFUP 2019-2020.pdf'
-rwxr-x--- 1 bas bas  195659 Mar  2  2021 '2021-02-27_CR AG AFUP 2020-2021.pdf'
-rwxr-x--- 1 bas bas  455637 Feb 22  2022 '2022-02-12_CR AG AFUP 2021-2022.pdf'
-rwxr-x--- 1 bas bas  423990 Feb 28  2023 '2023-02-11_CR AG AFUP 2022-2023.pdf'
-rwxr-x--- 1 bas bas  453787 Feb 23  2024 '2024-02-10_CR AG AFUP 2023-2024.pdf'
```