### PR TITLE
Migration de l'enum `SocialNetwork` en natif

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "laminas/laminas-feed": "^2.18",
     "league/iso3166": "^4.0",
     "league/oauth2-github": "^3.1",
-    "myclabs/php-enum": "^1.8",
     "nyholm/psr7": "^1.8",
     "pear/pear": "^1.10",
     "phpmailer/phpmailer": "^6.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0124d4f3ca7001a46fd9f639f626e323",
+    "content-hash": "6ac9333a292122d988356fcec34792f9",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3298,69 +3298,6 @@
                 }
             ],
             "time": "2025-03-24T10:02:05+00:00"
-        },
-        {
-            "name": "myclabs/php-enum",
-            "version": "1.8.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/php-enum.git",
-                "reference": "e7be26966b7398204a234f8673fdad5ac6277802"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/php-enum/zipball/e7be26966b7398204a234f8673fdad5ac6277802",
-                "reference": "e7be26966b7398204a234f8673fdad5ac6277802",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": "^7.3 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "1.*",
-                "vimeo/psalm": "^4.6.2 || ^5.2"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "MyCLabs\\Enum\\": "src/"
-                },
-                "classmap": [
-                    "stubs/Stringable.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP Enum contributors",
-                    "homepage": "https://github.com/myclabs/php-enum/graphs/contributors"
-                }
-            ],
-            "description": "PHP Enum implementation",
-            "homepage": "https://github.com/myclabs/php-enum",
-            "keywords": [
-                "enum"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/php-enum/issues",
-                "source": "https://github.com/myclabs/php-enum/tree/1.8.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/mnapoli",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/php-enum",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-01-14T11:49:03+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
@@ -30,7 +30,7 @@ final class BlueskyTransport implements Transport
 
     public function socialNetwork(): SocialNetwork
     {
-        return SocialNetwork::Bluesky();
+        return SocialNetwork::Bluesky;
     }
 
     public function send(Status $status): ?StatusId

--- a/sources/AppBundle/SocialNetwork/SocialNetwork.php
+++ b/sources/AppBundle/SocialNetwork/SocialNetwork.php
@@ -6,34 +6,24 @@ namespace AppBundle\SocialNetwork;
 
 use AppBundle\Event\Model\Speaker;
 use AppBundle\VideoNotifier\HistoryEntry;
-use MyCLabs\Enum\Enum;
 use function Symfony\Component\String\u;
 
-/**
- * @extends Enum<SocialNetwork::*>
- * @method static SocialNetwork Bluesky()
- * @method static SocialNetwork Mastodon()
- */
-final class SocialNetwork extends Enum
+enum SocialNetwork: string
 {
-    private const Bluesky = 'bluesky';
-    private const Mastodon = 'mastodon';
+    case Bluesky = 'bluesky';
+    case Mastodon = 'mastodon';
 
     public function statusMaxLength(): int
     {
-        switch ($this->value) {
-            case self::Bluesky:
-                return 300;
-            case self::Mastodon:
-                return 500;
-            default:
-                return 280;
-        }
+        return match ($this) {
+            self::Bluesky => 300,
+            self::Mastodon => 500,
+        };
     }
 
     public function getSpeakerHandle(Speaker $speaker): ?string
     {
-        if ($this->value === self::Bluesky) {
+        if ($this === self::Bluesky) {
             $handle = $speaker->getBluesky();
         } else {
             $handle = $speaker->getMastodon();
@@ -48,7 +38,7 @@ final class SocialNetwork extends Enum
 
     public function setStatusId(HistoryEntry $historyEntry, StatusId $statusId): void
     {
-        if ($this->value === self::Bluesky) {
+        if ($this === self::Bluesky) {
             $historyEntry->setStatusIdBluesky($statusId->value);
             return;
         }

--- a/sources/AppBundle/VideoNotifier/Engine.php
+++ b/sources/AppBundle/VideoNotifier/Engine.php
@@ -84,7 +84,7 @@ final class Engine
                 // On ignore les erreurs pour pouvoir tenter avec un autre transport
                 $this->logger->error(sprintf(
                     '[video-notifier] %s error: %s',
-                    $transport->socialNetwork()->getValue(),
+                    $transport->socialNetwork()->value,
                     $e->getMessage(),
                 ));
             }

--- a/sources/AppBundle/VideoNotifier/StatusGenerator.php
+++ b/sources/AppBundle/VideoNotifier/StatusGenerator.php
@@ -63,7 +63,7 @@ final class StatusGenerator
         if ($this->isTextTooLong($text)) {
             throw new \LengthException(sprintf(
                 "Statut généré pour %s trop long",
-                $this->socialNetwork->getValue(),
+                $this->socialNetwork->value,
             ));
         }
 

--- a/tests/unit/AppBundle/SocialNetwork/SocialNetworkTest.php
+++ b/tests/unit/AppBundle/SocialNetwork/SocialNetworkTest.php
@@ -25,25 +25,25 @@ class SocialNetworkTest extends TestCase
     public function speakerHandleDataProvider(): \Generator
     {
         yield 'bluesky without @ prefix' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Speaker())->setBluesky('foo.bar'),
             '@foo.bar',
         ];
 
         yield 'bluesky with @ prefix' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Speaker())->setBluesky('@foo.bar'),
             '@foo.bar',
         ];
 
         yield 'mastodon without @ prefix' => [
-            SocialNetwork::Mastodon(),
+            SocialNetwork::Mastodon,
             (new Speaker())->setMastodon('foo.bar'),
             '@foo.bar',
         ];
 
         yield 'mastodon with @ prefix' => [
-            SocialNetwork::Mastodon(),
+            SocialNetwork::Mastodon,
             (new Speaker())->setMastodon('@foo.bar'),
             '@foo.bar',
         ];
@@ -53,7 +53,7 @@ class SocialNetworkTest extends TestCase
     {
         $entry = new HistoryEntry(123);
 
-        SocialNetwork::Bluesky()->setStatusId($entry, new StatusId('abcd'));
+        SocialNetwork::Bluesky->setStatusId($entry, new StatusId('abcd'));
 
         self::assertEquals('abcd', $entry->getStatusIdBluesky());
         self::assertNull($entry->getStatusIdMastodon());
@@ -63,7 +63,7 @@ class SocialNetworkTest extends TestCase
     {
         $entry = new HistoryEntry(123);
 
-        SocialNetwork::Mastodon()->setStatusId($entry, new StatusId('abcd'));
+        SocialNetwork::Mastodon->setStatusId($entry, new StatusId('abcd'));
 
         self::assertEquals('abcd', $entry->getStatusIdMastodon());
         self::assertNull($entry->getStatusIdBluesky());

--- a/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
+++ b/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
@@ -19,7 +19,7 @@ class StatusGeneratorTest extends TestCase
         self::expectException(\InvalidArgumentException::class);
         self::expectExceptionMessage('Aucun speaker pour le talk');
 
-        $generator = new StatusGenerator(SocialNetwork::Bluesky());
+        $generator = new StatusGenerator(SocialNetwork::Bluesky);
 
         $generator->generate(new Talk(), []);
     }
@@ -44,8 +44,8 @@ class StatusGeneratorTest extends TestCase
     public function textTooLongDataProvider(): \Generator
     {
         yield [
-            SocialNetwork::Bluesky(),
-            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Bluesky()->statusMaxLength() * 2)),
+            SocialNetwork::Bluesky,
+            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Bluesky->statusMaxLength() * 2)),
             [
                 (new Speaker())->setBluesky($this->faker()->domainName()),
             ],
@@ -53,8 +53,8 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield [
-            SocialNetwork::Mastodon(),
-            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Mastodon()->statusMaxLength() * 2)),
+            SocialNetwork::Mastodon,
+            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Mastodon->statusMaxLength() * 2)),
             [
                 (new Speaker())->setMastodon($this->faker()->domainName()),
             ],
