### PR TITLE
retour de la date de fin de saisie des tokens sponsor

### DIFF
--- a/sources/AppBundle/Event/Form/EventType.php
+++ b/sources/AppBundle/Event/Form/EventType.php
@@ -109,6 +109,11 @@ class EventType extends AbstractType
                 'label' => 'Date annonce planning',
                 'required' => false,
             ])
+            ->add('dateEndSalesSponsorToken', DateTimeType::class, [
+                'widget' => 'single_text',
+                'label' => 'Date fin saisie token sponsor',
+                'required' => false,
+            ])
             ->add('cfp', EventCFPTextType::class, [
                 'label' => false
             ])

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -334,7 +334,8 @@ SQL;
                 'fieldName' => 'dateEndSalesSponsorToken',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
             ->addField([

--- a/templates/admin/event/form.html.twig
+++ b/templates/admin/event/form.html.twig
@@ -101,6 +101,7 @@
         <div class="ui clearing divider"></div>
 
         <div class="ui form">
+            {{ form_row(form.dateEndSalesSponsorToken) }}
             {{ _self.wysiwyg(form.cfp.become_sponsor_description) }}
             {{ _self.wysiwyg(form.cfp.sponsor_management_fr) }}
             {{ _self.wysiwyg(form.cfp.sponsor_management_en) }}


### PR DESCRIPTION
Depuis la migration sous symfony de cette page la date de fin de saisie des tokens sponsors n'était plus présente sur la création/modification d'un événement. On l'affiche/permet de la modifier à nouveau.

![Screenshot 2025-04-21 at 14-35-56 Administration AFUP](https://github.com/user-attachments/assets/acace72c-679b-495c-848e-851241dd23b0)
