### PR TITLE
correction de l'affichage du planning personnalisé

### DIFF
--- a/htdocs/calendrier/js/controllers/PlanningCtrl.js
+++ b/htdocs/calendrier/js/controllers/PlanningCtrl.js
@@ -17,9 +17,9 @@ planningPHPTourApp.controller('planningCtrl', ['$scope','$http', '$rootScope', '
     $scope.events = [];
 
     //Chargement des conférences
-    $http.get($('body').data('planning-url')).success(function(data) {
+    $http.get($('body').data('planning-url')).then(function(response) {
         //Save Data
-        $scope.confs = data;
+        $scope.confs = response.data;
 
         //Mave Event
         $scope.events = fullCalendarService.getEventList($scope.confs);


### PR DESCRIPTION
en allant sur https://afup.org/event/afupday2025lille/calendar

Le planning ne s'affiche pas et on a cette erreur : `TypeError: $http.get(...).success is not a function`.

![Capture d’écran du 2025-03-05 21-19-34](https://github.com/user-attachments/assets/bcc65654-105a-45ca-b351-1c4eb50e57d8)


On est en angular 1.8.3 :
```
cat node_modules/angular/package.json
{
  "name": "angular",
  "version": "1.8.3",
```

Et en fait même à priori dans le lock on était en 1.8.3 : https://github.com/afup/web/blob/f5c4ebf4d3e9a8b4aa7107be974c88d9f56d09f2/yarn.lock#L82

si on regarde dans un ancien dossier on était en 1.2.16.

On le confirme en local :
```
cat node_modules_old/angular/package.json
{
  "name": "angular",
  "version": "1.2.16",
```

Et sur l'ancienne prod :
```
afupsvr01:/home/sources/web/current$ cat node_modules/angular/package.json
{
  "name": "angular",
  "version": "1.2.16",
```

On adapte donc l'appel à la nouvelle version d'angular pour faire fonctionner le calendrier.