### PR TITLE
Modernisation des extensions Twig

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -214,20 +214,6 @@ services:
         arguments:
             $backOfficePages: '%app.pages_backoffice%'
 
-    AppBundle\Twig\TwigExtension:
-        arguments: ['@AppBundle\Routing\LegacyRouter', "@Parsedown", '@AppBundle\Email\Parsedown', "%google_analytics_enabled%", "%google_analytics_id%"]
-        tags:
-            -  { name: twig.extension }
-
-    AppBundle\Twig\AssetsExtension:
-        arguments: ["%kernel.project_dir%"]
-        tags:
-            -  { name: twig.extension }
-
-    AppBundle\Twig\OfficesExtension:
-        tags:
-            -  { name: twig.extension }
-
     AppBundle\Association\Form\HelpMessageExtension:
         autowire: true
         tags:

--- a/sources/AppBundle/Twig/AssetsExtension.php
+++ b/sources/AppBundle/Twig/AssetsExtension.php
@@ -5,23 +5,19 @@ declare(strict_types=1);
 
 namespace AppBundle\Twig;
 
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Twig\Extension\AbstractExtension;
-use Twig\Extension\GlobalsInterface;
 use Twig\TwigFunction;
 
-class AssetsExtension extends AbstractExtension implements GlobalsInterface
+class AssetsExtension extends AbstractExtension
 {
-    private $kernelProjectDir;
-
-    public function __construct($kernelProjectDir)
-    {
-        $this->kernelProjectDir = $kernelProjectDir;
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private string $kernelProjectDir,
+    ) {
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('asset_md5_start', function (string $url) {
@@ -35,10 +31,5 @@ class AssetsExtension extends AbstractExtension implements GlobalsInterface
     public function getName(): string
     {
         return 'assets';
-    }
-
-    public function getGlobals(): array
-    {
-        return [];
     }
 }

--- a/sources/AppBundle/Twig/OfficesExtension.php
+++ b/sources/AppBundle/Twig/OfficesExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigFunction;
 
 class OfficesExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('office_name', fn ($code): string => (new AntennesCollection())->findByCode($code)->label),

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-
 namespace AppBundle\Twig;
 
-use AppBundle\Routing\LegacyRouter;
+use Parsedown;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Twig\Extension\AbstractExtension;
 use Twig\Extension\GlobalsInterface;
 use Twig\TwigFilter;
@@ -13,23 +13,14 @@ use Twig\TwigFunction;
 
 class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
-    private LegacyRouter $legacyRouter;
-    private \Parsedown $parsedown;
-    private \Parsedown $emailParsedown;
-    private string $googleAnalyticsEnabled;
-    private string $googleAnalyticsId;
-
-    public function __construct(LegacyRouter $legacyRouter,
-                                \Parsedown $parsedown,
-                                \Parsedown $emailParsedown,
-                                string $googleAnalyticsEnabled,
-                                string $googleAnalyticsId
+    public function __construct(
+        private Parsedown $parsedown,
+        private Parsedown $emailParsedown,
+        #[Autowire('%google_analytics_enabled%')]
+        private string $googleAnalyticsEnabled,
+        #[Autowire('%google_analytics_id%')]
+        private string $googleAnalyticsId,
     ) {
-        $this->legacyRouter = $legacyRouter;
-        $this->parsedown = $parsedown;
-        $this->emailParsedown = $emailParsedown;
-        $this->googleAnalyticsEnabled = $googleAnalyticsEnabled;
-        $this->googleAnalyticsId = $googleAnalyticsId;
     }
 
     public function getFunctions(): array
@@ -59,9 +50,8 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     public function getGlobals(): array
     {
         return [
-            'legacy_router' => $this->legacyRouter,
             'google_analytics_enabled' => $this->googleAnalyticsEnabled,
-            'google_analytics_id' => $this->googleAnalyticsId
+            'google_analytics_id' => $this->googleAnalyticsId,
         ];
     }
 


### PR DESCRIPTION
Avec l'arrivée des attributs de PHP 8 et de Symfony qui avance on peut commencer à vider encore plus la config des services.

Les extensions Twig sont détectés automatiquement à la compilation du container donc plus besoin de les tag à la main.