### PR TITLE
Archivage des évènements

### DIFF
--- a/app/config/routing/admin_event.yml
+++ b/app/config/routing/admin_event.yml
@@ -89,3 +89,15 @@ admin_event_badges:
 admin_event_previous_registrations:
   path: /previous_registrations
   defaults: {_controller: AppBundle\Controller\Admin\Event\PreviousRegistrationsAction }
+
+admin_event_archive:
+  path: /archive/{id}
+  defaults: { _controller: AppBundle\Controller\Admin\Event\ArchiveAction }
+  requirements:
+    id: \d+
+
+admin_event_restore:
+  path: /restore/{id}
+  defaults: { _controller: AppBundle\Controller\Admin\Event\RestoreAction }
+  requirements:
+    id: \d+

--- a/db/migrations/20250412223717_add_archived_at_to_events.php
+++ b/db/migrations/20250412223717_add_archived_at_to_events.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddArchivedAtToEvents extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_forum')
+            ->addColumn('archived_at', 'timestamp', [
+                'null' => true,
+            ])
+            ->save();
+    }
+}

--- a/htdocs/pages/administration/forum_inscriptions.php
+++ b/htdocs/pages/administration/forum_inscriptions.php
@@ -121,7 +121,7 @@ if ($action == 'lister') {
         ],
     ]);
 
-    $smarty->assign('forums', $forum->obtenirListe());
+    $smarty->assign('forums', $forum->obtenirListActive());
     $smarty->assign('inscriptions', $forum_inscriptions->obtenirListe($_GET['id_forum'], $list_champs, $list_ordre, $list_associatif, $list_filtre));
     $smarty->assign('finForum', (new \DateTime($forumData['date_fin']))->format('U'));
     $smarty->assign('now', (new \DateTime())->format('U'));

--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -119,6 +119,11 @@ class Forum
         }
     }
 
+    public function obtenirListActive()
+    {
+        return $this->_bdd->obtenirTous('SELECT * FROM afup_forum WHERE archived_at IS NULL ORDER BY titre');
+    }
+
     public function afficherDeroulementMobile($sessions): string
     {
         $deroulement = "<div class=\"deroulements\">";

--- a/sources/AppBundle/Controller/Admin/Event/ArchiveAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ArchiveAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Event;
+
+use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Repository\EventRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class ArchiveAction extends AbstractController
+{
+    private EventRepository $eventRepository;
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(EventRepository $eventRepository, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->eventRepository = $eventRepository;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function __invoke(Request $request, int $id): Response
+    {
+        $event = $this->eventRepository->get($id);
+
+        if (!$event instanceof Event) {
+            $this->addFlash('error', 'Évènement non trouvé');
+
+            return new RedirectResponse($this->urlGenerator->generate('admin_event_list'));
+        }
+
+        $event->setArchivedAt(new \DateTime());
+        $this->eventRepository->save($event);
+
+        return new RedirectResponse($this->urlGenerator->generate('admin_event_edit', ['id' => $id]));
+    }
+}

--- a/sources/AppBundle/Controller/Admin/Event/RestoreAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RestoreAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Event;
+
+use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Repository\EventRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+final class RestoreAction extends AbstractController
+{
+    private EventRepository $eventRepository;
+    private UrlGeneratorInterface $urlGenerator;
+
+    public function __construct(EventRepository $eventRepository, UrlGeneratorInterface $urlGenerator)
+    {
+        $this->eventRepository = $eventRepository;
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public function __invoke(Request $request, int $id): Response
+    {
+        $event = $this->eventRepository->get($id);
+
+        if (!$event instanceof Event) {
+            $this->addFlash('error', 'Évènement non trouvé');
+
+            return new RedirectResponse($this->urlGenerator->generate('admin_event_list'));
+        }
+
+        $event->setArchivedAt(null);
+        $this->eventRepository->save($event);
+
+        return new RedirectResponse($this->urlGenerator->generate('admin_event_edit', ['id' => $id]));
+    }
+}

--- a/sources/AppBundle/Event/Form/EventSelectType.php
+++ b/sources/AppBundle/Event/Form/EventSelectType.php
@@ -34,7 +34,7 @@ class EventSelectType extends AbstractType
                     'choice_value' => 'id',
                     'data' => $options['data'] ?? null,
                     'choices' => $this->eventHelper->sortEventsByStartDate(
-                        iterator_to_array($this->eventRepository->getAll()),
+                        iterator_to_array($this->eventRepository->getAllActive()),
                     ),
                     'group_by' => fn (Event $choice): string => $this->eventHelper->groupByYear($choice),
                 ]

--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -98,6 +98,8 @@ class Event implements NotifyPropertyInterface
 
     private bool $hasPricesDefinedWithVat = true;
 
+    private ?DateTime $archivedAt = null;
+
     /**
      * @return int
      */
@@ -681,6 +683,19 @@ class Event implements NotifyPropertyInterface
 
         $this->propertyChanged('transportInformationEnabled', $this->transportInformationEnabled, $transportInformationEnabled);
         $this->transportInformationEnabled = $transportInformationEnabled;
+
+        return $this;
+    }
+
+    public function getArchivedAt(): ?DateTime
+    {
+        return $this->archivedAt;
+    }
+
+    public function setArchivedAt(?DateTime $archivedAt): self
+    {
+        $this->propertyChanged('archivedAt', $this->archivedAt, $archivedAt);
+        $this->archivedAt = $archivedAt;
 
         return $this;
     }

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -87,7 +87,7 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getList($id = null)
     {
         $sql = <<<ENDSQL
-SELECT f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente, IF(count(s.session_id) + count(i.id)>0, 0, 1) as est_supprimable
+SELECT f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente, f.archived_at, IF(count(s.session_id) + count(i.id)>0, 0, 1) as est_supprimable
 FROM afup_forum f
 LEFT JOIN afup_sessions s ON (f.id = s.id_forum)
 LEFT JOIN afup_inscription_forum i ON (f.id = i.id_forum)
@@ -205,6 +205,13 @@ SQL;
     public function getByPath($path)
     {
         return $this->getBy(['path' => $path])->first();
+    }
+
+    public function getAllActive(): CollectionInterface
+    {
+        $query = $this->getQuery('SELECT * FROM afup_forum WHERE archived_at IS NULL');
+
+        return $query->query($this->getCollection(new HydratorSingleObject()));
     }
 
     public static function initMetadata(SerializerFactoryInterface $serializerFactory, array $options = [])
@@ -388,6 +395,11 @@ SQL;
                 'fieldName' => 'transportInformationEnabled',
                 'type' => 'bool',
                 'serializer' => Boolean::class
+            ])
+            ->addField([
+                'columnName' => 'archived_at',
+                'fieldName' => 'archivedAt',
+                'type' => 'datetime',
             ])
         ;
 

