### PR TITLE
Gestion des ID YouTube vides

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -752,10 +752,6 @@ services:
             $connection: '@Doctrine\DBAL\Connection'
 
     AppBundle\VideoNotifier\Engine:
+        autowire: true
         arguments:
             $transports: !tagged_iterator app.social_network.transport
-            $planningRepository: '@AppBundle\Event\Model\Repository\PlanningRepository'
-            $talkRepository: '@AppBundle\Event\Model\Repository\TalkRepository'
-            $speakerRepository: '@AppBundle\Event\Model\Repository\SpeakerRepository'
-            $historyRepository: '@AppBundle\VideoNotifier\HistoryRepository'
-            $logger: '@logger'

--- a/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
@@ -42,7 +42,7 @@ class PlanningRepository extends Repository implements MetadataInitializer
     /**
      * @return CollectionInterface<Planning>
      */
-    public function findNonKeynotesSince(\DateTime $since): CollectionInterface
+    public function findNonKeynotesBetween(\DateTimeInterface $since, \DateTimeInterface $until): CollectionInterface
     {
         /** @var SelectInterface $qb */
         $qb = $this->getQueryBuilder(self::QUERY_SELECT);
@@ -50,12 +50,15 @@ class PlanningRepository extends Repository implements MetadataInitializer
         $qb->from('afup_forum_planning')
             ->cols(['*'])
             ->where('keynote = 0')
-            ->where('debut >= :since');
+            ->where('debut >= :since')
+            ->where('debut < :until')
+        ;
 
         return $this
             ->getPreparedQuery($qb->getStatement())
             ->setParams([
                 'since' => $since->getTimestamp(),
+                'until' => $until->getTimestamp(),
             ])
             ->query($this->getCollection(new HydratorSingleObject()));
     }

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -290,7 +290,7 @@ class Talk implements NotifyPropertyInterface
 
     public function hasYoutubeId(): bool
     {
-        return null !== $this->getYoutubeId();
+        return null !== $this->getYoutubeId() && '' !== $this->getYoutubeId();
     }
 
     public function getYoutubeUrl(): ?string

--- a/sources/AppBundle/VideoNotifier/Engine.php
+++ b/sources/AppBundle/VideoNotifier/Engine.php
@@ -11,6 +11,7 @@ use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Talk;
 use AppBundle\SocialNetwork\Transport;
 use Exception;
+use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 
 final class Engine
@@ -27,6 +28,7 @@ final class Engine
     private SpeakerRepository $speakerRepository;
     private HistoryRepository $historyRepository;
     private LoggerInterface $logger;
+    private ClockInterface $clock;
 
     /**
      * @param iterable<Transport> $transports
@@ -37,7 +39,8 @@ final class Engine
         TalkRepository $talkRepository,
         SpeakerRepository $speakerRepository,
         HistoryRepository $historyRepository,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        ClockInterface $clock
     ) {
         $this->transports = $transports;
         $this->planningRepository = $planningRepository;
@@ -45,6 +48,7 @@ final class Engine
         $this->speakerRepository = $speakerRepository;
         $this->historyRepository = $historyRepository;
         $this->logger = $logger;
+        $this->clock = $clock;
     }
 
     public function run(): ?HistoryEntry
@@ -101,7 +105,7 @@ final class Engine
     {
         $minimumEventDate = new \DateTime('-2 years');
 
-        $plannings = $this->planningRepository->findNonKeynotesSince($minimumEventDate);
+        $plannings = $this->planningRepository->findNonKeynotesBetween($minimumEventDate, $this->clock->now());
 
         $talkIds = [];
 


### PR DESCRIPTION
Cette PR corrige deux soucis :

- certains talks ont une string vide au lieu de `null` comme id youtube
- le script n'excluait pas les talks programmés dans le futur (qui sont dispos avant un event via la publication des programmes)