### PR TITLE
Utilisation de l'éditeur plus récent sur les events

### DIFF
--- a/sources/AppBundle/Event/Form/EventCFPTextType.php
+++ b/sources/AppBundle/Event/Form/EventCFPTextType.php
@@ -25,32 +25,27 @@ class EventCFPTextType extends AbstractType
             ])
             ->add('speaker_management_fr', TextareaType::class, [
                 'label' => 'Infos speakers (fr)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'tinymce'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
                 'required' => false,
             ])
             ->add('speaker_management_en', TextareaType::class, [
                 'label' => 'Infos speakers (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'tinymce'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
                 'required' => false,
             ])
             ->add('sponsor_management_fr', TextareaType::class, [
                 'label' => 'Infos sponsors (fr)',
-                'attr' => ['rows' => 5,'cols' => 50, 'class' => 'tinymce'],
+                'attr' => ['rows' => 5,'cols' => 50, 'class' => 'simplemde'],
                 'required' => false,
             ])
             ->add('sponsor_management_en', TextareaType::class, [
                 'label' => 'Infos sponsors (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'tinymce'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
                 'required' => false,
             ])
             ->add('mail_inscription_content', TextareaType::class, [
                 'label' => 'Contenu mail inscription',
                 'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
-                'required' => false,
-            ])
-            ->add('sponsor_management_en', TextareaType::class, [
-                'label' => 'Infos sponsors (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'tinymce'],
                 'required' => false,
             ])
             ->add('become_sponsor_description', TextareaType::class, [

--- a/templates/admin/event/form.html.twig
+++ b/templates/admin/event/form.html.twig
@@ -86,8 +86,8 @@
         <div class="ui form">
             {{ _self.wysiwyg(form.cfp.cfp_fr) }}
             {{ _self.wysiwyg(form.cfp.cfp_en) }}
-            {{ form_row(form.cfp.speaker_management_fr) }}
-            {{ form_row(form.cfp.speaker_management_en) }}
+            {{ _self.wysiwyg(form.cfp.speaker_management_fr) }}
+            {{ _self.wysiwyg(form.cfp.speaker_management_en) }}
             {{ form_row(form.speakersDinerEnabled) }}
             {{ form_row(form.accomodationEnabled) }}
             {{ form_row(form.dateEndSpeakersDinerInfosCollection) }}
@@ -102,8 +102,8 @@
 
         <div class="ui form">
             {{ _self.wysiwyg(form.cfp.become_sponsor_description) }}
-            {{ form_row(form.cfp.sponsor_management_fr) }}
-            {{ form_row(form.cfp.sponsor_management_en) }}
+            {{ _self.wysiwyg(form.cfp.sponsor_management_fr) }}
+            {{ _self.wysiwyg(form.cfp.sponsor_management_en) }}
 
             {{ form_row(form.sponsor_file_fr) }}
             {{ _self.file_path_link(sponsor_file_path_fr, 'Voir le dossier de sponsoring (FR)') }}


### PR DESCRIPTION
> Cette PR vient d'une demande d'Amélie, à l'édition d'un évènement certains textearea utilisent encore l'ancien wysiwyg (tinymce) qui est je cite "tout pourri" 😄
> 
> Avec ce patch on permet l'utilisation de l'éditeur plus récent (simplemde) sur tous les textearea de l'édition/création d'évènement.
> 
> C'est fait de façon à ne pas toucher aux évènements actuels, qui restent sur tinymce qui génère un mix de html et de markdown. On pourra bien sûr migrer les anciens évènement après ce patch si on veut un jour se débarrasser totalement de tinymce.
> 
> Et les nouveaux évènements sont configurés de façon à utiliser le nouvel éditeur à la création.

En fait c'est pas ça le soucis ni la solution, voir ce commentaire : https://github.com/afup/web/pull/1732#issuecomment-2810836854