@@ -81,7 +81,7 @@ class StatusGeneratorTest extends TestCase
     public function validStatusDataProvider(): \Generator
     {
         yield 'mastodon full case' => [
-            SocialNetwork::Mastodon(),
+            SocialNetwork::Mastodon,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor si amet')
@@ -106,7 +106,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield '1 speaker with username' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor si amet')
@@ -127,7 +127,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield '1 speaker without username' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor si amet')
@@ -148,7 +148,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield '2 speakers' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor si amet')
@@ -170,7 +170,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield '3+ speakers' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor si amet')
@@ -193,7 +193,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield 'title a bit too long 1' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab accusantium architecto assumenda consequuntur corporis dolorem doloremque eaque magnam mollitia necessitatibus neque nesciunt, obcaecati odio odit quam, repellat repellendus.')
@@ -214,7 +214,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield 'title a bit too long 2' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab accusantium architecto assumenda consequuntur corporis dolorem doloremque eaque magnam mollitia necessitatibus neque nesciunt, obcaecati odio odit quam, repellat repellendus magnam.')
@@ -235,7 +235,7 @@ class StatusGeneratorTest extends TestCase
         ];
 
         yield 'title with consecutive spaces' => [
-            SocialNetwork::Bluesky(),
+            SocialNetwork::Bluesky,
             (new Talk())
                 ->setId(123)
                 ->setTitle('  Lorem    ipsum ')


### PR DESCRIPTION
Cela permet aussi de retirer la dépendance à `myclabs/php-enum`.