### PR TITLE
CSS Form input width

### DIFF
--- a/htdocs/templates/site/scss/generic/form.scss
+++ b/htdocs/templates/site/scss/generic/form.scss
@@ -64,10 +64,12 @@ form li label {
   font-weight: 400
 }
 
-input[type="color"], input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="email"], input[type="month"], input[type="number"], input[type="password"], input[type="search"], input[type="tel"], input[type="text"], input[type="time"], input[type="url"], input[type="week"], select, textarea, button, input[type="button"], input[type="reset"] {
-  min-width: 300px;
-  padding: .2em 0 .2em .2em;
-  border: 1px solid #ccc
+form {
+  input[type="color"], input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="email"], input[type="month"], input[type="number"], input[type="password"], input[type="search"], input[type="tel"], input[type="text"], input[type="time"], input[type="url"], input[type="week"], select, textarea, button, input[type="button"], input[type="reset"] {
+    min-width: 300px;
+    padding: .2em 0 .2em .2em;
+    border: 1px solid #ccc
+  }
 }
 
 input[type="submit"] {


### PR DESCRIPTION
La règle CSS était trop large et avait des incidences sur la debug bar de Symfony.
Le bouton de fermeture faisait 300px de large et masquait une partie de la bar.

En limitant la règle CSS aux balises `input` enfants de `form`cela règle le problème.

Avant : 

![avant](https://github.com/user-attachments/assets/c699e954-99c2-4b99-919c-fb91277de05a)

Après : 

![après](https://github.com/user-attachments/assets/346f8cb2-ce53-4109-ac0c-111f590de7f8)