--- a/templates/admin/event/edit.html.twig
+++ b/templates/admin/event/edit.html.twig
@@ -2,6 +2,17 @@
 
 {% block content %}
     <h2>Modifier un évènement</h2>
+
+    {% if event.archivedAt %}
+        <div class="ui warning message">
+            <div class="header">
+                Cet évènement est archivé depuis le {{ event.archivedAt|date("d/m/Y") }}
+            </div>
+
+            Les données sont encore là, mais il n'est plus affiché sur les autres pages de la section Évènements.
+        </div>
+    {% endif %}
+
     <div class="ui menu">
         <a href="{{ path('admin_event_send_test_mail_inscription', {id: event.id}) }}" class="item">
             <i class=" icon mail"></i>
@@ -18,10 +29,25 @@
                 <a class="item" target="_blank" href="{{ path('openfeedback_json', {eventSlug: event.path}) }}">Export vers Openfeedback</a>
             </div>
         </div>
+
+        <div class="right menu">
+            {% if event.archivedAt %}
+                <a href="{{ path('admin_event_restore', {id: event.id}) }}" class="item">
+                    <div data-tooltip="Restaurer un évènement l'affiche à nouveau dans le sélecteur des différentes pages" data-position="bottom right">
+                        <i class="icon archive"></i>
+                        Restaurer cet évènement
+                    </div>
+                </a>
+            {% else %}
+                <a href="{{ path('admin_event_archive', {id: event.id}) }}" class="item">
+                    <div data-tooltip="Archiver un évènement le masque dans le sélecteur des différentes pages" data-position="bottom right">
+                        <i class="icon archive"></i>
+                        Archiver cet évènement
+                    </div>
+                </a>
+            {% endif %}
+        </div>
     </div>
 
     {% include 'admin/event/form.html.twig' %}
 {% endblock %}
-
-
-

--- a/templates/admin/event/list.html.twig
+++ b/templates/admin/event/list.html.twig
@@ -32,9 +32,11 @@
         </thead>
         <tbody>
         {% for event in events %}
-            <tr>
+            <tr class="{% if event.archived_at %}warning{% endif %}">
                 <td>
-                    <strong>{{ event.titre }}</strong>
+                    <strong {% if event.archived_at %}data-tooltip="Archivé depuis le {{ event.archived_at|date("d/m/Y") }}" data-position="top left"{% endif %}>
+                        {{ event.titre }}
+                    </strong>
                 </td>
                 <td>{{ event.path }}</td>
                 <td class="right aligned">{{ event.nb_places }}</td>


### PR DESCRIPTION
Avec les années il commence à y avoir pas mal d'évènements dans la base de données.

Cela rend parfois la navigation compliquée dans les différents sous-menus de la section `Évènements` avec le sélecteur très long.

L'idée de ce commit est d'ajouter une notion d'archivage des évènements. C'est une simple colonne nullable en base avec la date d'archivage.
Quand cette date est présente, l'évènement n'est affiché que sur la page `Gestion évènements`.

Le bouton pour archiver :
![image](https://github.com/user-attachments/assets/d40956c6-c323-43e9-9461-098f90775dc2)

L'affichage une fois archivé :
![image](https://github.com/user-attachments/assets/3fb1d9c9-8395-4feb-b067-e5d410d862c3)

Dans la liste ça colore la ligne en jaune :
![image](https://github.com/user-attachments/assets/769c6eca-d53e-4a90-81c3-afa5f693e0cd)

Et au survol on voit la date :
![image](https://github.com/user-attachments/assets/e73602bf-a48b-45b5-be63-dc0721f563f5)
