### PR TITLE
on désactive l'envoi des depréciations dans la liste des erreurs sur new relic

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -435,3 +435,4 @@ ewz_recaptcha:
 
 ekino_new_relic:
     exceptions: true
+    deprecations: false


### PR DESCRIPTION
Depuis le https://github.com/afup/web/pull/1674/files nous sommes passés de la version 1.4 à la version 2.4 du bundle EkinoNewRelicBundle.

Entre les deux versions la fonctionnalité de log de dépréciations a été ajoutée : https://github.com/ekino/EkinoNewRelicBundle/compare/1.4.0...2.4.0

Cela dans la version v2.0.0-beta1 (dans le changelog il est indiqué :
```
- Added a new `deprecations` parameter to logs `E_USER_DEPRECATED`.
```
)

Le nombre d'erreur a très nettement augmenté sur New Relic.

Cela est devenu moins exploitable.

![Capture d’écran du 2025-03-27 20-53-14](https://github.com/user-attachments/assets/e1f472bb-df96-460e-ba99-c5bd21e6ce43)
![Capture d’écran du 2025-03-27 20-52-58](https://github.com/user-attachments/assets/5ab76bb9-e8bf-450e-9f7a-0c32922b8b1f)

![Capture d’écran du 2025-03-27 21-03-29](https://github.com/user-attachments/assets/9459735a-f229-47c9-8ae2-06d089e859eb)


Dans le cadre du mise à jour dans une prochaine majeure de Symfony mieux vaudra d'abord faire une première passe de correction des dépréciations en CI, puis activer le log de déprécations en prod quelques jours avant la mise en prod.

On désactive donc pour le moment le log des dépréciations afin d'avoir un log d'erreur exploitable (il y a aussi des 404 rémontées à New Relic mais c'est un sujet à traiter dans une autre PR)