### PR TITLE
Modification de l'heure de post auto

### DIFF
--- a/clevercloud/cron.json
+++ b/clevercloud/cron.json
@@ -11,5 +11,5 @@
   "55 15 * * * $ROOT/clevercloud/scripts/deduplicate_cron.sh /usr/bin/php $ROOT/bin/console --env=prod slack-member-notification",
   "0 * * * * $ROOT/clevercloud/scripts/deduplicate_cron.sh /usr/bin/php $ROOT/bin/console --env=prod update-user-state",
   "32 * * * * $ROOT/clevercloud/scripts/deduplicate_cron.sh /usr/bin/php $ROOT/bin/console --env=prod update-company-member-state",
-  "0 13 * * 2,4 $ROOT/clevercloud/scripts/deduplicate_cron.sh /usr/bin/php $ROOT/bin/console --env=prod videos:run-notifier"
+  "0 12 * * 2,4 $ROOT/clevercloud/scripts/deduplicate_cron.sh /usr/bin/php $ROOT/bin/console --env=prod videos:run-notifier"
 ]


### PR DESCRIPTION
Le serveur est en UTC donc il faut décaler.

Un jour il faudra revoir ça avec le scheduler de Symfony qui gère les timezones mais on ne peut pas encore l'utiliser (il faut SF 6.3 minimum).