### PR TITLE
Suppression de la condition

### DIFF
--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -79,12 +79,8 @@ class Runner
     public function transformMeetupsForIndexation(CollectionInterface $meetupsCollection): array
     {
         $meetupsArray = [];
-        /** @var Meetup $meetup */
         foreach ($meetupsCollection as $meetup) {
-            if (null === ($transformedMeetup = $this->transformer->transform($meetup))) {
-                continue;
-            }
-            $meetupsArray[] = $transformedMeetup;
+            $meetupsArray[] = $this->transformer->transform($meetup);
         }
 
         return $meetupsArray;


### PR DESCRIPTION
La méthode `transform` retourne toujours un array donc pas besoin de vérifier.