### PR TITLE
Création des évènements avec tarifs HT par défaut

### DIFF
--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -96,7 +96,7 @@ class Event implements NotifyPropertyInterface
      */
     private $waitingListUrl;
 
-    private bool $hasPricesDefinedWithVat = true;
+    private bool $hasPricesDefinedWithVat = false;
 
     private ?DateTime $archivedAt = null;
 


### PR DESCRIPTION
On est maintenant en full Hors Taxes donc plus besoin d'avoir de nouveaux évènements avec tarifs hybrides.