### PR TITLE
On évite de remonter dans les logs les erreurs 404

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -344,6 +344,10 @@ framework:
     fragments:       ~
     http_method_override: true
     assets: ~
+    exceptions:
+        Symfony\Component\HttpKernel\Exception\NotFoundHttpException:
+            log_level: debug
+            status_code: 404
 
 # Twig Configuration
 twig:


### PR DESCRIPTION
Dans les logs on avait ce genre d'erreur :

```
2025-03-23T22:28:19.003Z request.ERROR: Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\NotFoundHttpException: "No route found for "GET https://preprod.afup.org/article15.php3"" at /home/bas/app_d6e663fe-4730-44e4-a2f4-b0b9e0e13060/vendor/symfony/http-kernel/EventListener/RouterListener.php line 135 {"exception":"[object] (Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException(code: 0): No route found for \"GET https://preprod.afup.org/article15.php3\" at /home/bas/app_d6e663fe-4730-44e4-a2f4-b0b9e0e13060/vendor/symfony/http-kernel/EventListener/RouterListener.php:135)\n[previous exception] [object] (Symfony\\Component\\Routing\\Exception\\ResourceNotFoundException(code: 0): No routes found for \"/article15.php3/\". at /home/bas/app_d6e663fe-4730-44e4-a2f4-b0b9e0e13060/vendor/symfony/routing/Matcher/Dumper/CompiledUrlMatcherTrait.php:74)"} []
```

Même avec le https://github.com/afup/web/commit/320d16c291e4b37a6a5e7bbe49299e0e4c726dda on continuait à avoices 404 qui remontaient en erreur dans les logs.

On évite donc de les remonter en passant en debug le niveau de ces eceptions.