### PR TITLE
Activation du scroll horizontal quand la fenêtre est trop petite

### DIFF
--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -25,6 +25,9 @@
                 padding: 20px;
             }
 
+            .scrollable-content {
+                overflow-y: scroll;
+            }
 
             .full-height > .toc .menu {
                 border-radius: 0;
@@ -91,7 +94,7 @@
                     </div>
                 </div>
 
-                <div class="content">
+                <div class="content scrollable-content">
                     {% for bag in ['notice', 'success', 'error'] %}
                         {% for flash_message in app.session.flashBag.get(bag)%}
                             {% if bag == 'error'%}


### PR DESCRIPTION
Demande d'Amélie qui galère sur la page des "venue speakers".

Quand la fenêtre est trop petite, la table a trop d'éléments et ne peut plus se compresser, ce qui masque les colonnes de droite, et la page n'est pas scrollable.

Le scroll ne s'active que si la fenêtre est petite, sinon ça reste l'ancien comportement.