### PR TITLE
Amélioration de la performance de la liste des events

### DIFF
--- a/sources/AppBundle/Controller/Admin/Event/RemoveEventAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RemoveEventAction.php
@@ -42,7 +42,7 @@ class RemoveEventAction
             return new RedirectResponse($this->urlGenerator->generate('admin_event_list'));
         }
 
-        if ($result->first()['est_supprimable'] !== 1) {
+        if ($result[0]['est_supprimable'] === false) {
             $this->flashBag->add('error', 'Impossible de supprimer un évènement utilisé');
             return new RedirectResponse($this->urlGenerator->generate('admin_event_list'));
         }

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -87,22 +87,53 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getList($id = null)
     {
         $sql = <<<ENDSQL
-SELECT f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente, f.archived_at, IF(count(s.session_id) + count(i.id)>0, 0, 1) as est_supprimable
+SELECT f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente, f.archived_at
 FROM afup_forum f
-LEFT JOIN afup_sessions s ON (f.id = s.id_forum)
-LEFT JOIN afup_inscription_forum i ON (f.id = i.id_forum)
 %s
 GROUP BY f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente
 ORDER BY date_debut desc;
 ENDSQL;
         $sql = sprintf($sql, $id === null ? '':'WHERE f.id = :id');
 
+        $sessions = $this->countRelation('afup_sessions');
+        $inscriptions = $this->countRelation('afup_inscription_forum');
 
         $query = $this->getQuery($sql);
         if ($id !== null) {
             $query->setParams(['id'=>$id]);
         }
-        return $query->query($this->getCollection(new HydratorArray()));
+
+        $results = $query->query($this->getCollection(new HydratorArray()));
+        $data = [];
+
+        foreach ($results as $result) {
+            $result['est_supprimable'] = !array_key_exists($result['id'], $sessions) && !array_key_exists($result['id'], $inscriptions);
+
+            $data[] = $result;
+        }
+
+        return $data;
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function countRelation(string $table): array
+    {
+        if (!in_array($table, ['afup_sessions', 'afup_inscription_forum'], true)) {
+            throw new \InvalidArgumentException('Table non gérée');
+        }
+
+        $query = $this->getQuery('SELECT id_forum, COUNT(id_forum) as quantity FROM ' . $table . ' GROUP BY id_forum;');
+        $results = $query->query($this->getCollection(new HydratorArray()));
+
+        $data = [];
+
+        foreach ($results as $result) {
+            $data[$result['id_forum']] = $result['quantity'];
+        }
+
+        return $data;
     }
 
     public function getAllPastEventWithSpeakerEmail($email)

--- a/templates/admin/event/list.html.twig
+++ b/templates/admin/event/list.html.twig
@@ -53,7 +53,7 @@
                         <i class="pencil alernate icon"></i>
                     </a>
 
-                    {% if  event.est_supprimable == '1' %}
+                    {% if event.est_supprimable %}
                         <a href="{{ path('admin_event_delete', {'id': event.id, 'token': token_delete}) }}"
                            data-position="left center"
                            data-tooltip="Supprimer le forum {{ event.titre }}"


### PR DESCRIPTION
La requête actuelle prend trop de temps à cause des jointures (environ 4 à 5 secondes).

En comptant les relations de façon séparée, le temps de chargement de la page passe de plusieurs secondes à environ 200ms.