### PR TITLE
fix/make-and-init : Fix l'install + makefile

### DIFF
--- a/compose.override.yml-dist
+++ b/compose.override.yml-dist
@@ -1,4 +1,3 @@
-version: "2.2"
 services:
   db:
     ports:

--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: "2.2"
-
 services:
   db:
     build: ./docker/dockerfiles/mysql

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -2,6 +2,8 @@ FROM php:7.0-apache
 
 RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list
 
+COPY --from=composer:2.2.25 /usr/bin/composer /usr/bin/composer
+
 ARG ENABLE_XDEBUG=false
 
 ## Update system


### PR DESCRIPTION
fix/make-and-init : Fix le Makefile pour supprimer le 'docker compose run make ...' qui font eux même des 'docker compose run' + rajoute le composer dans l'image afin de dockerisé complètement l'application en local + supprime l'utilisation du bin php dans certains make pour privilégier le service cliphp