### PR TITLE
correction de la planification de campagne pour les veille

### DIFF
--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -130,7 +130,7 @@ class Mailchimp
         ]);
     }
 
-    public function scheduleCampaign(int $campaignId, \DateTime $datetime)
+    public function scheduleCampaign(string $campaignId, \DateTime $datetime)
     {
         return $this->client->post('campaigns/' . $campaignId . '/actions/schedule', [
             'schedule_time' => $datetime->format('c')


### PR DESCRIPTION
En tendant de planifier la veille il y a eut une erreur 500.

En regardant les logs il y a eut cette erreur :
```
Exception 'TypeError' with message 'Argument 1 passed to AppBundle\Mailchimp\Mailchimp::scheduleCampaign() must be of the type int, string given, called in /home/bas/app_<GUID>/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php on line 192' in /home/bas/app_<GUID>/sources/AppBundle/Mailchimp/Mailchimp.php:133
```

L'id est une chaine et non un int, on modifie la signature de la méthode pour que cela fonctionne la fois suivante.