### PR TITLE
Le `$name` d'un utilisateur GitHub est nullable en base

### DIFF
--- a/sources/AppBundle/Event/Model/GithubUser.php
+++ b/sources/AppBundle/Event/Model/GithubUser.php
@@ -19,7 +19,7 @@ class GithubUser implements NotifyPropertyInterface, UserInterface, EquatableInt
 
     private string $login = '';
 
-    private string $name = '';
+    private ?string $name = null;
 
     private ?string $company = null;
 
@@ -93,12 +93,12 @@ class GithubUser implements NotifyPropertyInterface, UserInterface, EquatableInt
         return $this;
     }
 
-    public function getName(): string
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function setName(string $name): self
+    public function setName(?string $name): self
     {
         $this->propertyChanged('name', $this->name, $name);
         $this->name = $name;


### PR DESCRIPTION
Il y a une erreur quand on veut éditer un speaker dans le BO :

```
Argument 1 passed to AppBundle\Event\Model\GithubUser::setName() must be of the type string, null given
```