### PR TITLE
Quelques corrections

### DIFF
--- a/sources/AppBundle/Association/Model/CompanyMember.php
+++ b/sources/AppBundle/Association/Model/CompanyMember.php
@@ -674,4 +674,11 @@ class CompanyMember implements NotifyPropertyInterface
         $this->propertyChanged('cellphone', $this->cellphone, $cellphone);
         $this->cellphone = $cellphone;
     }
+
+    public function getMembershipFee(int $default = AFUP_PERSONNE_MORALE_SEUIL): float
+    {
+        $max = max($this->getMaxMembers(), $default);
+
+        return ceil($max / AFUP_PERSONNE_MORALE_SEUIL) * AFUP_COTISATION_PERSONNE_MORALE;
+    }
 }

--- a/sources/AppBundle/Association/Model/Repository/CompanyMemberRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/CompanyMemberRepository.php
@@ -39,7 +39,7 @@ class CompanyMemberRepository extends Repository implements MetadataInitializer
         );
     }
 
-    public function findById($id)
+    public function findById($id):? CompanyMember
     {
         $queryBuilder = $this->getQueryBuilderWithCompleteCompanyMember();
         $queryBuilder->where('apm.id = :id');

--- a/sources/AppBundle/Controller/Website/MemberShipController.php
+++ b/sources/AppBundle/Controller/Website/MemberShipController.php
@@ -502,7 +502,7 @@ class MemberShipController extends AbstractController
             $id_personne = $user->getCompanyId();
             $type_personne = AFUP_PERSONNES_MORALES;
             $prefixe = 'Personne morale';
-            $montant = $this->companyMemberRepository->findById($id_personne);
+            $montant = AFUP_COTISATION_PERSONNE_MORALE;
             if ($isSubjectedToVat) {
                 $montant *= 1 + Utils::MEMBERSHIP_FEE_VAT_RATE;
             }

--- a/sources/AppBundle/Controller/Website/MemberShipController.php
+++ b/sources/AppBundle/Controller/Website/MemberShipController.php
@@ -502,7 +502,11 @@ class MemberShipController extends AbstractController
             $id_personne = $user->getCompanyId();
             $type_personne = AFUP_PERSONNES_MORALES;
             $prefixe = 'Personne morale';
-            $montant = AFUP_COTISATION_PERSONNE_MORALE;
+
+            if (!$company = $this->companyMemberRepository->findById($id_personne)) {
+                throw $this->createNotFoundException('La personne morale n\'existe pas');
+            }
+            $montant = $company->getMembershipFee();
             if ($isSubjectedToVat) {
                 $montant *= 1 + Utils::MEMBERSHIP_FEE_VAT_RATE;
             }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -498,22 +498,12 @@ class FeatureContext implements Context
     public function iShouldReceiveAnEmail(): void
     {
         $content = file_get_contents(self::MAILCATCHER_URL . '/messages');
-        $decodedContent = json_decode($content, true);
+        $emails = json_decode($content, true);
 
-        $foundEmails = [];
-        foreach ($decodedContent as $mail) {
-            $foundEmails[] = [
-                'to' => $mail['to'],
-                'subject' => $mail['subject'],
-            ];
-        }
-
-        if (count($foundEmails) !== 1) {
+        if (count($emails) !== 1) {
             throw new ExpectationException(
-                sprintf(
-                    'The email has not been received "%s" (expected "%s")',
-                    var_export($foundEmails, true),
-                )
+                'The email has not been received.',
+                $this->minkContext->getSession()->getDriver()
             );
         }
     }
@@ -530,17 +520,15 @@ class FeatureContext implements Context
         foreach ($decodedContent as $mail) {
             $foundEmails[] = [
                 'id' => $mail['id'],
-                'to' => $mail['to'],
+                'to' => $mail['to'] ?? $mail['recipients'][0],
                 'subject' => $mail['subject'],
             ];
         }
 
         if (count($foundEmails) !== 1) {
             throw new ExpectationException(
-                sprintf(
-                    'The email has not been received "%s" (expected "%s")',
-                    var_export($foundEmails, true),
-                )
+                'The email has not been received.',
+                $this->minkContext->getSession()->getDriver()
             );
         }
 
@@ -551,7 +539,7 @@ class FeatureContext implements Context
                     'The email content does not contain the expected URL "%s" (expected "%s")',
                     $content,
                     $arg1
-                )
+                ), $this->minkContext->getSession()->getDriver()
             );
         }
     }

--- a/tests/unit/AppBundle/Association/Model/CompanyMemberTest.php
+++ b/tests/unit/AppBundle/Association/Model/CompanyMemberTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Tests\Association\Model;
+
+use AppBundle\Association\Model\CompanyMember;
+use PHPUnit\Framework\TestCase;
+
+class CompanyMemberTest extends TestCase
+{
+    /** @dataProvider companies */
+    public function testMembershipFee(CompanyMember $companyMember, float $expectedAmount): void
+    {
+        self::assertEquals($expectedAmount, $companyMember->getMembershipFee());
+    }
+
+    public function companies(): array
+    {
+        return [
+            'null' => [(new CompanyMember()), AFUP_COTISATION_PERSONNE_MORALE],
+            'under' => [(new CompanyMember())->setMaxMembers(2), AFUP_COTISATION_PERSONNE_MORALE],
+            'equal' => [(new CompanyMember())->setMaxMembers(3), AFUP_COTISATION_PERSONNE_MORALE],
+            'just over' => [(new CompanyMember())->setMaxMembers(4), 2 * AFUP_COTISATION_PERSONNE_MORALE],
+            'over' => [(new CompanyMember())->setMaxMembers(6), 2 * AFUP_COTISATION_PERSONNE_MORALE],
+        ];
+    }
+
+}


### PR DESCRIPTION
Quelques corrections pour préparer le passage à PHP 8.2 :
- le montant de la cotisation pour une personne morale
- correction du contexte behat lié aux emails.