### PR TITLE
Suppression de tests inutiles

### DIFF
--- a/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
@@ -162,14 +162,6 @@ final class BlueskyTransport implements Transport
             return null;
         }
 
-        if (count($matches) !== 4) {
-            return null;
-        }
-
-        if (!is_string($matches[3])) {
-            return null;
-        }
-
         return $matches[3];
     }
 }


### PR DESCRIPTION
PHPStan est [capable d'analyser les regexes](https://github.com/phpstan/phpstan-src/pull/2589) et donc de savoir que ces tests sont pour des cas impossibles.