### PR TITLE
Réduction de la largeur du menu de l'admin

### DIFF
--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -10,13 +10,13 @@
                 position: fixed;
                 z-index: 1;
                 background-color: #1b1c1d;
-                width: 250px;
+                width: 240px;
                 height: 100%;
                 -webkit-box-flex: 0;
             }
 
             .article {
-                margin-left: 250px;
+                margin-left: 240px;
                 flex: 1 1 auto;
                 min-width: 0;
             }


### PR DESCRIPTION
Pour améliorer l'affichage des pages sur les petits écrans.

Je n'ai réduis que de 10 pixels. Si on réduit plus ça créé des sauts de ligne sur certains menus.

## Avant
![image](https://github.com/user-attachments/assets/dbb98f01-1cb7-497f-b232-d9ac092abf09)


## Après
![image](https://github.com/user-attachments/assets/1390ae0b-8940-4efa-b8ed-f7d23e88f5d0)
