### PR TITLE
on désactive le champ "Prix définis en incluant la TVA"

### DIFF
--- a/sources/AppBundle/Event/Form/EventType.php
+++ b/sources/AppBundle/Event/Form/EventType.php
@@ -132,6 +132,7 @@ class EventType extends AbstractType
             ->add('pricesDefinedWithVat', CheckboxType::class, [
                 'label' => 'Prix définis en incluant la TVA (définis en TTC) ',
                 'required' => false,
+                'disabled' => true,
             ])
             ->add('registration_email_file', FileType::class, [
                 'label' => ' Pièce jointe du mail d\'inscription',


### PR DESCRIPTION
Ce champ ne doit être coché que sur des anciens événéments. Il est là pour gérer l'historique et ne doit plus être coché. Afin d'éviter qu'il soit coché dans le futur on le désactive, ainsi il reste affiché à titre informatif.