### PR TITLE
correction de l'export de l'inscription

### DIFF
--- a/sources/AppBundle/Offices/OfficeFinder.php
+++ b/sources/AppBundle/Offices/OfficeFinder.php
@@ -121,6 +121,10 @@ class OfficeFinder
         $localOfficesDistance = [];
 
         foreach ($this->antennesCollection->getAll() as $antenne) {
+            if (null === $antenne->map) {
+                continue;
+            }
+
             $localOfficesDistance[$antenne->code] = $this->haversineGreatCircleDistance(
                 $coordinates->getLatitude(),
                 $coordinates->getLongitude(),


### PR DESCRIPTION
Nous avons actuellement une 500 lors de l'export du CSV des inscriptions.

Il y a cette erreur :
```
Uncaught PHP Exception TypeError: "Argument 3 passed to AppBundle\Offices\OfficeFinder::haversineGreatCircleDistance() must be of the type float, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Offices/OfficeFinder.php on line 128" at /home/bas/app_ee619ef6-05d2-4b4c...
```

Certaines antennes n'ont pas de ville, à juste titre : https://github.com/afup/web/blob/adc7b0935c4d27fd4d5d255bdd09dbc8576d030e/sources/AppBundle/Antennes/AntennesCollection.php#L453

Il faut donc prévoir le cas pour ne pas passer un null

Cela se voit maintenant qu'on a un plus fort typage (cf https://github.com/afup/web/commit/242883255f1ec651741fd0b25c4f1cfd9dcb0a6f#diff-3b3beab268a7572cf54c50d39c238818f5072822e046059575aaac5934011339)