### PR TITLE
Correction de l'affichage des tarifs sur la liste des inscriptions

### DIFF
--- a/htdocs/templates/administration/forum_inscriptions.html
+++ b/htdocs/templates/administration/forum_inscriptions.html
@@ -62,7 +62,7 @@
             {assign var=confirmes_total value=$confirmes_total+$confirmes}
             {assign var=payants_total value=$payants_total+$payants}
             {assign var=montant_total value=$montant_total+$montant}
-            {if $inscrits != ''}
+            {if $inscrits !== 0}
             <tr>
               <td>
                 {$forum_tarifs_lib[$forum_tarif_key]}


### PR DESCRIPTION
Avec le passage en PHP 8, la comparaison basique ne fonctionne plus.

Du coup ça affiche tous les tarifs au lieu de seulement ceux qui ont des places inscrites.