### PR TITLE
PHP 8 constructor property promotion

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,5 +1,7 @@
 <?php
 
+use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
+
 $finder = (new PhpCsFixer\Finder())
     ->name('*.php')
     ->in([
@@ -12,6 +14,7 @@ $finder = (new PhpCsFixer\Finder())
 ;
 
 return (new PhpCsFixer\Config())
+    ->registerCustomFixers(new PhpCsFixerCustomFixers\Fixers())
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
@@ -30,7 +33,14 @@ return (new PhpCsFixer\Config())
         'no_unused_imports' => true,
         'no_whitespace_in_blank_line' => true,
         'method_argument_space' => false,
-        'statement_indentation' => false
+        'statement_indentation' => false,
+        MultilinePromotedPropertiesFixer::name() => [
+            'keep_blank_lines' => true,
+            'minimum_number_of_parameters' => 2,
+        ],
+        'trailing_comma_in_multiline' => [
+            'elements' => ['arrays', 'parameters']
+        ],
     ])
     ->setFinder($finder)
     ->setCacheFile(__DIR__.'/var/.php-cs-fixer.cache')

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -467,7 +467,7 @@ services:
 
     AppBundle\Github\GithubClient:
         arguments:
-            $githubClient: '@http_client.github'
+            $httpClient: '@http_client.github'
 
     AppBundle\Indexation\Meetups\MeetupClient:
         autowire: true

--- a/composer.json
+++ b/composer.json
@@ -139,6 +139,7 @@
     "friends-of-behat/mink-extension": "^2.7",
     "friendsofphp/php-cs-fixer": "^3.75",
     "ifsnop/mysqldump-php": "^2.12",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.24",
     "phpunit/phpunit": "^9.6",
     "rector/rector": "^2.0",
     "smalot/pdfparser": "^0.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ac9333a292122d988356fcec34792f9",
+    "content-hash": "d50fb707a7afb362a175427f584436f5",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -10427,6 +10427,52 @@
                 "source": "https://github.com/ifsnop/mysqldump-php/tree/v2.12"
             },
             "time": "2023-04-12T07:43:14+00:00"
+        },
+        {
+            "name": "kubawerlos/php-cs-fixer-custom-fixers",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
+                "reference": "93222100a91399314c3726857e249e76c4a7d760"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/93222100a91399314c3726857e249e76c4a7d760",
+                "reference": "93222100a91399314c3726857e249e76c4a7d760",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-tokenizer": "*",
+                "friendsofphp/php-cs-fixer": "^3.61.1",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.22 || 10.5.45 || ^11.5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixerCustomFixers\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kuba Werłos",
+                    "email": "werlos@gmail.com"
+                }
+            ],
+            "description": "A set of custom fixers for PHP CS Fixer",
+            "support": {
+                "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.24.0"
+            },
+            "time": "2025-03-22T16:51:39+00:00"
         },
         {
             "name": "masterminds/html5",

--- a/db/migrations/20250228163339_create_video_notifier_history_table.php
+++ b/db/migrations/20250228163339_create_video_notifier_history_table.php
@@ -21,7 +21,7 @@ class CreateVideoNotifierHistoryTable extends AbstractMigration
             ])
             ->addColumn('created_at', 'timestamp', [
                 'default' => 'CURRENT_TIMESTAMP',
-                'update' => ''
+                'update' => '',
             ])
             ->create();
     }

--- a/db/seeds/FeedArticle.php
+++ b/db/seeds/FeedArticle.php
@@ -42,7 +42,7 @@ class FeedArticle extends AbstractSeed
                 'auteur' => 'Un super auteur',
                 'resume' => 'Un super article',
                 'contenu' => 'Le contenu du super article',
-                'etat' => 1
+                'etat' => 1,
             ],
             [
                 'afup_planete_flux_id' => 1,
@@ -53,7 +53,7 @@ class FeedArticle extends AbstractSeed
                 'auteur' => 'Toujours un super auteur',
                 'resume' => 'Un article qui déchire',
                 'contenu' => 'Le contenu de l\'article qui déchire',
-                'etat' => 1
+                'etat' => 1,
             ],
             [
                 'afup_planete_flux_id' => 1,
@@ -64,7 +64,7 @@ class FeedArticle extends AbstractSeed
                 'auteur' => 'Un super désactivé',
                 'resume' => 'Un super désactivé',
                 'contenu' => 'Le contenu du super désactivé',
-                'etat' => 0
+                'etat' => 0,
             ],
         ];
 
@@ -78,7 +78,7 @@ class FeedArticle extends AbstractSeed
                 'auteur' => 'Un super auteur ' . $i,
                 'resume' => 'Un super article ' . $i,
                 'contenu' => 'Le contenu du super article ' . $i,
-                'etat' => 1
+                'etat' => 1,
             ];
         }
 
@@ -91,7 +91,7 @@ class FeedArticle extends AbstractSeed
             'auteur' => 'Un super auteur',
             'resume' => 'Un super article',
             'contenu' => 'Le contenu du super article',
-            'etat' => 1
+            'etat' => 1,
         ];
 
         $data[] = [
@@ -103,7 +103,7 @@ class FeedArticle extends AbstractSeed
             'auteur' => 'Un super auteur',
             'resume' => 'Un super article',
             'contenu' => 'Le contenu du super article',
-            'etat' => 1
+            'etat' => 1,
         ];
 
         $data[] = [
@@ -115,7 +115,7 @@ class FeedArticle extends AbstractSeed
             'auteur' => 'Un super auteur',
             'resume' => 'Un super article',
             'contenu' => 'Le contenu du super article',
-            'etat' => 1
+            'etat' => 1,
         ];
 
         $data[] = [
@@ -127,7 +127,7 @@ class FeedArticle extends AbstractSeed
             'auteur' => 'Un super auteur',
             'resume' => 'Un super article',
             'contenu' => 'Le contenu du super article',
-            'etat' => 1
+            'etat' => 1,
         ];
 
         $table = $this->table('afup_planete_billet');

--- a/db/seeds/Feuilles.php
+++ b/db/seeds/Feuilles.php
@@ -136,7 +136,7 @@ class Feuilles extends AbstractSeed
                 'children' => [
                     [
                         'nom' => 'Accueil',
-                        'lien' => '/'
+                        'lien' => '/',
                     ],
                     [
                         'nom' => 'Actualités',
@@ -146,7 +146,7 @@ class Feuilles extends AbstractSeed
                         'nom' => 'Plan du site',
                         'lien' => '/plan-du-site',
                     ],
-                ]
+                ],
             ],
             [
                 'nom' => 'Association / Antennes',
@@ -162,7 +162,7 @@ class Feuilles extends AbstractSeed
                     [
                         'nom' => 'Meetups',
                         'lien' => '/meetups/',
-                    ]
+                    ],
                 ],
             ],
             [
@@ -170,7 +170,7 @@ class Feuilles extends AbstractSeed
                 'children' => [
                     [
                         'nom' => 'AFUP Day 2019',
-                        'lien' => 'https://event.afup.org'
+                        'lien' => 'https://event.afup.org',
                     ],
                     [
                         'nom' => 'Baromètre des salaires',
@@ -180,8 +180,8 @@ class Feuilles extends AbstractSeed
                         'nom' => 'Planète PHP',
                         'lien' => 'https://www.planete-php.fr',
                     ],
-                ]
-            ]
+                ],
+            ],
         ];
     }
 

--- a/db/seeds/GeneralMeetings.php
+++ b/db/seeds/GeneralMeetings.php
@@ -21,11 +21,11 @@ class GeneralMeetings extends AbstractSeed
         $data = [
             [
                 'date' => 1635544800,
-                'description' => 'Assemblée octobre 2021'
+                'description' => 'Assemblée octobre 2021',
             ],
             [
                 'date' => $timestamp,
-                'description' => 'Assemblée dans 2 mois'
+                'description' => 'Assemblée dans 2 mois',
             ],
         ];
 
@@ -41,12 +41,12 @@ class GeneralMeetings extends AbstractSeed
             [
                 'id_personne_physique' => '1',
                 'date' => 1635544800,
-                'presence' => 1
+                'presence' => 1,
             ],
             [
                 'id_personne_physique' => '1',
                 'date' => $timestamp,
-                'presence' => 1
+                'presence' => 1,
             ],
         ];
 
@@ -63,12 +63,12 @@ class GeneralMeetings extends AbstractSeed
             [
                 'date' => $timestamp,
                 'label' => 'Une 1ère question. Alors d\'accord ?',
-                'created_at' => '2021-09-01 10:42:42'
+                'created_at' => '2021-09-01 10:42:42',
             ],
             [
                 'date' => $timestamp,
                 'label' => 'Une autre question pertinente. On vote ?',
-                'created_at' => '2021-09-12 10:42:42'
+                'created_at' => '2021-09-12 10:42:42',
             ],
         ];
 

--- a/db/seeds/Session.php
+++ b/db/seeds/Session.php
@@ -8,7 +8,7 @@ class Session extends AbstractSeed
 {
     const ID_SESSIONS = [
         1,
-        2
+        2,
     ];
 
     public function run(): void
@@ -117,7 +117,7 @@ il souffre aussi de d&eacute;fauts souvent sous-estim&eacute;s parmi lesquels l&
         foreach ($sessions as $session) {
             $conferenciers[] = [
                 'session_id' => $session['session_id'],
-                'conferencier_id' => Conferenciers::ID_CONFERENCIER
+                'conferencier_id' => Conferenciers::ID_CONFERENCIER,
             ];
         }
 

--- a/db/seeds/Users.php
+++ b/db/seeds/Users.php
@@ -35,7 +35,7 @@ class Users extends AbstractSeed
                 'id_pays' => 'FR',
                 'etat' => 1,
                 'public_profile_enabled' => 1,
-                'max_members' => 3
+                'max_members' => 3,
             ],
             [
                 'id'    => self::ID_PERSONNE_MORALE_HELIOS_AEROSPACE,
@@ -51,7 +51,7 @@ class Users extends AbstractSeed
                 'id_pays' => 'FR',
                 'etat' => 1,
                 'public_profile_enabled' => 1,
-                'max_members' => 3
+                'max_members' => 3,
             ],
         ];
 

--- a/htdocs/pages/administration/compta_banque.php
+++ b/htdocs/pages/administration/compta_banque.php
@@ -72,9 +72,9 @@ if ($action == 'lister') {
     for ($i = 1; $i < 13; $i++) {
         $compteurLigne[$i] = 4;
         $sheet = $workbook->createSheet($i);
-        $sheet->setTitle('Mois de ' . strftime('%B %Y', mktime(0, 0, 0, $i, 1, (int) date('Y', strtotime($periode_debut)))));
+        $sheet->setTitle('Mois de ' . strftime('%B %Y', mktime(0, 0, 0, $i, 1, (int) date('Y', strtotime((string) $periode_debut)))));
         $sheet->setCellValue('A1',
-            'Mois de ' . strftime('%B %Y', mktime(0, 0, 0, $i, 1, (int) date('Y', strtotime($periode_debut)))));
+            'Mois de ' . strftime('%B %Y', mktime(0, 0, 0, $i, 1, (int) date('Y', strtotime((string) $periode_debut)))));
         $sheet->setCellValue('A3', 'Date');
         $sheet->setCellValue('B3', 'Opération');
         $sheet->setCellValue('C3', 'Description');
@@ -89,7 +89,7 @@ if ($action == 'lister') {
     }
     foreach ($journal as $ecriture) {
         $sheet = $workbook->getSheet($ecriture['mois']);
-        $sheet->setCellValue('A' . $compteurLigne[$ecriture['mois']], date('d/m/Y', strtotime($ecriture['date_regl'])));
+        $sheet->setCellValue('A' . $compteurLigne[$ecriture['mois']], date('d/m/Y', strtotime((string) $ecriture['date_regl'])));
         $sheet->setCellValue('B' . $compteurLigne[$ecriture['mois']], $ecriture['reglement']);
         $sheet->setCellValue('C' . $compteurLigne[$ecriture['mois']], $ecriture['description']);
         $sheet->setCellValue('D' . $compteurLigne[$ecriture['mois']], $ecriture['evenement']);
@@ -112,34 +112,34 @@ if ($action == 'lister') {
             'font' => [
                 'size' => 12,
                 'bold' => true,
-                'name' => 'Ubuntu'
-            ]
+                'name' => 'Ubuntu',
+            ],
         ]);
         $sheet->getStyle('A3:K3')->applyFromArray([
             'font' => [
                 'size' => 10,
                 'bold' => true,
-                'name' => 'Ubuntu'
+                'name' => 'Ubuntu',
             ],
             'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER],
             'borders' => [
                 'allborders' => [
                     'style' => Border::BORDER_THIN,
-                    'color' => ['rgb' => 'FF666666']
-                ]
-            ]
+                    'color' => ['rgb' => 'FF666666'],
+                ],
+            ],
         ]);
         $sheet->getStyle('A4:K' . ($compteurLigne[$i] + 1))->applyFromArray([
             'font' => [
                 'size' => 10,
-                'name' => 'Ubuntu'
+                'name' => 'Ubuntu',
             ],
             'borders' => [
                 'allborders' => [
                     'style' => Border::BORDER_THIN,
-                    'color' => ['rgb' => 'FF666666']
-                ]
-            ]
+                    'color' => ['rgb' => 'FF666666'],
+                ],
+            ],
         ]);
         $sheet->getStyle('J3:I200')->applyFromArray(['alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER]]);
 
@@ -154,8 +154,8 @@ if ($action == 'lister') {
             'font' => [
                 'size' => 10,
                 'bold' => true,
-                'name' => 'Ubuntu'
-            ]
+                'name' => 'Ubuntu',
+            ],
         ]);
         $sheet->getStyle('F' . ($compteurLigne[$i] + 1))->getAlignment()->applyFromArray(['horizontal' => Alignment::HORIZONTAL_CENTER]);
 
@@ -182,7 +182,7 @@ if ($action == 'lister') {
     //$workbook->removeSheetByIndex(0);
 
     header('Content-Type: application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    header('Content-Disposition: attachment;filename="compta_afup_' . date('Y', strtotime($periode_debut)) . '.xlsx"');
+    header('Content-Disposition: attachment;filename="compta_afup_' . date('Y', strtotime((string) $periode_debut)) . '.xlsx"');
     header('Cache-Control: max-age=0');
 
     $writer = new Xlsx($workbook);
@@ -195,7 +195,7 @@ if ($action == 'lister') {
 
     try {
         // Get the year
-        $year = date('Y', strtotime($listPeriode[$id_periode - 1]['date_debut']));
+        $year = date('Y', strtotime((string) $listPeriode[$id_periode - 1]['date_debut']));
 
         // Create the zip
         $zipFilename = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'afup_justificatifs-' . $year . '.zip';

--- a/htdocs/pages/administration/compta_facture.php
+++ b/htdocs/pages/administration/compta_facture.php
@@ -18,7 +18,7 @@ $action = verifierAction([
                     'lister',
                     'modifier',
                     'telecharger_facture',
-                    'envoyer_facture'
+                    'envoyer_facture',
                     ]);
 
 

--- a/htdocs/pages/administration/compta_journal.php
+++ b/htdocs/pages/administration/compta_journal.php
@@ -338,7 +338,7 @@ if ($action == 'lister') {
                 $line['montant_tva_10'],
                 $line['montant_ht_20'],
                 $line['montant_tva_20'],
-                Comptabilite::getTvaZoneLabel($line['tva_zone'], 'Non définie')
+                Comptabilite::getTvaZoneLabel($line['tva_zone'], 'Non définie'),
             ],
             $csvDelimiter,
             $csvEnclosure
@@ -471,7 +471,7 @@ if ($action == 'lister') {
         }
 
         // The directory
-        $directory = date('Ym', strtotime($line['date_ecriture'])) . DIRECTORY_SEPARATOR;
+        $directory = date('Ym', strtotime((string) $line['date_ecriture'])) . DIRECTORY_SEPARATOR;
         $uploadDirectory = AFUP_CHEMIN_RACINE . 'uploads' . DIRECTORY_SEPARATOR . $directory;
         if (!is_dir($uploadDirectory)) {
             mkdir($uploadDirectory, 0750, true);
@@ -512,7 +512,7 @@ if ($action == 'lister') {
 
         // Move/Rename
         $filename = sprintf('%s.%s',
-            date('Y-m-d', strtotime($line['date_ecriture'])) . '_' . $line['id'] . '_' . substr(sha1_file($_FILES['file']['tmp_name']), 0, 6),
+            date('Y-m-d', strtotime((string) $line['date_ecriture'])) . '_' . $line['id'] . '_' . substr(sha1_file($_FILES['file']['tmp_name']), 0, 6),
             $ext
         );
         $moved = move_uploaded_file(
@@ -623,7 +623,7 @@ if ($action == 'lister') {
     $ligneCompta = $compta->obtenir($idCompta);
     $montantTotal = 0;
 
-    foreach (explode(';', $_GET['montant']) as $montant) {
+    foreach (explode(';', (string) $_GET['montant']) as $montant) {
         $montant = (float) $montant;
         $compta->ajouter($ligneCompta['idoperation'],
             $ligneCompta['idcompte'],

--- a/htdocs/pages/administration/compta_recherche.php
+++ b/htdocs/pages/administration/compta_recherche.php
@@ -36,7 +36,7 @@ switch ($action) {
     // Results
     case 'results':
         // No search param?
-        if (!isset($_GET['q']) || !($q = trim($_GET['q']))) {
+        if (!isset($_GET['q']) || !($q = trim((string) $_GET['q']))) {
             $smarty->assign('action', $defaultAction);
             break;
         }

--- a/htdocs/pages/administration/forum_facturation.php
+++ b/htdocs/pages/administration/forum_facturation.php
@@ -79,12 +79,12 @@ if ($action == 'lister') {
             $invoiceService->deleteInvoice($invoice);
             Logs::log('Supprimer => facture n°' . $_GET['ref']);
             afficherMessage('La facture est supprimée', 'index.php?page=forum_facturation&action=lister');
-        } catch (Exception $e) {
+        } catch (Exception) {
         }
     }
     afficherMessage("La facture n'a pas pu être supprimée", 'index.php?page=forum_facturation&action=lister', true);
 } elseif ($action == 'changer_date_reglement') {
-    $reglement = strtotime(implode('-', array_reverse(explode('/', $_GET['reglement']))));
+    $reglement = strtotime(implode('-', array_reverse(explode('/', (string) $_GET['reglement']))));
     if ($forum_facturation->changerDateReglement($_GET['ref'], $reglement)) {
         afficherMessage('La date de réglement a été changée', 'index.php?page=forum_facturation&action=lister');
     } else {

--- a/htdocs/pages/administration/forum_inscriptions.php
+++ b/htdocs/pages/administration/forum_inscriptions.php
@@ -41,7 +41,7 @@ function updateGlobalsForTarif(
     TicketEventTypeRepository $ticketEventTypeRepository,
     TicketTypeAvailability $ticketTypeAvailability,
     $forumId,
-    &$membersTickets = []
+    &$membersTickets = [],
 ): array {
     global $AFUP_Tarifs_Forum, $AFUP_Tarifs_Forum_Lib;
     $event = $eventRepository->get($forumId);
@@ -177,7 +177,7 @@ if ($action == 'lister') {
                 'mail_partenaire' => 0,
                 'newsletter_afup' => 0,
                 'newsletter_nexen' => 0,
-                'date_reglement' => (new \DateTime())->format('Y-m-d')
+                'date_reglement' => (new \DateTime())->format('Y-m-d'),
             ]
         );
     } else {
@@ -371,7 +371,7 @@ if ($action == 'lister') {
             try {
                 $ticketRepository->save($ticket);
                 $ok = true;
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $ok = false;
             }
         } else {
@@ -426,7 +426,7 @@ if ($action == 'lister') {
                                                     $valeurs['autorisation'],
                                                     $valeurs['transaction'],
                                                     $valeurs['etat']);
-        } catch (Exception $e) {
+        } catch (Exception) {
             $ok = false;
         }
 

--- a/htdocs/pages/administration/message.php
+++ b/htdocs/pages/administration/message.php
@@ -16,7 +16,7 @@ if (!defined('PAGE_LOADED_USING_INDEX')) {
     ob_clean();
 
     // On affiche la page du message
-    $smarty->assign('message', stripslashes($_GET['message']));
+    $smarty->assign('message', stripslashes((string) $_GET['message']));
     $smarty->assign('url'    , $_GET['url']);
     $smarty->assign('erreur' , $_GET['erreur']);
     $smarty->display('message.html');

--- a/htdocs/pages/administration/site_articles.php
+++ b/htdocs/pages/administration/site_articles.php
@@ -36,7 +36,7 @@ foreach ($forum->obtenirListe(null, '*', 'date_debut DESC') as $forum) {
 
 function checkNoSpace($value): bool
 {
-    return !preg_match('/(\s)/', $value);
+    return !preg_match('/(\s)/', (string) $value);
 }
 
 if ($action == 'lister') {

--- a/htdocs/pages/event-payment/index.php
+++ b/htdocs/pages/event-payment/index.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/../../../sources/Afup/Bootstrap/Http.php';
 if (
     !isset($_GET['ref'])
     ||
-    !preg_match('`ins-([0-9]+)`', $_GET['ref'], $matches) && !preg_match('`elephpant-([0-9]+)`', $_GET['ref'], $matches)
+    !preg_match('`ins-([0-9]+)`', (string) $_GET['ref'], $matches) && !preg_match('`elephpant-([0-9]+)`', (string) $_GET['ref'], $matches)
 ) {
     die('Missing ref');
 }
@@ -31,7 +31,7 @@ if (!isset($forumData['id']) || !$forumData['id']) {
 $ref = $matches[1];
 $inscription = $forum_inscriptions->obtenir($ref);
 
-if (preg_match('`elephpant-([0-9]+)`', $_GET['ref'], $matches)) {
+if (preg_match('`elephpant-([0-9]+)`', (string) $_GET['ref'], $matches)) {
     $prix = 25;
     $action = 'elep';
 } else {
@@ -53,10 +53,10 @@ $paybox
     ->setTotal($prix * 100)
     ->setCmd(strtr($forumData['path'], ['forum' => 'frm', 'phptour' => 'tour']) . '-' . $action . '-' . $ref . '-' . $prix)
     ->setPorteur($inscription['email'])
-    ->setUrlRetourEffectue('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_effectue.php')
-    ->setUrlRetourRefuse('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_refuse.php')
-    ->setUrlRetourAnnule('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_annule.php')
-    ->setUrlRetourErreur('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_erreur.php')
+    ->setUrlRetourEffectue('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_effectue.php')
+    ->setUrlRetourRefuse('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_refuse.php')
+    ->setUrlRetourAnnule('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_annule.php')
+    ->setUrlRetourErreur('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_erreur.php')
 ;
 
 $invoiceRepository = $symfonyKernel->getKernel()->getContainer()->get(InvoiceRepository::class);
@@ -71,7 +71,7 @@ $payboxBilling = PayboxBilling::createFromInvoice($invoice);
 
 $smarty->assign('paybox', $paybox->generate(new \DateTime(), $payboxBilling));
 $smarty->assign('inscription', $inscription);
-$smarty->assign('original_ref', urlencode($_GET['ref']));
+$smarty->assign('original_ref', urlencode((string) $_GET['ref']));
 $smarty->assign('forum', $forumData);
 $smarty->display('paybox_formulaire.html');
 

--- a/htdocs/pages/paiement/index.php
+++ b/htdocs/pages/paiement/index.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/../../../sources/Afup/Bootstrap/Http.php';
 
 $comptaFact = new Facture($bdd);
 
-$ref = Utils::decryptFromText(urldecode($_GET['ref']));
+$ref = Utils::decryptFromText(urldecode((string) $_GET['ref']));
 
 $facture = $comptaFact->obtenir($ref);
 if ($facture) {
@@ -35,10 +35,10 @@ if ($facture) {
             ->setTotal($prix * 100)
             ->setCmd($facture['numero_facture'])
             ->setPorteur($facture['email'])
-            ->setUrlRetourEffectue('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_effectue.php')
-            ->setUrlRetourAnnule('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_annule.php')
-            ->setUrlRetourRefuse('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_refuse.php')
-            ->setUrlRetourErreur('https://' . $_SERVER['HTTP_HOST'] . dirname($_SERVER['REQUEST_URI']) . '/paybox_erreur.php')
+            ->setUrlRetourEffectue('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_effectue.php')
+            ->setUrlRetourAnnule('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_annule.php')
+            ->setUrlRetourRefuse('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_refuse.php')
+            ->setUrlRetourErreur('https://' . $_SERVER['HTTP_HOST'] . dirname((string) $_SERVER['REQUEST_URI']) . '/paybox_erreur.php')
         ;
 
         $payboxBilling = new PayboxBilling($facture['prenom'], $facture['nom'], $facture['adresse'], $facture['code_postal'], $facture['ville'], $facture['id_pays']);
@@ -48,7 +48,7 @@ if ($facture) {
 
         $smarty->assign('facture', $facture);
         $smarty->assign('details_facture', $details);
-        $smarty->assign('original_ref', urlencode($_GET['ref']));
+        $smarty->assign('original_ref', urlencode((string) $_GET['ref']));
         $smarty->display('paybox_formulaire.html');
     }
 } else {

--- a/htdocs/pages/paiement/payment_tracking.php
+++ b/htdocs/pages/paiement/payment_tracking.php
@@ -14,7 +14,7 @@ $forum_facturation = new Facturation($bdd);
 $forumEvent = new Forum($bdd);
 $incriptionType = new InscriptionType();
 
-$query = parse_url($_SERVER['HTTP_REFERER'], PHP_URL_QUERY); // Should be like http://event.afup.org/paiement-confirme?cmd=F201610-0707-CCMBE-68287
+$query = parse_url((string) $_SERVER['HTTP_REFERER'], PHP_URL_QUERY); // Should be like http://event.afup.org/paiement-confirme?cmd=F201610-0707-CCMBE-68287
 parse_str($query, $result); // Should contains cmd=XXXX
 
 if (isset($cmd) === false) {
@@ -29,5 +29,5 @@ echo $twig->render('paiement/payment_tracking.html.twig', [
     'inscriptions' => $inscriptions,
     'invoice' => $invoice,
     'inscriptionType' => $incriptionType,
-    'event' => $event
+    'event' => $event,
 ]);

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
+use Rector\Set\ValueObject\LevelSetList;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\Set\TwigSetList;
 
@@ -10,14 +12,10 @@ return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/app',
         __DIR__ . '/db',
-        __DIR__ . '/htdocs',
+        __DIR__ . '/htdocs/pages',
         __DIR__ . '/sources',
         __DIR__ . '/tests',
     ])
-    ->withSkip([
-        __DIR__ . '/htdocs/cache',
-    ])
-    ->withPhp74Sets()
     ->withTypeCoverageLevel(10)
     ->withDeadCodeLevel(10)
     ->withCodeQualityLevel(10)
@@ -32,6 +30,7 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_54,
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
-        TwigSetList::TWIG_UNDERSCORE_TO_NAMESPACE
+        TwigSetList::TWIG_UNDERSCORE_TO_NAMESPACE,
+        LevelSetList::UP_TO_PHP_82
     ])
 ;

--- a/sources/Afup/Association/Cotisations.php
+++ b/sources/Afup/Association/Cotisations.php
@@ -39,16 +39,12 @@ define('AFUP_COTISATIONS_PAIEMENT_REFUSE', 3);
  */
 class Cotisations
 {
-    private Base_De_Donnees $_bdd;
-
-    private ?Droits $_droits;
-
     private ?CompanyMemberRepository $companyMemberRepository = null;
 
-    public function __construct(Base_De_Donnees $bdd, Droits $droits = null)
-    {
-        $this->_bdd = $bdd;
-        $this->_droits = $droits;
+    public function __construct(
+        private readonly Base_De_Donnees $_bdd,
+        private readonly ?Droits $_droits = null,
+    ) {
     }
 
     /**
@@ -248,13 +244,13 @@ class Cotisations
 
     public function validerReglementEnLigne($cmd, $total, string $autorisation, string $transaction)
     {
-        $reference = substr($cmd, 0, strlen($cmd) - 4);
-        $verif = substr($cmd, strlen($cmd) - 3, strlen($cmd));
+        $reference = substr((string) $cmd, 0, strlen((string) $cmd) - 4);
+        $verif = substr((string) $cmd, strlen((string) $cmd) - 3, strlen((string) $cmd));
         $result = false;
 
-        if (str_starts_with($cmd, 'F')) {
+        if (str_starts_with((string) $cmd, 'F')) {
             // This is an invoice ==> we dont have to create a new cotisation, just update the existing one
-            $invoiceNumber = substr($cmd, 1);
+            $invoiceNumber = substr((string) $cmd, 1);
             $cotisation = $this->getByInvoice($invoiceNumber);
 
             $this
@@ -263,7 +259,7 @@ class Cotisations
                     AFUP_COTISATIONS_REGLEMENT_ENLIGNE, "autorisation : " . $autorisation . " / transaction : " . $transaction
                 );
         } elseif (substr(md5($reference), -3) === strtolower($verif) && !$this->estDejaReglee($cmd)) {
-            [$ref, $date, $type_personne, $id_personne, $reste] = explode('-', $cmd, 5);
+            [$ref, $date, $type_personne, $id_personne, $reste] = explode('-', (string) $cmd, 5);
             $date_debut = mktime(0, 0, 0, (int) substr($date, 2, 2), (int) substr($date, 0, 2), (int) substr($date, 4, 4));
 
             $cotisation = $this->obtenirDerniere($type_personne, $id_personne);
@@ -292,7 +288,7 @@ class Cotisations
      */
     public function getAccountFromCmd($cmd): array
     {
-        $arr = explode('-', $cmd, 5);
+        $arr = explode('-', (string) $cmd, 5);
         // Personne morale : $cmd=FCOTIS-2023-202
         if (3 === count($arr)) {
             return ['type' => UserRepository::USER_TYPE_COMPANY, 'id' => $arr[2]];

--- a/sources/Afup/AuthentificationWiki.php
+++ b/sources/Afup/AuthentificationWiki.php
@@ -17,7 +17,7 @@ class AuthentificationWiki implements AuthentificationInterface
     {
         $wikiUser = [];
         $wikiUser["show_comments"] = "Y";
-        $wikiUser["name"] = ucfirst(strtolower($event["prenom"])) . ucfirst(strtolower($event["nom"]));
+        $wikiUser["name"] = ucfirst(strtolower((string) $event["prenom"])) . ucfirst(strtolower((string) $event["nom"]));
         $wikiUser["email"] = $event["email"];
         $_SESSION["user"] = $wikiUser;
     }

--- a/sources/Afup/Bootstrap/Http.php
+++ b/sources/Afup/Bootstrap/Http.php
@@ -49,12 +49,12 @@ header('Content-type: text/html; charset=UTF-8');
 
 $serveur   = '';
 $url = $_SERVER['REQUEST_URI'];
-if (strrpos($url, '?') !== false) {
-    $position = strrpos($url, '?');
-    $url      = substr($url, 0, $position);
+if (strrpos((string) $url, '?') !== false) {
+    $position = strrpos((string) $url, '?');
+    $url      = substr((string) $url, 0, $position);
 }
-$position  = strrpos($url, '/');
-$url       = substr($_SERVER['REQUEST_URI'], 0, $position);
+$position  = strrpos((string) $url, '/');
+$url       = substr((string) $_SERVER['REQUEST_URI'], 0, $position);
 $parties   = explode('/', $url);
 $sous_site = array_pop($parties);
 

--- a/sources/Afup/Bootstrap/commonStart.php
+++ b/sources/Afup/Bootstrap/commonStart.php
@@ -22,7 +22,7 @@ $translator->addResource('xliff', __DIR__ . '/../../../translations/inscription.
 $translator->addResource('xliff', __DIR__ . '/../../../translations/cfp.en.xlf', 'en');
 $translator->setFallbackLocales(['fr']);
 if (isset($smarty)) {
-    $smarty->register_modifier('trans', [$translator, 'trans']);
+    $smarty->register_modifier('trans', $translator->trans(...));
 }
 
 
@@ -190,8 +190,8 @@ $services->get('ConnectionPool')->setConfig([
             'user'      => $GLOBALS['AFUP_CONF']->obtenir('database_user'),
             'password'  => $GLOBALS['AFUP_CONF']->obtenir('database_password'),
             'port'      => 3306,
-        ]
-    ]
+        ],
+    ],
 ]);
 
 $services

--- a/sources/Afup/Comptabilite/Comptabilite.php
+++ b/sources/Afup/Comptabilite/Comptabilite.php
@@ -21,16 +21,10 @@ class Comptabilite
         'hors_ue' => 'Hors Union Européenne',
     ];
 
-    /**
-     * @var Base_De_Donnees
-     */
-    protected $_bdd;
-
     public $lastId;
 
-    public function __construct(&$bdd)
+    public function __construct(protected Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
 
@@ -43,7 +37,7 @@ class Comptabilite
      */
     public function obtenirJournalBanque($compte = 1,
                                   $periode_debut = '',
-                                  $periode_fin = ''
+                                  $periode_fin = '',
     ) {
         $periode_debut = $this->periodeDebutFin($debutFin = 'debut', $periode_debut);
         $periode_fin = $this->periodeDebutFin($debutFin = 'fin', $periode_fin);
@@ -105,7 +99,7 @@ class Comptabilite
                 "debit" => $debit[$i],
                 "credit" => $credit[$i],
                 "dif" => $dif,
-                "nligne" => $nligne[$i]
+                "nligne" => $nligne[$i],
             ];
             $dif_old = $dif;
         }
@@ -138,7 +132,7 @@ class Comptabilite
         $tableau = [
             "debit" => $debit,
             "credit" => $credit,
-            "dif" => $credit - $debit
+            "dif" => $credit - $debit,
         ];
         //	$dif_old=$dif;
         //}
@@ -163,7 +157,7 @@ class Comptabilite
     public function obtenirJournal(string $debitCredit = '',
                             $periode_debut = '',
                             $periode_fin = '',
-                            $onlyUnclasifedEntries = true
+                            $onlyUnclasifedEntries = true,
     ) {
         $periode_debut = $this->periodeDebutFin($debutFin = 'debut', $periode_debut);
         $periode_fin = $this->periodeDebutFin($debutFin = 'fin', $periode_fin);
@@ -536,7 +530,7 @@ class Comptabilite
     public function modifier(string $id, $idoperation, $idcompte, $idcategorie, $date_ecriture, $nom_frs, $tva_intra, $montant, $description,
                       $numero, $idmode_regl, $date_regl, $obs_regl, $idevenement, $comment, $numero_operation = null, $attachmentRequired = 0,
                       $montantHtSoumisTva0 = null, $montantHtSoumisTva55 = null, $montantHtSoumisTva10 = null, $montantHtSoumisTva20 = null,
-                      $tvaZone = null
+                      $tvaZone = null,
     ) {
         $requete = 'UPDATE ';
         $requete .= 'compta ';

--- a/sources/Afup/Comptabilite/Facture.php
+++ b/sources/Afup/Comptabilite/Facture.php
@@ -16,14 +16,8 @@ use AppBundle\Email\Mailer\Message;
 
 class Facture
 {
-    /**
-     * @var Base_De_Donnees
-     */
-    private $_bdd;
-
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
 
@@ -403,15 +397,10 @@ class Facture
 
         $totalTtc = 0;
         $totalHt = 0;
-        switch ($coordonnees['devise_facture']) {
-            case 'DOL':
-                $devise = ' $';
-                break;
-            case 'EUR':
-            default:
-                $devise = ' €';
-                break;
-        }
+        $devise = match ($coordonnees['devise_facture']) {
+            'DOL' => ' $',
+            default => ' €',
+        };
 
         $yInitial = $pdf->getY();
 
@@ -600,15 +589,10 @@ class Facture
 
         $totalTtc = 0;
         $totalHt = 0;
-        switch ($coordonnees['devise_facture']) {
-            case 'DOL':
-                $devise = ' $';
-                break;
-            case 'EUR':
-            default:
-                $devise = ' €';
-                break;
-        }
+        $devise = match ($coordonnees['devise_facture']) {
+            'DOL' => ' $',
+            default => ' €',
+        };
         $yInitial = $pdf->getY();
         $columns = $isSubjectedToVat ? [0, 30, 90, 110, 130, 160, 190] : [0, 30, 110, 130, 160, 190];
 

--- a/sources/Afup/Comptabilite/PDF.php
+++ b/sources/Afup/Comptabilite/PDF.php
@@ -69,7 +69,7 @@ class PDF extends tFPDF
             $this->SETXY($position, $y);
             $this->Cell($w[0], 6, $row[0], 'LR', 0, 'L', $fill);
 
-            $this->Cell($w[1], 6, substr($row[1], 0, 54), 'LR', 0, 'L', $fill);
+            $this->Cell($w[1], 6, substr((string) $row[1], 0, 54), 'LR', 0, 'L', $fill);
             $this->Cell($w[2], 6, number_format($row[2], 2, ',', ' '), 'LR', 0, 'R', $fill);
 
             $this->Ln();

--- a/sources/Afup/Corporate/Accueil.php
+++ b/sources/Afup/Corporate/Accueil.php
@@ -37,7 +37,7 @@ class Accueil
             $colonne .= '<a href="' . $article->route() . '" class="article article-teaser">';
             $colonne .= '<time datetime="' . date('Y-m-d', $article->date) . '">' . date('d|m|y', $article->date) . '</time>';
             $colonne .= '<h2>' . $article->titre . '</h2>';
-            $colonne .= '<p>' . strip_tags($chapeau, '<p><strong>') . '</p>';
+            $colonne .= '<p>' . strip_tags((string) $chapeau, '<p><strong>') . '</p>';
             $colonne .= '</a>';
         }
 

--- a/sources/Afup/Corporate/Article.php
+++ b/sources/Afup/Corporate/Article.php
@@ -9,7 +9,6 @@ use Afup\Site\Utils\Configuration;
 class Article
 {
     public $soustitre;
-    public $id;
     public $id_site_rubrique;
     public $id_personne_physique;
     public $titre;
@@ -71,10 +70,11 @@ class Article
      */
     protected $bdd;
 
-    public function __construct($id = 0, $bdd = false, $conf = false)
-    {
-        $this->id = $id;
-
+    public function __construct(
+        public $id = 0,
+        $bdd = false,
+        $conf = false,
+    ) {
         $this->bdd = $bdd ?: new _Site_Base_De_Donnees();
 
         $this->conf = $conf ?: $GLOBALS['AFUP_CONF'];
@@ -103,13 +103,10 @@ class Article
 
     public function teaser()
     {
-        switch (true) {
-            case !empty($this->chapeau):
-                $teaser = $this->chapeau;
-                break;
-            default:
-                $teaser = substr(strip_tags($this->contenu), 0, 200);
-        }
+        $teaser = match (true) {
+            !empty($this->chapeau) => $this->chapeau,
+            default => substr(strip_tags((string) $this->contenu), 0, 200),
+        };
         return $teaser;
     }
 

--- a/sources/Afup/Corporate/Branche.php
+++ b/sources/Afup/Corporate/Branche.php
@@ -90,15 +90,10 @@ class Branche
                 if ($extraction === "") {
                     $class = ' class="top"';
                 }
-                switch (true) {
-                    case preg_match('#^http://#', $feuille['lien']):
-                    case preg_match('#^/#', $feuille['lien']):
-                        $route = $feuille['lien'];
-                        break;
-                    default:
-                        $route = Site::WEB_PATH . Site::WEB_PREFIX . Site::WEB_QUERY_PREFIX . $feuille['lien'];
-                        break;
-                }
+                $route = match (true) {
+                    preg_match('#^http://#', (string) $feuille['lien']), preg_match('#^/#', (string) $feuille['lien']) => $feuille['lien'],
+                    default => Site::WEB_PATH . Site::WEB_PREFIX . Site::WEB_QUERY_PREFIX . $feuille['lien'],
+                };
                 $extraction .= '<li' . $class . '>';
                 if ($this->navigation == 'image' && $feuille['image'] !== null) {
                     $extraction .= '<a href="' . $route . '"><img alt="' . $feuille['alt'] . '" src="' . Site::WEB_PATH . 'templates/site/images/' . $feuille['image'] . '" /><br>';

--- a/sources/Afup/Corporate/Feuille.php
+++ b/sources/Afup/Corporate/Feuille.php
@@ -14,8 +14,6 @@ class Feuille
     const ID_FEUILLE_HEADER = 21;
     const ID_FEUILLE_FOOTER = 38;
     const ID_FEUILLE_NOS_ACTIONS = 96;
-
-    public $id;
     public $id_parent;
     public $nom;
     public $lien;
@@ -32,9 +30,10 @@ class Feuille
      */
     protected $bdd;
 
-    public function __construct($id = 0, $bdd = false)
-    {
-        $this->id = $id;
+    public function __construct(
+        public $id = 0,
+        $bdd = false,
+    ) {
         $this->bdd = $bdd ?: new _Site_Base_De_Donnees();
     }
 

--- a/sources/Afup/Corporate/Page.php
+++ b/sources/Afup/Corporate/Page.php
@@ -33,16 +33,16 @@ class Page
     {
         $this->route = $route;
         switch (true) {
-            case preg_match("%\s*/[0-9]*/\s*%", $this->route):
-                [, $id, ] = explode("/", $this->route);
+            case preg_match("%\s*/[0-9]*/\s*%", (string) $this->route):
+                [, $id, ] = explode("/", (string) $this->route);
                 $article = new Article($id, $this->bdd);
                 $article->charger();
                 $this->title = $article->titre;
                 $this->content = $article->afficher();
                 break;
 
-            case preg_match("%s*/[0-9]*%", $this->route):
-                [, $id] = explode("/", $this->route);
+            case preg_match("%s*/[0-9]*%", (string) $this->route):
+                [, $id] = explode("/", (string) $this->route);
                 $rubrique = new Rubrique($id, $this->bdd);
                 $rubrique->charger();
                 $this->title = $rubrique->nom;
@@ -66,7 +66,7 @@ class Page
     public function header($url = null, UserInterface $user = null): string
     {
         $branche = new Branche($this->bdd);
-        $url = urldecode($url);
+        $url = urldecode((string) $url);
         $str = '<ul>';
 
         $feuillesEnfants = $branche->feuillesEnfants(Feuille::ID_FEUILLE_HEADER);
@@ -96,14 +96,14 @@ class Page
                 'etat' => '1',
                 'image' => null,
                 'patterns' => null,
-                'class' => 'desktop-hidden'
+                'class' => 'desktop-hidden',
             ];
         }
 
         foreach ($feuillesEnfants as $feuille) {
             $isCurrent = false;
             if ($feuille['patterns']) {
-                foreach (explode(PHP_EOL, $feuille['patterns']) as $pattern) {
+                foreach (explode(PHP_EOL, (string) $feuille['patterns']) as $pattern) {
                     $pattern = trim($pattern);
                     if ($pattern === '') {
                         continue;
@@ -175,7 +175,7 @@ class Page
         foreach ($branche->feuillesEnfants(Feuille::ID_FEUILLE_FOOTER) as $feuilleColonne) {
             $footerColumns[] = [
                 'nom' => $branche->getNom($feuilleColonne['id']),
-                'items' => $branche->feuillesEnfants($feuilleColonne['id'])
+                'items' => $branche->feuillesEnfants($feuilleColonne['id']),
             ];
         }
 

--- a/sources/Afup/Corporate/Rubrique.php
+++ b/sources/Afup/Corporate/Rubrique.php
@@ -14,8 +14,6 @@ class Rubrique
     const ID_RUBRIQUE_ANTENNES = 84;
     const ID_RUBRIQUE_INFORMATIONS_PRATIQUES = 86;
     const ID_RUBRIQUE_NOS_ACTIONS = 88;
-
-    public $id;
     public $id_personne_physique;
     public $id_parent;
     public $nom;
@@ -40,10 +38,11 @@ class Rubrique
     protected $conf;
     protected $page_courante;
 
-    public function __construct($id = 0, $bdd = false, $conf = false)
-    {
-        $this->id = $id;
-
+    public function __construct(
+        public $id = 0,
+        $bdd = false,
+        $conf = false,
+    ) {
         $this->bdd = $bdd ?: new _Site_Base_De_Donnees();
 
         $this->conf = $conf ?: $GLOBALS['AFUP_CONF'];
@@ -376,7 +375,7 @@ class Rubrique
                 $this->page_courante,
                 $this->pagination,
                 $this->compte_autres_articles(),
-                [$this, 'genere_route']
+                $this->genere_route(...)
             );
         } else {
             return '';

--- a/sources/Afup/Corporate/Rubriques.php
+++ b/sources/Afup/Corporate/Rubriques.php
@@ -46,14 +46,14 @@ class Rubriques
     public function obtenirListe(string $champs = '*',
                           string $ordre = 'titre',
                           $filtre = null,
-                          $associatif = false
+                          $associatif = false,
     ) {
         $requete = 'SELECT';
         $requete .= '  ' . $champs . ' ';
         $requete .= 'FROM';
         $requete .= '  afup_site_rubrique ';
 
-        if ($filtre && trim($filtre) !== '') {
+        if ($filtre && trim((string) $filtre) !== '') {
             $requete .= sprintf(' WHERE afup_site_rubrique.nom LIKE %s ', $this->bdd->echapper('%' . $filtre . '%'));
         }
 

--- a/sources/Afup/Corporate/Site.php
+++ b/sources/Afup/Corporate/Site.php
@@ -35,13 +35,13 @@ class Site
 
     public static function transformer_lien_spip($texte)
     {
-        $texte = preg_replace('`\[(.*?)[[:space:]]*->http://(.*?)\]`', '<a href="http://$2">$1</a>', $texte);
-        return preg_replace('`\[(.*?)->(.*?)\]`', '<a href="http://$2">$1</a>', $texte);
+        $texte = preg_replace('`\[(.*?)[[:space:]]*->http://(.*?)\]`', '<a href="http://$2">$1</a>', (string) $texte);
+        return preg_replace('`\[(.*?)->(.*?)\]`', '<a href="http://$2">$1</a>', (string) $texte);
     }
 
     public static function transformer_liste_spip($texte): string
     {
-        $lignes = explode("\n", $texte);
+        $lignes = explode("\n", (string) $texte);
         foreach ($lignes as &$ligne) {
             $ligne = preg_replace("`^- (.*)`", "<ul>\n<li>\$1</li>\n</ul>", $ligne);
         }
@@ -53,9 +53,9 @@ class Site
     {
         $texte = self::transformer_lien_spip($texte);
         for ($i = 0; $i < 2; $i++) {
-            $texte = preg_replace('`\{\{\{[[:space:]]*(.*?)[[:space:]]*\}\}\}`', '<h3>$1</h3>', $texte);
-            $texte = preg_replace('`\{\{[[:space:]]*(.*?)[[:space:]]*\}\}`', '<strong>$1</strong>', $texte);
-            $texte = preg_replace('`\{[[:space:]]*(.*?)[[:space:]]*\}`', '<em>$1</em>', $texte);
+            $texte = preg_replace('`\{\{\{[[:space:]]*(.*?)[[:space:]]*\}\}\}`', '<h3>$1</h3>', (string) $texte);
+            $texte = preg_replace('`\{\{[[:space:]]*(.*?)[[:space:]]*\}\}`', '<strong>$1</strong>', (string) $texte);
+            $texte = preg_replace('`\{[[:space:]]*(.*?)[[:space:]]*\}`', '<em>$1</em>', (string) $texte);
         }
         return self::transformer_liste_spip($texte);
     }
@@ -97,7 +97,7 @@ class Site
                 $article->chapeau = self::transformer_spip_en_html(($article_spip['chapo']));
                 $article->contenu = self::transformer_spip_en_html(($article_spip['texte']));
                 $article->position = 0;
-                $article->date = strtotime($article_spip['date']);
+                $article->date = strtotime((string) $article_spip['date']);
                 $article->etat = 1;
                 $article->inserer();
                 $nombre_articles++;

--- a/sources/Afup/Droits.php
+++ b/sources/Afup/Droits.php
@@ -27,18 +27,10 @@ class Droits
      */
     private array $_pages = [];
 
-    private TokenStorageInterface $tokenStorage;
-
-    private AuthorizationCheckerInterface $authorizationChecker;
-
-    /**
-     * Constructeur. Vérifie si l'utilisateur est connecté
-     *
-     */
-    public function __construct(TokenStorageInterface $tokenStorage, AuthorizationCheckerInterface $authorizationChecker)
-    {
-        $this->tokenStorage = $tokenStorage;
-        $this->authorizationChecker = $authorizationChecker;
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+    ) {
     }
 
     /**

--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -9,23 +9,10 @@ use AppBundle\Event\Model\Talk;
 
 class AppelConferencier
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var Base_De_Donnees
-     */
-    private $_bdd;
-
     const DEFAULT_JOURNEE = 0;
 
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     public function supprimerSession($id)
@@ -329,7 +316,7 @@ class AppelConferencier
                                   $filtre = false,
                                   $type = 'session',
                                   $needsMentoring = null,
-                                  $planned = null
+                                  $planned = null,
     ) {
         $requete = ' SELECT ';
         $requete .= '  COUNT(co.id) as commentaires_nombre, ';
@@ -422,7 +409,7 @@ class AppelConferencier
         $date_publication = null,
         $tweets = null,
         $transcript = null,
-        $verbatim = null
+        $verbatim = null,
     ) {
         $this->_bdd->executer("SET NAMES utf8mb4");
 
@@ -432,7 +419,7 @@ class AppelConferencier
         $requete .= ' titre = ' . $this->_bdd->echapper($titre) . ', ';
         $requete .= ' abstract = ' . $this->_bdd->echapper($abstract) . ', ';
         $requete .= ' genre = ' . $this->_bdd->echapper($genre) . ', ';
-        if (strlen(trim($joindin)) > 0) {
+        if (strlen(trim((string) $joindin)) > 0) {
             $requete .= ' joindin = ' . $this->_bdd->echapper($joindin) . ', ';
         } else {
             $requete .= ' joindin = NULL, ';
@@ -510,7 +497,7 @@ class AppelConferencier
         int $plannifie = 0,
         int $needs_mentoring = 0,
         int $level = Talk::SKILL_NA,
-        $useMarkdown = false
+        $useMarkdown = false,
     ) {
         $donnees = [
             $this->_bdd->echapper($id_forum),
@@ -522,7 +509,7 @@ class AppelConferencier
             $this->_bdd->echapper($plannifie),
             $this->_bdd->echapper($needs_mentoring),
             $this->_bdd->echapper($level),
-            (int) $useMarkdown
+            (int) $useMarkdown,
         ];
 
         $requete = ' INSERT INTO afup_sessions

--- a/sources/Afup/Forum/Coupon.php
+++ b/sources/Afup/Forum/Coupon.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace Afup\Site\Forum;
 
+use Afup\Site\Utils\Base_De_Donnees;
+
 class Coupon
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var     object
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**
@@ -56,7 +45,7 @@ class Coupon
         $requete .= '  afup_forum_coupon (id, id_forum, texte) ';
         $requete .= 'VALUES (null,';
         $requete .= (int) $id_forum . ',';
-        $requete .= $this->_bdd->echapper(strtoupper($texte)) . ')';
+        $requete .= $this->_bdd->echapper(strtoupper((string) $texte)) . ')';
         return $this->_bdd->executer($requete);
     }
 

--- a/sources/Afup/Forum/Facturation.php
+++ b/sources/Afup/Forum/Facturation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Afup\Site\Forum;
 
+use Afup\Site\Utils\Base_De_Donnees;
 use Afup\Site\Utils\Mail;
 use Afup\Site\Utils\Pays;
 use Afup\Site\Utils\PDF_Facture;
@@ -18,21 +19,8 @@ use AppBundle\Event\Model\Ticket;
 
 class Facturation
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var     object
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**
@@ -87,9 +75,9 @@ class Facturation
 
     public function creerReference($id_forum, $label): string
     {
-        $label = preg_replace('/[^A-Z0-9_\-\:\.;]/', '', strtoupper(supprimerAccents($label)));
+        $label = preg_replace('/[^A-Z0-9_\-\:\.;]/', '', strtoupper((string) supprimerAccents($label)));
 
-        return 'F' . date('Y') . sprintf('%02d', $id_forum) . '-' . date('dm') . '-' . substr($label, 0, 5) . '-' . substr(md5(date('r') . $label), -5);
+        return 'F' . date('Y') . sprintf('%02d', $id_forum) . '-' . date('dm') . '-' . substr((string) $label, 0, 5) . '-' . substr(md5(date('r') . $label), -5);
     }
 
     public function estFacture($reference)
@@ -197,7 +185,7 @@ class Facturation
             return $value;
         }
 
-        return substr($value, 0, $length) . '...';
+        return substr((string) $value, 0, $length) . '...';
     }
 
     /**
@@ -264,7 +252,7 @@ class Facturation
         if ($facture['informations_reglement']) {
             $pdf->Ln(10);
             $pdf->Cell(32, 5, 'Référence client : ');
-            $infos = explode("\n", $facture['informations_reglement']);
+            $infos = explode("\n", (string) $facture['informations_reglement']);
             foreach ($infos as $info) {
                 $pdf->Cell(100, 5, $info);
                 $pdf->Ln();

--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace Afup\Site\Forum;
 
+use Afup\Site\Utils\Base_De_Donnees;
+
 class Forum
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var     object
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**
@@ -535,7 +524,7 @@ CODE_HTML;
         foreach ($donnees as $conference) {
 
             // Gestion de la description
-            $description = html_entity_decode($conference['abstract'], ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8');
+            $description = html_entity_decode((string) $conference['abstract'], ENT_QUOTES|ENT_SUBSTITUTE, 'UTF-8');
             $description = strip_tags($description);
             $description = str_replace('"', '\"', $description);
 
@@ -543,7 +532,7 @@ CODE_HTML;
             $conferenciers = [];
             for ($i = 1; $i <= 2; $i++) {
                 if (!empty($conference['conferencier' . $i]) &&
-                    'En cours de validation' !== trim($conference['conferencier' . $i])
+                    'En cours de validation' !== trim((string) $conference['conferencier' . $i])
                 ) {
                     $conferenciers[] = $conference['conferencier' . $i];
                 }
@@ -600,7 +589,7 @@ CODE_HTML;
         $accomodationEnabled = true,
         $waitingListUrl = null,
         $hasPricesDefinedWithVat = false,
-        $transportInformationEnabled = false
+        $transportInformationEnabled = false,
     ) {
         $requete = 'INSERT INTO ';
         $requete .= '  afup_forum (id, titre, nb_places, date_debut, date_fin, annee, date_fin_appel_projet,';
@@ -621,7 +610,7 @@ CODE_HTML;
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_repas_speakers, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_nuites_hotel, true) . ',';
         $requete .= $this->_bdd->echapperSqlDateFromQuickForm($date_annonce_planning, true) . ',';
-        $requete .= $this->_bdd->echapper($chemin_template, true) . ',';
+        $requete .= $this->_bdd->echapper($chemin_template) . ',';
         $requete .= $this->_bdd->echapper(json_encode($text)) . ', ';
         $requete .= $this->_bdd->echapper($logoUrl) . ',';
         $requete .= $this->_bdd->echapper($placeName) . ',';
@@ -663,7 +652,7 @@ CODE_HTML;
         $accomodationEnabled = true,
         $waitingListUrl = null,
         $hasPricesDefinedWithVat = false,
-        $transportInformationEnabled = false
+        $transportInformationEnabled = false,
     ) {
         $requete = 'UPDATE ';
         $requete .= '  afup_forum ';
@@ -682,7 +671,7 @@ CODE_HTML;
         $requete .= '  date_fin_saisie_repas_speakers=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_repas_speakers, true) . ',';
         $requete .= '  date_fin_saisie_nuites_hotel=' . $this->_bdd->echapperSqlDateFromQuickForm($date_fin_saisie_nuites_hotel, true) . ',';
         $requete .= '  date_annonce_planning=' . $this->_bdd->echapperSqlDateFromQuickForm($date_annonce_planning, true) . ',';
-        $requete .= '  path=' . $this->_bdd->echapper($chemin_template, true) . ', ';
+        $requete .= '  path=' . $this->_bdd->echapper($chemin_template) . ', ';
         $requete .= ' `text` = ' . $this->_bdd->echapper(json_encode($text)) . ', ';
         $requete .= ' `logo_url` = ' . $this->_bdd->echapper($logoUrl) . ', ';
         $requete .= ' `place_name` = ' . $this->_bdd->echapper($placeName) . ', ';

--- a/sources/Afup/Forum/Inscriptions.php
+++ b/sources/Afup/Forum/Inscriptions.php
@@ -8,21 +8,8 @@ use Afup\Site\Utils\Base_De_Donnees;
 
 class Inscriptions
 {
-    /**
-     * Instance de la couche d'abstraction ï¿½ la base de donnï¿½es
-     * @var     Base_De_Donnees
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction ï¿½ la base de donnï¿½es
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**
@@ -138,7 +125,7 @@ SQL;
             $suivis[$i] = [
                 'jour' => $i,
                 'n' => $daysToEndOfSales >= $i ? $infoForum : null,
-                'n_1' => $infoN1
+                'n_1' => $infoN1,
             ];
         }
 
@@ -146,7 +133,7 @@ SQL;
             'suivi' => $suivis,
             'min' => $nombre_par_date[0]['jour'],
             'max' => $i,
-            'daysToEndOfSales' => $daysToEndOfSales
+            'daysToEndOfSales' => $daysToEndOfSales,
         ];
     }
 
@@ -169,7 +156,7 @@ SQL;
 
         $derniere_lettre = "";
         foreach ($liste as $inscrit) {
-            $premiere_lettre = strtoupper($inscrit['nom'][0]);
+            $premiere_lettre = strtoupper((string) $inscrit['nom'][0]);
             if ($derniere_lettre !== $premiere_lettre) {
                 $liste_emargement[] = [
                     'nom' => $premiere_lettre,
@@ -202,7 +189,7 @@ SQL;
 
         $derniere_lettre = "";
         foreach ($liste as $inscrit) {
-            $premiere_lettre = strtoupper($inscrit['nom'][0]);
+            $premiere_lettre = strtoupper((string) $inscrit['nom'][0]);
             if ($derniere_lettre !== $premiere_lettre) {
                 $liste_emargement[] = [
                     'nom' => $premiere_lettre,

--- a/sources/Afup/Forum/Partenaires.php
+++ b/sources/Afup/Forum/Partenaires.php
@@ -8,21 +8,8 @@ use Afup\Site\Utils\Base_De_Donnees;
 
 class Partenaires
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var     Base_De_Donnees
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**

--- a/sources/Afup/Niveau_Partenariat.php
+++ b/sources/Afup/Niveau_Partenariat.php
@@ -4,23 +4,12 @@ declare(strict_types=1);
 
 namespace Afup\Site;
 
+use Afup\Site\Utils\Base_De_Donnees;
+
 class Niveau_Partenariat
 {
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var     object
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**

--- a/sources/Afup/Pagination.php
+++ b/sources/Afup/Pagination.php
@@ -4,22 +4,17 @@ declare(strict_types=1);
 
 namespace Afup\Site;
 
-class Pagination
+class Pagination implements \Stringable
 {
-    private $page_courante;
-    private $nombre_elements_par_page;
-    private $nombre_elements_total;
-    private $genere_route;
-
-    public function __construct($page_courante, $nombre_elements_par_page, $nombre_elements_total, $genere_route)
-    {
-        $this->page_courante = $page_courante;
-        $this->nombre_elements_par_page = $nombre_elements_par_page;
-        $this->nombre_elements_total = $nombre_elements_total;
-        $this->genere_route = $genere_route;
+    public function __construct(
+        private $page_courante,
+        private $nombre_elements_par_page,
+        private $nombre_elements_total,
+        private $genere_route,
+    ) {
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         global $smarty;
 
@@ -36,6 +31,6 @@ class Pagination
 
         ob_start();
         $smarty->display('pagination.html');
-        return ob_get_clean();
+        return (string) ob_get_clean();
     }
 }

--- a/sources/Afup/Utils/Configuration.php
+++ b/sources/Afup/Utils/Configuration.php
@@ -25,7 +25,7 @@ class Configuration
         $parameters = [
             'database_host', 'database_name', 'database_user', 'database_password', 'database_port',
             'smtp_host', 'smtp_port', 'smtp_tls', 'smtp_username', 'smtp_password',
-            'mailer_force_recipients', 'mailer_bcc'
+            'mailer_force_recipients', 'mailer_bcc',
         ];
 
         foreach ($parameters as $param) {

--- a/sources/Afup/Utils/PDF_Facture.php
+++ b/sources/Afup/Utils/PDF_Facture.php
@@ -17,13 +17,6 @@ class PDF_Facture extends PDF
      */
     public $configuration;
 
-    private BankAccount $bankAccount;
-
-    /**
-     * @var bool
-     */
-    private $isSubjectedToVat;
-
     /**
      * Constructor
      *
@@ -33,12 +26,17 @@ class PDF_Facture extends PDF
      * @param string $format The page's format. Default is A4
      * @return void
      * @throws \Exception
+     * @param bool $isSubjectedToVat
      */
-    public function __construct($configuration, BankAccount $bankAccount, $isSubjectedToVat = false, $orientation = 'P', $unit = 'mm', $format = 'A4')
-    {
+    public function __construct(
+        $configuration,
+        private readonly BankAccount $bankAccount,
+        private $isSubjectedToVat = false,
+        $orientation = 'P',
+        $unit = 'mm',
+        $format = 'A4',
+    ) {
         parent::__construct($orientation, $unit, $format);
-        $this->bankAccount = $bankAccount;
-        $this->isSubjectedToVat = $isSubjectedToVat;
 
         $this->setAFUPConfiguration($configuration);
     }

--- a/sources/Afup/Utils/Pays.php
+++ b/sources/Afup/Utils/Pays.php
@@ -11,21 +11,8 @@ class Pays
 {
     const DEFAULT_ID = 'FR';
 
-    /**
-     * Instance de la couche d'abstraction à la base de données
-     * @var Base_De_Donnees
-     */
-    private $_bdd;
-
-    /**
-     * Constructeur.
-     *
-     * @param  object $bdd Instance de la couche d'abstraction à la base de données
-     * @return void
-     */
-    public function __construct(&$bdd)
+    public function __construct(private readonly Base_De_Donnees $_bdd)
     {
-        $this->_bdd = $bdd;
     }
 
     /**

--- a/sources/Afup/Utils/Sympa.php
+++ b/sources/Afup/Utils/Sympa.php
@@ -6,18 +6,11 @@ namespace Afup\Site\Utils;
 
 class Sympa
 {
-    /**
-     * @var Base_De_Donnees
-     */
-    private $_bdd;
-    private $_configUrl;
-    private $configHost;
-
-    public function __construct($bdd, $configUrl, $configHost)
-    {
-        $this->_bdd = $bdd;
-        $this->_configUrl = $configUrl;
-        $this->configHost = $configHost;
+    public function __construct(
+        private readonly Base_De_Donnees $_bdd,
+        private $_configUrl,
+        private $configHost,
+    ) {
     }
 
     public function getAllMailingList()

--- a/sources/Afup/fonctions.php
+++ b/sources/Afup/fonctions.php
@@ -89,7 +89,7 @@ function verifierAction($actions_disponibles)
  */
 function supprimerAccents($texte): ?string
 {
-    $texte = htmlentities($texte);
+    $texte = htmlentities((string) $texte);
     return preg_replace('/&([a-z])[a-z]+;/i',"$1", $texte);
 }
 

--- a/sources/AppBundle/Association/CompanyMembership/AbstractCompanyReminder.php
+++ b/sources/AppBundle/Association/CompanyMembership/AbstractCompanyReminder.php
@@ -17,28 +17,12 @@ use AppBundle\Email\Mailer\Message;
 
 abstract class AbstractCompanyReminder implements MembershipReminderInterface
 {
-    private Mailer $mailer;
-
-    protected $membershipFee;
-
-    protected $membersPerFee;
-
-    private SubscriptionReminderLogRepository $subscriptionReminderLogRepository;
-
-    /**
-     * @param int                               $membershipFee
-     * @param int                               $membersPerFee
-     */
     public function __construct(
-        Mailer $mailer,
-        $membershipFee,
-        $membersPerFee,
-        SubscriptionReminderLogRepository $subscriptionReminderLogRepository
+        private readonly Mailer $mailer,
+        protected int $membershipFee,
+        protected int $membersPerFee,
+        private readonly SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
     ) {
-        $this->mailer = $mailer;
-        $this->membershipFee = $membershipFee;
-        $this->membersPerFee = $membersPerFee;
-        $this->subscriptionReminderLogRepository = $subscriptionReminderLogRepository;
     }
 
     abstract protected function getText();

--- a/sources/AppBundle/Association/CompanyMembership/CompanyReminderFactory.php
+++ b/sources/AppBundle/Association/CompanyMembership/CompanyReminderFactory.php
@@ -11,14 +11,10 @@ use AppBundle\Email\Mailer\Mailer;
 
 class CompanyReminderFactory
 {
-    private Mailer $mailer;
-
-    private SubscriptionReminderLogRepository $subscriptionReminderLogRepository;
-
-    public function __construct(Mailer $mailer, SubscriptionReminderLogRepository $subscriptionReminderLogRepository)
-    {
-        $this->mailer = $mailer;
-        $this->subscriptionReminderLogRepository = $subscriptionReminderLogRepository;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Association/CompanyMembership/InvitationMail.php
+++ b/sources/AppBundle/Association/CompanyMembership/InvitationMail.php
@@ -17,17 +17,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InvitationMail
 {
-    private Mailer $mailer;
-
-    private TranslatorInterface $translator;
-
-    private RouterInterface $router;
-
-    public function __construct(Mailer $mailer, TranslatorInterface $translator, RouterInterface $router)
-    {
-        $this->mailer = $mailer;
-        $this->translator = $translator;
-        $this->router = $router;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly TranslatorInterface $translator,
+        private readonly RouterInterface $router,
+    ) {
     }
 
     /**
@@ -46,7 +40,7 @@ class InvitationMail
                     'company_invitation',
                     ['invitationId' => $invitation->getId(), 'token' => $invitation->getToken()],
                     UrlGeneratorInterface::ABSOLUTE_URL
-                )
+                ),
             ]
         );
 

--- a/sources/AppBundle/Association/CompanyMembership/SubscriptionManagement.php
+++ b/sources/AppBundle/Association/CompanyMembership/SubscriptionManagement.php
@@ -12,11 +12,8 @@ use AppBundle\LegacyModelFactory;
 
 class SubscriptionManagement
 {
-    private LegacyModelFactory $legacyModelFactory;
-
-    public function __construct(LegacyModelFactory $legacyModelFactory)
+    public function __construct(private readonly LegacyModelFactory $legacyModelFactory)
     {
-        $this->legacyModelFactory = $legacyModelFactory;
     }
 
     public function createInvoiceForInscription(CompanyMember $company, $numberOfMembers): array

--- a/sources/AppBundle/Association/CompanyMembership/UserCompany.php
+++ b/sources/AppBundle/Association/CompanyMembership/UserCompany.php
@@ -11,14 +11,10 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class UserCompany
 {
-    private UserRepository $userRepository;
-
-    private EventDispatcherInterface $eventDispatcher;
-
-    public function __construct(UserRepository $userRepository, EventDispatcherInterface $eventDispatcher)
-    {
-        $this->userRepository = $userRepository;
-        $this->eventDispatcher = $eventDispatcher;
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
     }
 
     public function setManager(User $user): void

--- a/sources/AppBundle/Association/Event/NewMemberEvent.php
+++ b/sources/AppBundle/Association/Event/NewMemberEvent.php
@@ -9,11 +9,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class NewMemberEvent extends Event
 {
-    private User $user;
-
-    public function __construct(User $user)
+    public function __construct(private readonly User $user)
     {
-        $this->user = $user;
     }
 
     public function getUser(): User

--- a/sources/AppBundle/Association/Event/UserDisabledEvent.php
+++ b/sources/AppBundle/Association/Event/UserDisabledEvent.php
@@ -9,11 +9,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class UserDisabledEvent extends Event
 {
-    private User $user;
-
-    public function __construct(User $user)
+    public function __construct(private readonly User $user)
     {
-        $this->user = $user;
     }
 
     public function getUser(): User

--- a/sources/AppBundle/Association/Form/BadgeType.php
+++ b/sources/AppBundle/Association/Form/BadgeType.php
@@ -37,9 +37,9 @@ class BadgeType extends AbstractType
                             'maxHeight' => 850,
                             'mimeTypes' => [
                                 'image/png',
-                            ]
-                        ])
-                    ]
+                            ],
+                        ]),
+                    ],
                 ]
             )
             ->add(

--- a/sources/AppBundle/Association/Form/CompanyEditType.php
+++ b/sources/AppBundle/Association/Form/CompanyEditType.php
@@ -17,11 +17,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CompanyEditType extends AbstractType
 {
-    private Pays $pays;
-
-    public function __construct(Pays $pays)
+    public function __construct(private readonly Pays $pays)
     {
-        $this->pays = $pays;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/sources/AppBundle/Association/Form/CompanyMemberType.php
+++ b/sources/AppBundle/Association/Form/CompanyMemberType.php
@@ -42,21 +42,21 @@ class CompanyMemberType extends AbstractType
                 'maxMembers',
                 ChoiceType::class,
                 [
-                    'choices' => $choices
+                    'choices' => $choices,
                 ]
             )
             ->add('invitations', CollectionType::class, [
                 // each entry in the array will be an "email" field
                 'entry_type'   => CompanyMemberInvitationType::class,
                 'allow_add' => true,
-                'required' => false
+                'required' => false,
             ])
             ->add('recaptcha', EWZRecaptchaType::class, [
                 'label' => 'Vérification',
                 'mapped' => false,
                 'constraints' => [
-                    new RecaptchaIsValid()
-                ]
+                    new RecaptchaIsValid(),
+                ],
             ])
             ->add('save', SubmitType::class, ['label' => 'saveMembership'])
         ;

--- a/sources/AppBundle/Association/Form/CompanyPublicProfile.php
+++ b/sources/AppBundle/Association/Form/CompanyPublicProfile.php
@@ -48,7 +48,7 @@ class CompanyPublicProfile extends AbstractType
                 'maxWidth' => 1000,
                 'minHeight' => 200,
                 'minWidth' => 200,
-            ])
+            ]),
         ];
 
         if ($options['logo_required']) {
@@ -64,7 +64,7 @@ class CompanyPublicProfile extends AbstractType
                     'required' => false,
                     'constraints' => [
                         new Type(['type' => 'boolean']),
-                    ]
+                    ],
                 ]
             )
             ->add(
@@ -78,7 +78,7 @@ class CompanyPublicProfile extends AbstractType
                     'constraints' => [
                         new NotNull(),
                         new Length(['max' => self::DESCRIPTION_MAX_LENGTH]),
-                    ]
+                    ],
                 ]
             )
             ->add(
@@ -144,7 +144,7 @@ class CompanyPublicProfile extends AbstractType
                             'multiple' => true,
                             'strict' => true,
                         ]),
-                    ]
+                    ],
                 ]
             )
             ->add(

--- a/sources/AppBundle/Association/Form/ContactDetailsType.php
+++ b/sources/AppBundle/Association/Form/ContactDetailsType.php
@@ -40,28 +40,28 @@ class ContactDetailsType extends AbstractType
             ->add('email', EmailType::class, [
                 'constraints' => [
                     new Email(),
-                ]
+                ],
             ])
             ->add('address', TextareaType::class, [
                 'constraints' => [
                     new NotBlank(),
-                ]
+                ],
             ])
             ->add('zipcode', TextType::class, [
                 'label' => 'Zip code',
                 'constraints' => [
                     new NotBlank(),
-                ]
+                ],
             ])
             ->add('city', TextType::class, [
                 'constraints' => [
                     new NotBlank(),
-                ]
+                ],
             ])
             ->add('country', ChoiceType::class, [
                 'label' => 'Pays',
                 'choices' => $this->getCountyChoices(),
-                'preferred_choices' => ['FR']
+                'preferred_choices' => ['FR'],
             ])
             ->add('phone', TextType::class, [
                 'required' => false,
@@ -81,12 +81,12 @@ class ContactDetailsType extends AbstractType
             ])
             ->add('username', TextType::class, [
                 'attr' => [
-                    'maxlength' => 30
+                    'maxlength' => 30,
                 ],
                 'constraints' => [
                     new NotBlank(),
                     new Length(['max' => 30]),
-                ]
+                ],
             ])
             ->add('plainPassword', RepeatedType::class, [
                 'mapped' => false,

--- a/sources/AppBundle/Association/Form/RegisterUserType.php
+++ b/sources/AppBundle/Association/Form/RegisterUserType.php
@@ -24,23 +24,23 @@ class RegisterUserType extends AbstractType
             ])
             ->add('country', CountryType::class, [
                 'label' => 'Pays',
-                'required' => true
+                'required' => true,
             ])
             ->add('mobilephone', TelType::class, [
                 'label' => 'Portable',
-                'required' => false
+                'required' => false,
             ])
             ->add('nearestOffice', NearestOfficeChoiceType::class, [
-                'required' => false
+                'required' => false,
             ])
             ->add('civility', ChoiceType::class, [
                 'choices' => ['M.' => User::CIVILITE_M, 'Mme' => User::CIVILITE_MME],
-                'required' => true
+                'required' => true,
             ])
         ;
 
         $builder->get('userCommonInfo')->add('phone', TextType::class, [
-            'required' => false
+            'required' => false,
         ]);
     }
 

--- a/sources/AppBundle/Association/Form/TicketEventType.php
+++ b/sources/AppBundle/Association/Form/TicketEventType.php
@@ -25,42 +25,42 @@ class TicketEventType extends AbstractType
             ->add('ticketType', ChoiceType::class, [
                 'choices' => $this->ticketTypesToChoices($options['ticketTypes']),
                 'constraints' => [
-                    new NotBlank()
+                    new NotBlank(),
                 ],
-                'label' => 'Type de ticket'
+                'label' => 'Type de ticket',
             ])
             ->add('price', MoneyType::class, [
                 'currency' => 'EUR',
                 'constraints' => [
                     new GreaterThanOrEqual(0),
-                    new NotBlank()
+                    new NotBlank(),
                 ],
                 'label' => $options['has_prices_defined_with_vat'] ? 'Montant TTC' : 'Montant HT',
             ])
             ->add('dateStart', DateTimeType::class, [
                 'widget' => 'choice',
                 'constraints' => [
-                    new NotBlank()
+                    new NotBlank(),
                 ],
-                'label' => 'Date de début'
+                'label' => 'Date de début',
             ])
             ->add('dateEnd', DateTimeType::class, [
                 'widget' => 'choice',
                 'constraints' => [
-                    new NotBlank()
+                    new NotBlank(),
                 ],
-                'label' => 'Date de fin'
+                'label' => 'Date de fin',
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,
-                'label' => 'Description'
+                'label' => 'Description',
             ])
             ->add('maxTickets', IntegerType::class, [
                 'constraints' => [
                     new GreaterThanOrEqual(0),
                 ],
                 'required' => false,
-                'label' => 'Nombre max. de tickets'
+                'label' => 'Nombre max. de tickets',
             ]);
     }
 
@@ -71,7 +71,7 @@ class TicketEventType extends AbstractType
             'has_prices_defined_with_vat' => true,
         ]);
         $resolver->setRequired([
-            'ticketTypes'
+            'ticketTypes',
         ]);
     }
 

--- a/sources/AppBundle/Association/Form/UserBadgeType.php
+++ b/sources/AppBundle/Association/Form/UserBadgeType.php
@@ -16,14 +16,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class UserBadgeType extends AbstractType
 {
-    private BadgeRepository $badgeRepository;
-
-    private UserBadgeRepository $userBadgeRepository;
-
-    public function __construct(BadgeRepository $badgeRepository, UserBadgeRepository $userBadgeRepository)
-    {
-        $this->badgeRepository = $badgeRepository;
-        $this->userBadgeRepository = $userBadgeRepository;
+    public function __construct(
+        private readonly BadgeRepository $badgeRepository,
+        private readonly UserBadgeRepository $userBadgeRepository,
+    ) {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/sources/AppBundle/Association/Form/UserEditFormData.php
+++ b/sources/AppBundle/Association/Form/UserEditFormData.php
@@ -16,97 +16,61 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
 class UserEditFormData
 {
     public $companyId;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Choice(choices={"M.", "Mme"}, strict=true)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: ['M.', 'Mme'], strict: true)]
     public $civility = 'M.';
-    /**
-     * @Assert\NotBlank()
-     */
+    #[Assert\NotBlank]
     public $lastname;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Length(max=40)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 40)]
     public $firstname;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Email()
-     * @Assert\Length(max=100)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Email]
+    #[Assert\Length(max: 100)]
     public $email;
-    /**
-     * @Assert\Email()
-     * @Assert\Length(max=100)
-     */
+    #[Assert\Email]
+    #[Assert\Length(max: 100)]
     public $alternateEmail;
-    /**
-     * @Assert\NotBlank()
-     */
+    #[Assert\NotBlank]
     public $address;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Length(min=4, max=10)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 4, max: 10)]
     public $zipcode;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Length(max=50)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 50)]
     public $city;
     /** @var string */
     public $countryId = 'FR';
-    /**
-     * @Assert\Length(max=20)
-     */
+    #[Assert\Length(max: 20)]
     public $phone;
-    /**
-     * @Assert\Length(max=20)
-     */
+    #[Assert\Length(max: 20)]
     public $cellphone;
-    /**
-     * @Assert\Choice(choices={0, 1, 2}, strict=true)
-     */
+    #[Assert\Choice(choices: [0, 1, 2], strict: true)]
     public $level = User::LEVEL_MEMBER;
     /**
      */
     public $directoryLevel = User::LEVEL_MEMBER;
-    /**
-     * @Assert\Choice(choices={0, 2}, strict=true)
-     */
+    #[Assert\Choice(choices: [0, 2], strict: true)]
     public $eventLevel = User::LEVEL_MEMBER;
-    /**
-     * @Assert\Choice(choices={0, 2}, strict=true)
-     */
+    #[Assert\Choice(choices: [0, 2], strict: true)]
     public $websiteLevel = User::LEVEL_MEMBER;
-    /**
-     * @Assert\Choice(choices={0, 2}, strict=true)
-     */
+    #[Assert\Choice(choices: [0, 2], strict: true)]
     public $officeLevel = User::LEVEL_MEMBER;
-    /**
-     * @Assert\Choice(choices={0, 1, -1}, strict=true)
-     */
+    #[Assert\Choice(choices: [0, 1, -1], strict: true)]
     public $status = User::STATUS_INACTIVE;
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Length(max=30)
-     */
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 30)]
     public $username;
-    /**
-     * @Assert\Length(max=30)
-     */
+    #[Assert\Length(max: 30)]
     public $password;
     public $roles;
     /** @var bool */
     public $needsUpToDateMembership;
 
-    /**
-     * @Assert\Callback
-     */
+    #[Assert\Callback]
     public function validate(ExecutionContextInterface $context): void
     {
-        if (!is_array(json_decode($this->roles, true))) {
+        if (!is_array(json_decode((string) $this->roles, true))) {
             $context->buildViolation('Les roles ne sont pas valides')
                 ->atPath('roles')
                 ->addViolation();

--- a/sources/AppBundle/Association/Form/UserEditType.php
+++ b/sources/AppBundle/Association/Form/UserEditType.php
@@ -25,15 +25,10 @@ use Symfony\Component\Validator\Constraints\NotBlank;
 
 class UserEditType extends AbstractType
 {
-    private CompanyMemberRepository $companyMemberRepository;
-    private Pays $pays;
-
     public function __construct(
-        CompanyMemberRepository $companyMemberRepository,
-        Pays $pays
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly Pays $pays,
     ) {
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->pays = $pays;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -226,7 +221,7 @@ class UserEditType extends AbstractType
 
         $builder->get('roles')->addModelTransformer(new CallbackTransformer(
             fn ($rolesAsArray): string => json_encode($rolesAsArray),
-            fn ($rolesAsString): array => json_decode($rolesAsString)
+            fn ($rolesAsString): array => json_decode((string) $rolesAsString)
         ));
 
         $builder

--- a/sources/AppBundle/Association/Form/UserType.php
+++ b/sources/AppBundle/Association/Form/UserType.php
@@ -28,7 +28,7 @@ class UserType extends AbstractType
             ->add('password', RepeatedType::class, [
                 'first_options'  => ['label' => 'Password'],
                 'second_options' => ['label' => 'Repeat Password'],
-                'type' => PasswordType::class
+                'type' => PasswordType::class,
             ])
             ->add('address', TextareaType::class)
             ->add('zipcode', TextType::class, ['label' => 'Zip code'])

--- a/sources/AppBundle/Association/MembershipFeeReferenceGenerator.php
+++ b/sources/AppBundle/Association/MembershipFeeReferenceGenerator.php
@@ -17,10 +17,10 @@ class MembershipFeeReferenceGenerator
      */
     public function generate(\DateTimeImmutable $currentDate, $typePersonne, $idPersonne, $nomPersonne)
     {
-        $reference = strtoupper('C' . $currentDate->format('Y') . '-' . $currentDate->format('dmYHi') . '-' . $typePersonne . '-' . $idPersonne . '-' . substr(supprimerAccents($nomPersonne), 0, 5));
+        $reference = strtoupper('C' . $currentDate->format('Y') . '-' . $currentDate->format('dmYHi') . '-' . $typePersonne . '-' . $idPersonne . '-' . substr((string) supprimerAccents($nomPersonne), 0, 5));
         $reference = supprimerAccents($reference);
-        $reference = preg_replace('/[^A-Z0-9_\-\:\.;]/', '', $reference);
+        $reference = preg_replace('/[^A-Z0-9_\-\:\.;]/', '', (string) $reference);
 
-        return $reference . ('-' . strtoupper(substr(md5($reference), - 3)));
+        return $reference . ('-' . strtoupper(substr(md5((string) $reference), - 3)));
     }
 }

--- a/sources/AppBundle/Association/Model/CompanyMember.php
+++ b/sources/AppBundle/Association/Model/CompanyMember.php
@@ -25,57 +25,57 @@ class CompanyMember implements NotifyPropertyInterface
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $firstName;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $lastName;
 
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Email()
      */
+    #[Assert\NotBlank]
+    #[Assert\Email]
     private $email;
 
     /**
      * @var string
-     * @Assert\NotBlank(message="Raison sociale manquante")
      */
+    #[Assert\NotBlank(message: 'Raison sociale manquante')]
     private $companyName;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $siret;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $address;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $zipCode;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $city;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $country = 'FR';
 
     /**

--- a/sources/AppBundle/Association/Model/CompanyMemberInvitation.php
+++ b/sources/AppBundle/Association/Model/CompanyMemberInvitation.php
@@ -29,8 +29,8 @@ class CompanyMemberInvitation implements NotifyPropertyInterface
 
     /**
      * @var string
-     * @Assert\Email()
      */
+    #[Assert\Email]
     private $email;
 
     /**

--- a/sources/AppBundle/Association/Model/Repository/CompanyMemberInvitationRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/CompanyMemberInvitationRepository.php
@@ -23,7 +23,7 @@ class CompanyMemberInvitationRepository extends Repository implements MetadataIn
     {
         return $this->getBy([
             'companyId' => $companyMember->getId(),
-            'status' => CompanyMemberInvitation::STATUS_PENDING
+            'status' => CompanyMemberInvitation::STATUS_PENDING,
         ]);
     }
 
@@ -45,38 +45,38 @@ class CompanyMemberInvitationRepository extends Repository implements MetadataIn
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'company_id',
                 'fieldName' => 'companyId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'token',
                 'fieldName' => 'token',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'manager',
                 'fieldName' => 'manager',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'submitted_on',
                 'fieldName' => 'submittedOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'status',
                 'fieldName' => 'status',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/Repository/CompanyMemberRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/CompanyMemberRepository.php
@@ -279,7 +279,7 @@ class CompanyMemberRepository extends Repository implements MetadataInitializer
                 'columnName' => 'public_profile_enabled',
                 'fieldName' => 'publicProfileEnabled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'description',

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingResponseRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingResponseRepository.php
@@ -45,7 +45,7 @@ class GeneralMeetingResponseRepository extends Repository implements MetadataIni
                 'fieldName' => 'date',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                 ],
             ])
             ->addField([

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
@@ -65,12 +65,12 @@ SQL;
             ->addField([
                 'columnName' => 'afup_assemblee_generale_question_id',
                 'fieldName' => 'questionId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'afup_personnes_physiques_id',
                 'fieldName' => 'userId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'weight',

--- a/sources/AppBundle/Association/Model/Repository/SubscriptionReminderLogRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/SubscriptionReminderLogRepository.php
@@ -44,37 +44,37 @@ class SubscriptionReminderLogRepository extends Repository implements MetadataIn
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'user_id',
                 'fieldName' => 'userId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'user_type',
                 'fieldName' => 'userType',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'reminder_key',
                 'fieldName' => 'reminderKey',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'reminder_date',
                 'fieldName' => 'reminderDate',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'mail_sent',
                 'fieldName' => 'mailSent',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/Repository/SubscriptionRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/SubscriptionRepository.php
@@ -38,63 +38,63 @@ class SubscriptionRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date_debut',
                 'fieldName' => 'startDate',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin',
                 'fieldName' => 'endDate',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                ],
             ])
             ->addField([
                 'columnName' => 'type_personne',
                 'fieldName' => 'userType',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_personne',
                 'fieldName' => 'userId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'montant',
                 'fieldName' => 'amount',
-                'type' => 'float'
+                'type' => 'float',
             ])
             ->addField([
                 'columnName' => 'type_reglement',
                 'fieldName' => 'paymentType',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'informations_reglement',
                 'fieldName' => 'paymentDetails',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'numero_facture',
                 'fieldName' => 'invoiceNumber',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'commentaires',
                 'fieldName' => 'comments',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'token',
                 'fieldName' => 'token',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/Repository/TechletterSubscriptionsRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/TechletterSubscriptionsRepository.php
@@ -128,17 +128,17 @@ class TechletterSubscriptionsRepository extends Repository implements MetadataIn
                 'fieldName' => 'id',
                 'primary' => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'user_id',
                 'fieldName' => 'userId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'subscription_date',
                 'fieldName' => 'subscriptionDate',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/Repository/TechletterUnsubscriptionsRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/TechletterUnsubscriptionsRepository.php
@@ -54,27 +54,27 @@ class TechletterUnsubscriptionsRepository extends Repository implements Metadata
                 'fieldName' => 'id',
                 'primary' => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'unsubscription_date',
                 'fieldName' => 'unsubscriptionDate',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'reason',
                 'fieldName' => 'reason',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'mailchimp_id',
                 'fieldName' => 'mailchimpId',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/Repository/UserRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/UserRepository.php
@@ -52,7 +52,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
             ->getPreparedQuery($queryBuilder->getStatement())
             ->setParams([
                 'username' => $username,
-                'email' => $username
+                'email' => $username,
             ])
             ->query($this->getCollection($this->getHydratorForUser()));
 
@@ -103,7 +103,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
         $result = $this
             ->getPreparedQuery($queryBuilder->getStatement())
             ->setParams([
-                'hash' => $hash
+                'hash' => $hash,
             ])
             ->query($this->getCollection($this->getHydratorForUser()));
 
@@ -125,7 +125,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
             ->getPreparedQuery($queryBuilder->getStatement())
             ->setParams([
                 'company' => $companyMember->getId(),
-                'state' => User::STATUS_ACTIVE
+                'state' => User::STATUS_ACTIVE,
             ])
             ->query($this->getCollection($this->getHydratorForUser()))
             ;
@@ -178,7 +178,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
         $userId = null,
         $onlyActive = true,
         $isCompanyManager = null,
-        $needsUptoDateMembership = null
+        $needsUptoDateMembership = null,
     ) {
         Assertion::inArray($direction, ['asc', 'desc']);
         $sorts = [
@@ -196,7 +196,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
         //   Même si l'email ne colle pas on pourra trouver la personne.
         // C'est un peu barbare mais généralement on ne met qu'un seul terme dans la recherche… du coup c'est pas bien grave.
         if ($filter) {
-            $filters = explode(' ', $filter);
+            $filters = explode(' ', (string) $filter);
             $filters = array_filter(array_map('trim', $filters));
             $ors = [];
             foreach ($filters as $i => $value) {
@@ -362,7 +362,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
         $queryBuilder
             ->cols([
                 'app.`id`', 'app.`login`', 'app.`prenom`', 'app.`nom`',
-                'app.`email`', 'apm.`id`', 'apm.`raison_sociale`', 'apm.`max_members`', 'app.`id_personne_morale`'
+                'app.`email`', 'apm.`id`', 'apm.`raison_sociale`', 'apm.`max_members`', 'app.`id_personne_morale`',
             ])
             ->from('afup_personnes_physiques app')
             ->join('LEFT', 'afup_personnes_morales apm', 'apm.id = app.id_personne_morale')
@@ -385,7 +385,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
                 'app.`slack_invite_status`', 'app.`slack_alternate_email`', 'app.`needs_up_to_date_membership`',
                 'app.`nearest_office`',
                 'MD5(CONCAT(app.`id`, \'_\', app.`email`, \'_\', app.`login`)) as hash',
-                "MAX(ac.date_fin) AS lastsubcription"
+                "MAX(ac.date_fin) AS lastsubcription",
             ]);
     }
 
@@ -434,7 +434,7 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
             ->getPreparedQuery($queryBuilder->getStatement())
             ->setParams([
                 'start' => $today->format('U'),
-                'status' => User::STATUS_ACTIVE
+                'status' => User::STATUS_ACTIVE,
             ])
             ->query($this->getCollection(new HydratorSingleObject()));
     }
@@ -463,15 +463,15 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
             ->setParams([
                 'start' => $startOfDay->format('U'),
                 'end' => $endOfDay->format('U'),
-                'status' => User::STATUS_ACTIVE
+                'status' => User::STATUS_ACTIVE,
             ])
             ->query($this->getCollection(new HydratorSingleObject()));
     }
 
     public function refreshUser(UserInterface $user)
     {
-        if ($this->supportsClass(get_class($user)) === false) {
-            throw new UnsupportedUserException(sprintf('Instance of %s not supported', get_class($user)));
+        if ($this->supportsClass($user::class) === false) {
+            throw new UnsupportedUserException(sprintf('Instance of %s not supported', $user::class));
         }
 
         return $this->loadUserByUsername($user->getUsername());
@@ -500,100 +500,100 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_personne_morale',
                 'fieldName' => 'companyId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'login',
                 'fieldName' => 'username',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'mot_de_passe',
                 'fieldName' => 'password',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'civilite',
                 'fieldName' => 'civility',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'prenom',
                 'fieldName' => 'firstName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nom',
                 'fieldName' => 'lastName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'niveau',
                 'fieldName' => 'level',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'niveau_modules',
                 'fieldName' => 'levelModules',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'roles',
                 'fieldName' => 'roles',
                 'type' => 'json',
                 'serializer_options' => [
-                    'unserialize' => ['assoc' => true]
-                ]
+                    'unserialize' => ['assoc' => true],
+                ],
             ])
             ->addField([
                 'columnName' => 'adresse',
                 'fieldName' => 'address',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'code_postal',
                 'fieldName' => 'zipCode',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'ville',
                 'fieldName' => 'city',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'id_pays',
                 'fieldName' => 'country',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'telephone_fixe',
                 'fieldName' => 'phone',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'telephone_portable',
                 'fieldName' => 'mobilephone',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nearest_office',
                 'fieldName' => 'nearestOffice',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'etat',
                 'fieldName' => 'status',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'slack_invite_status',
@@ -603,13 +603,13 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
             ->addField([
                 'columnName' => 'slack_alternate_email',
                 'fieldName' => 'alternateEmail',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'needs_up_to_date_membership',
                 'fieldName' => 'needsUpToDateMembership',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
         ;
 

--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -738,7 +738,7 @@ class User implements NotifyPropertyInterface, NotifiableInterface, UserInterfac
         return [
             'id' => $this->id,
             'username' => $this->username,
-            'password' => $this->password
+            'password' => $this->password,
         ];
     }
 

--- a/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
+++ b/sources/AppBundle/Association/UserMembership/AbstractUserReminder.php
@@ -17,22 +17,11 @@ use AppBundle\Email\Mailer\Message;
 
 abstract class AbstractUserReminder implements MembershipReminderInterface
 {
-    private Mailer $mailer;
-
-    protected $membershipFee;
-
-    private SubscriptionReminderLogRepository $subscriptionReminderLogRepository;
-
-    /**
-     * AbstractUserReminder constructor.
-     *
-     * @param int                               $membershipFee
-     */
-    public function __construct(Mailer $mailer, $membershipFee, SubscriptionReminderLogRepository $subscriptionReminderLogRepository)
-    {
-        $this->mailer = $mailer;
-        $this->membershipFee = $membershipFee;
-        $this->subscriptionReminderLogRepository = $subscriptionReminderLogRepository;
+    public function __construct(
+        private readonly Mailer $mailer,
+        protected int $membershipFee,
+        private readonly SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
+    ) {
     }
 
     abstract protected function getText();

--- a/sources/AppBundle/Association/UserMembership/BadgesComputer.php
+++ b/sources/AppBundle/Association/UserMembership/BadgesComputer.php
@@ -12,20 +12,12 @@ use AppBundle\Event\Model\Repository\UserBadgeRepository;
 
 class BadgesComputer
 {
-    private SeniorityComputer $seniorityComputer;
-
-    private EventRepository $eventRepository;
-
-    private UserBadgeRepository $userBadgeRepository;
-
-    private GeneralMeetingResponseRepository $generalMeetingResponseRepository;
-
-    public function __construct(SeniorityComputer $seniorityComputer, EventRepository $eventRepository, UserBadgeRepository $userBadgeRepository, GeneralMeetingResponseRepository $generalMeetingResponseRepository)
-    {
-        $this->seniorityComputer = $seniorityComputer;
-        $this->eventRepository = $eventRepository;
-        $this->userBadgeRepository = $userBadgeRepository;
-        $this->generalMeetingResponseRepository = $generalMeetingResponseRepository;
+    public function __construct(
+        private readonly SeniorityComputer $seniorityComputer,
+        private readonly EventRepository $eventRepository,
+        private readonly UserBadgeRepository $userBadgeRepository,
+        private readonly GeneralMeetingResponseRepository $generalMeetingResponseRepository,
+    ) {
     }
 
     public function getBadges(User $user): array
@@ -112,7 +104,7 @@ class BadgesComputer
             // identiques pour toutes les villes (cela permet de les créer en amont et
             // en simplifie la maintenance).
             $isolateTownPattern = '/afupday(?P<year>\d{4})/';
-            if (preg_match($isolateTownPattern, $eventInfo['path'], $pathMatches) && $pathMatches['year'] >= 2022) {
+            if (preg_match($isolateTownPattern, (string) $eventInfo['path'], $pathMatches) && $pathMatches['year'] >= 2022) {
                 $code = 'jy-etais-afupday' . $pathMatches['year'];
             }
 

--- a/sources/AppBundle/Association/UserMembership/SeniorityComputer.php
+++ b/sources/AppBundle/Association/UserMembership/SeniorityComputer.php
@@ -10,11 +10,8 @@ use AppBundle\Association\Model\User;
 
 class SeniorityComputer
 {
-    private Cotisations $cotisations;
-
-    public function __construct(Cotisations $cotisations)
+    public function __construct(private readonly Cotisations $cotisations)
     {
-        $this->cotisations = $cotisations;
     }
 
     public function computeCompany(CompanyMember $companyMember)

--- a/sources/AppBundle/Association/UserMembership/StatisticsComputer.php
+++ b/sources/AppBundle/Association/UserMembership/StatisticsComputer.php
@@ -11,13 +11,10 @@ use AppBundle\Association\Model\User;
 
 class StatisticsComputer
 {
-    private UserRepository $userRepository;
-    private CompanyMemberRepository $companyMemberRepository;
-
-    public function __construct(UserRepository $userRepository, CompanyMemberRepository $companyMemberRepository)
-    {
-        $this->userRepository = $userRepository;
-        $this->companyMemberRepository = $companyMemberRepository;
+    public function __construct(
+        private readonly UserRepository $userRepository,
+        private readonly CompanyMemberRepository $companyMemberRepository,
+    ) {
     }
 
     public function computeStatistics(): Statistics

--- a/sources/AppBundle/Association/UserMembership/UserReminderFactory.php
+++ b/sources/AppBundle/Association/UserMembership/UserReminderFactory.php
@@ -11,14 +11,10 @@ use AppBundle\Email\Mailer\Mailer;
 
 class UserReminderFactory
 {
-    private Mailer $mailer;
-
-    private SubscriptionReminderLogRepository $subscriptionReminderLogRepository;
-
-    public function __construct(Mailer $mailer, SubscriptionReminderLogRepository $subscriptionReminderLogRepository)
-    {
-        $this->mailer = $mailer;
-        $this->subscriptionReminderLogRepository = $subscriptionReminderLogRepository;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Association/UserMembership/UserService.php
+++ b/sources/AppBundle/Association/UserMembership/UserService.php
@@ -16,25 +16,15 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class UserService
 {
-    private UserRepository $userRepository;
-    private Mailer $mailer;
-    private UrlGeneratorInterface $urlGenerator;
     private string $sender = MailUser::DEFAULT_SENDER_EMAIL;
-    private Cotisations $cotisations;
-    private UserPasswordHasherInterface $passwordHasher;
 
     public function __construct(
-        UserRepository $userRepository,
-        Mailer $mailer,
-        UrlGeneratorInterface $urlGenerator,
-        Cotisations $cotisations,
-        UserPasswordHasherInterface $passwordHasher
+        private readonly UserRepository $userRepository,
+        private readonly Mailer $mailer,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly Cotisations $cotisations,
+        private readonly UserPasswordHasherInterface $passwordHasher,
     ) {
-        $this->userRepository = $userRepository;
-        $this->mailer = $mailer;
-        $this->urlGenerator = $urlGenerator;
-        $this->cotisations = $cotisations;
-        $this->passwordHasher = $passwordHasher;
     }
 
     public function generateRandomPassword(): string

--- a/sources/AppBundle/CFP/PhotoStorage.php
+++ b/sources/AppBundle/CFP/PhotoStorage.php
@@ -16,24 +16,21 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class PhotoStorage
 {
-    private $basePath;
-    private $publicPath;
-    private $legacyBasePath;
-    private Filesystem $filesystem;
+    private readonly Filesystem $filesystem;
 
     const DIR_ORIGINAL = 'originals';
     const DIR_THUMBS = 'thumbnails';
 
     const FORMAT = [
         'originals' => ['width' => 1000, 'height' => 1000],
-        'thumbnails' => ['width' => 90, 'height' => 120]
+        'thumbnails' => ['width' => 90, 'height' => 120],
     ];
 
-    public function __construct($basePath, $publicPath, $legacyBasePath)
-    {
-        $this->basePath = $basePath;
-        $this->publicPath = $publicPath;
-        $this->legacyBasePath = $legacyBasePath;
+    public function __construct(
+        private $basePath,
+        private $publicPath,
+        private $legacyBasePath,
+    ) {
         $this->filesystem = new Filesystem();
     }
 
@@ -146,7 +143,7 @@ class PhotoStorage
         if (file_exists($originalPath) === false) {
             return ;
         }
-        $ext = substr($speaker->getPhoto(), -4);
+        $ext = substr((string) $speaker->getPhoto(), -4);
         $transparent = false;
         // This part is just our old script. We should do better
         if ($ext === '.png') {

--- a/sources/AppBundle/CFP/SpeakerFactory.php
+++ b/sources/AppBundle/CFP/SpeakerFactory.php
@@ -14,13 +14,10 @@ use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class SpeakerFactory
 {
-    private TokenStorageInterface $tokenStorage;
-    private SpeakerRepository $speakerRepository;
-
-    public function __construct(TokenStorageInterface $tokenStorage, SpeakerRepository $speakerRepository)
-    {
-        $this->tokenStorage = $tokenStorage;
-        $this->speakerRepository = $speakerRepository;
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly SpeakerRepository $speakerRepository,
+    ) {
     }
 
     /**
@@ -39,7 +36,7 @@ class SpeakerFactory
 
         $speaker = $this->speakerRepository->getOneBy([
             'user' => $user,
-            'eventId' => $event->getId()
+            'eventId' => $event->getId(),
         ]);
 
         if ($speaker === null) {

--- a/sources/AppBundle/CFP/ViewModel/EventTalkList.php
+++ b/sources/AppBundle/CFP/ViewModel/EventTalkList.php
@@ -9,13 +9,13 @@ use AppBundle\Event\Model\Talk;
 
 class EventTalkList
 {
-    private Event $event;
     /** @var Talk[] */
     private array $talks = [];
 
-    public function __construct(Event $event, Talk ...$talks)
-    {
-        $this->event = $event;
+    public function __construct(
+        private readonly Event $event,
+        Talk ...$talks,
+    ) {
         foreach ($talks as $talk) {
             $this->addTalk($talk);
         }

--- a/sources/AppBundle/Calendar/IcsPLanningGenerator.php
+++ b/sources/AppBundle/Calendar/IcsPLanningGenerator.php
@@ -13,11 +13,8 @@ use Sabre\VObject\Component\VCalendar;
 
 class IcsPLanningGenerator
 {
-    private TalkRepository $talkRepository;
-
-    public function __construct(TalkRepository $talkRepository)
+    public function __construct(private readonly TalkRepository $talkRepository)
     {
-        $this->talkRepository = $talkRepository;
     }
 
     /**

--- a/sources/AppBundle/Calendar/JsonPlanningGenerator.php
+++ b/sources/AppBundle/Calendar/JsonPlanningGenerator.php
@@ -14,14 +14,10 @@ use AppBundle\Event\Model\Talk;
 
 class JsonPlanningGenerator
 {
-    private TalkRepository $talkRepository;
-
-    private PhotoStorage $photoStorage;
-
-    public function __construct(TalkRepository $talkRepository, PhotoStorage $photoStorage)
-    {
-        $this->talkRepository = $talkRepository;
-        $this->photoStorage = $photoStorage;
+    public function __construct(
+        private readonly TalkRepository $talkRepository,
+        private readonly PhotoStorage $photoStorage,
+    ) {
     }
 
     public function generate(Event $event): array

--- a/sources/AppBundle/Calendar/TechnoWatchCalendarGenerator.php
+++ b/sources/AppBundle/Calendar/TechnoWatchCalendarGenerator.php
@@ -8,20 +8,10 @@ use Sabre\VObject\Component\VCalendar;
 
 class TechnoWatchCalendarGenerator
 {
-    /**
-     * @var string
-     */
-    private $name;
-
-    private \DateTime $currentDate;
-
-    /**
-     * @param string $name
-     */
-    public function __construct($name, \DateTime $currentDate)
-    {
-        $this->name = $name;
-        $this->currentDate = $currentDate;
+    public function __construct(
+        private readonly string $name,
+        private readonly \DateTime $currentDate,
+    ) {
     }
 
     /**
@@ -64,11 +54,11 @@ class TechnoWatchCalendarGenerator
         $events = [];
 
         while (false !== ($row = fgetcsv($fp))) {
-            if (trim($row[0]) === '') {
+            if (trim((string) $row[0]) === '') {
                 continue;
             }
 
-            $date = \DateTimeImmutable::createFromFormat('d/m/Y', trim($row[0]));
+            $date = \DateTimeImmutable::createFromFormat('d/m/Y', trim((string) $row[0]));
 
             if (false == $date) {
                 continue;
@@ -80,10 +70,10 @@ class TechnoWatchCalendarGenerator
                 continue;
             }
 
-            $firstChair = trim($row[4]);
-            $secondChair = trim($row[5]);
+            $firstChair = trim((string) $row[4]);
+            $secondChair = trim((string) $row[5]);
 
-            if (strlen($filter) > 0 && ($firstChair != $filter && $secondChair != $filter)) {
+            if (strlen((string) $filter) > 0 && ($firstChair != $filter && $secondChair != $filter)) {
                 continue;
             }
 

--- a/sources/AppBundle/Command/CfpNotificationCommand.php
+++ b/sources/AppBundle/Command/CfpNotificationCommand.php
@@ -18,17 +18,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CfpNotificationCommand extends Command
 {
-    private MessageFactory $messageFactory;
-    private SlackNotifier $slackNotifier;
-    private RepositoryFactory $ting;
-
-    public function __construct(MessageFactory $messageFactory,
-                                SlackNotifier $slackNotifier,
-                                RepositoryFactory $ting)
-    {
-        $this->messageFactory = $messageFactory;
-        $this->slackNotifier = $slackNotifier;
-        $this->ting = $ting;
+    public function __construct(
+        private readonly MessageFactory $messageFactory,
+        private readonly SlackNotifier $slackNotifier,
+        private readonly RepositoryFactory $ting,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/CleanThrottlingCommand.php
+++ b/sources/AppBundle/Command/CleanThrottlingCommand.php
@@ -11,11 +11,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class CleanThrottlingCommand extends Command
 {
-    private ActionThrottling $actionThrottling;
-
-    public function __construct(ActionThrottling $actionThrottling)
+    public function __construct(private readonly ActionThrottling $actionThrottling)
     {
-        $this->actionThrottling = $actionThrottling;
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -27,7 +27,7 @@ EOF;
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $parsedUrl = parse_url($input->getArgument('url_paiement_effectue'));
+        $parsedUrl = parse_url((string) $input->getArgument('url_paiement_effectue'));
 
         $query = $parsedUrl['query'];
 

--- a/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
+++ b/sources/AppBundle/Command/GeneralMeetupNotificationCommand.php
@@ -15,25 +15,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class GeneralMeetupNotificationCommand extends Command
 {
-    private UserRepository $userRepository;
-    private GeneralMeetingRepository $generalMeetingRepository;
-    private MessageFactory $messageFactory;
-    private SlackNotifier $slackNotifier;
-    private UrlGeneratorInterface $urlGenerator;
-
     public function __construct(
-        UserRepository $userRepository,
-        GeneralMeetingRepository $generalMeetingRepository,
-        MessageFactory $messageFactory,
-        SlackNotifier $slackNotifier,
-        UrlGeneratorInterface $urlGenerator
+        private readonly UserRepository $userRepository,
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
+        private readonly MessageFactory $messageFactory,
+        private readonly SlackNotifier $slackNotifier,
+        private readonly UrlGeneratorInterface $urlGenerator,
     ) {
         parent::__construct();
-        $this->userRepository = $userRepository;
-        $this->generalMeetingRepository = $generalMeetingRepository;
-        $this->messageFactory = $messageFactory;
-        $this->slackNotifier = $slackNotifier;
-        $this->urlGenerator = $urlGenerator;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/IndexMeetupsCommand.php
+++ b/sources/AppBundle/Command/IndexMeetupsCommand.php
@@ -16,14 +16,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class IndexMeetupsCommand extends Command
 {
-    private RepositoryFactory $ting;
-    private SearchClient $searchClient;
-
-    public function __construct(RepositoryFactory $ting,
-                                SearchClient $searchClient)
-    {
-        $this->ting = $ting;
-        $this->searchClient = $searchClient;
+    public function __construct(
+        private readonly RepositoryFactory $ting,
+        private readonly SearchClient $searchClient,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/IndexTalksCommand.php
+++ b/sources/AppBundle/Command/IndexTalksCommand.php
@@ -11,12 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class IndexTalksCommand extends Command
 {
-    private Runner $runner;
-
-    public function __construct(Runner $runner)
+    public function __construct(private readonly Runner $runner)
     {
         parent::__construct();
-        $this->runner = $runner;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/PlaneteCrawlFeeds.php
+++ b/sources/AppBundle/Command/PlaneteCrawlFeeds.php
@@ -11,13 +11,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class PlaneteCrawlFeeds extends Command
 {
-    private FeedCrawler $feedReader;
-
-    public function __construct(FeedCrawler $feedReader)
+    public function __construct(private readonly FeedCrawler $feedReader)
     {
         parent::__construct();
-
-        $this->feedReader = $feedReader;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/QrCodesGeneratorCommand.php
+++ b/sources/AppBundle/Command/QrCodesGeneratorCommand.php
@@ -15,15 +15,11 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 class QrCodesGeneratorCommand extends Command
 {
-    private QrCodeGenerator $qrCodeGenerator;
-    private RepositoryFactory $ting;
-
-    public function __construct(QrCodeGenerator $qrCodeGenerator,
-                                RepositoryFactory $ting)
-    {
+    public function __construct(
+        private readonly QrCodeGenerator $qrCodeGenerator,
+        private readonly RepositoryFactory $ting,
+    ) {
         parent::__construct();
-        $this->qrCodeGenerator = $qrCodeGenerator;
-        $this->ting = $ting;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/RegistrationsExporterCommand.php
+++ b/sources/AppBundle/Command/RegistrationsExporterCommand.php
@@ -13,15 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class RegistrationsExporterCommand extends Command
 {
-    private EventRepository $eventRepository;
-    private RegistrationsExportGenerator $exportGenerator;
-
-    public function __construct(EventRepository $eventRepository,
-                                RegistrationsExportGenerator $exportGenerator)
-    {
+    public function __construct(
+        private readonly EventRepository $eventRepository,
+        private readonly RegistrationsExportGenerator $exportGenerator,
+    ) {
         parent::__construct();
-        $this->eventRepository = $eventRepository;
-        $this->exportGenerator = $exportGenerator;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
+++ b/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
@@ -17,15 +17,11 @@ class ScrappingMeetupEventsCommand extends Command
 {
     use LockableTrait;
 
-    private RepositoryFactory $ting;
-    private MeetupClient $meetupClient;
-
-    public function __construct(RepositoryFactory $ting,
-                                MeetupClient $meetupClient)
-    {
+    public function __construct(
+        private RepositoryFactory $ting,
+        private MeetupClient $meetupClient,
+    ) {
         parent::__construct();
-        $this->ting = $ting;
-        $this->meetupClient = $meetupClient;
     }
 
     protected function configure(): void
@@ -83,5 +79,6 @@ class ScrappingMeetupEventsCommand extends Command
         } catch (\Exception $e) {
             throw new \Exception('Problème lors du scraping ou de la sauvegarde des évènements Meetup', $e->getCode(), $e);
         }
+        return Command::SUCCESS;
     }
 }

--- a/sources/AppBundle/Command/SlackMemberNotificationCommand.php
+++ b/sources/AppBundle/Command/SlackMemberNotificationCommand.php
@@ -13,14 +13,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SlackMemberNotificationCommand extends Command
 {
-    private UsersChecker $usersChecker;
-    private MessageFactory $messageFactory;
-    private SlackNotifier $slackNotifier;
-    public function __construct(UsersChecker $usersChecker, MessageFactory $messageFactory, SlackNotifier $slackNotifier)
-    {
-        $this->usersChecker = $usersChecker;
-        $this->messageFactory = $messageFactory;
-        $this->slackNotifier = $slackNotifier;
+    public function __construct(
+        private readonly UsersChecker $usersChecker,
+        private readonly MessageFactory $messageFactory,
+        private readonly SlackNotifier $slackNotifier,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/SubscriptionReminderCommand.php
+++ b/sources/AppBundle/Command/SubscriptionReminderCommand.php
@@ -25,13 +25,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SubscriptionReminderCommand extends Command
 {
-    private Mailer $mailer;
-    private RepositoryFactory $ting;
-
-    public function __construct(Mailer $mailer, RepositoryFactory $ting)
-    {
-        $this->mailer = $mailer;
-        $this->ting = $ting;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly RepositoryFactory $ting,
+    ) {
         parent::__construct();
     }
     /**
@@ -71,22 +68,22 @@ class SubscriptionReminderCommand extends Command
             'in 15 days' => [
                 'date' => $today->add(new \DateInterval('P15D')),
                 'physical' => Reminder15DaysBeforeEnd::class,
-                'company' => Association\CompanyMembership\Reminder15DaysBeforeEnd::class
+                'company' => Association\CompanyMembership\Reminder15DaysBeforeEnd::class,
             ],
             'in 7 days' => [
                 'date' => $today->add(new \DateInterval('P7D')),
                 'physical' => Reminder7DaysBeforeEnd::class,
-                'company' => Association\CompanyMembership\Reminder7DaysBeforeEnd::class
+                'company' => Association\CompanyMembership\Reminder7DaysBeforeEnd::class,
             ],
             'Today' => [
                 'date' => $today,
                 'physical' => ReminderDDay::class,
-                'company' => Association\CompanyMembership\ReminderDDay::class
+                'company' => Association\CompanyMembership\ReminderDDay::class,
             ],
             '15 days ago' => [
                 'date' => $today->sub(new \DateInterval('P15D')),
                 'physical' => Reminder15DaysAfterEnd::class,
-                'company' => Association\CompanyMembership\Reminder15DaysAfterEnd::class
+                'company' => Association\CompanyMembership\Reminder15DaysAfterEnd::class,
             ],
         ];
 
@@ -113,7 +110,7 @@ class SubscriptionReminderCommand extends Command
         OutputInterface $output,
         MembershipReminderInterface $reminder,
         CollectionInterface $users,
-        $dryRun = true
+        $dryRun = true,
     ): void {
         foreach ($users as $user) {
             /**

--- a/sources/AppBundle/Command/SynchMembersCommand.php
+++ b/sources/AppBundle/Command/SynchMembersCommand.php
@@ -12,13 +12,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SynchMembersCommand extends Command
 {
-    private MailchimpMembersAutoListSynchronizer $synchronizer;
-    private LoggerInterface $logger;
-
-    public function __construct(MailchimpMembersAutoListSynchronizer $synchronizer, LoggerInterface $logger)
-    {
-        $this->synchronizer = $synchronizer;
-        $this->logger = $logger;
+    public function __construct(
+        private readonly MailchimpMembersAutoListSynchronizer $synchronizer,
+        private readonly LoggerInterface $logger,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/SynchTechLetterCommand.php
+++ b/sources/AppBundle/Command/SynchTechLetterCommand.php
@@ -12,13 +12,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SynchTechLetterCommand extends Command
 {
-    private MailchimpSynchronizer $synchronizer;
-    private LoggerInterface $logger;
-
-    public function __construct(MailchimpSynchronizer $synchronizer, LoggerInterface $logger)
-    {
-        $this->synchronizer = $synchronizer;
-        $this->logger = $logger;
+    public function __construct(
+        private readonly MailchimpSynchronizer $synchronizer,
+        private readonly LoggerInterface $logger,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/TicketStatsNotificationCommand.php
+++ b/sources/AppBundle/Command/TicketStatsNotificationCommand.php
@@ -18,20 +18,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TicketStatsNotificationCommand extends Command
 {
-    private MessageFactory $messageFactory;
-    private EventStatsRepository $eventStatsRepository;
-    private SlackNotifier $slackNotifier;
-    private RepositoryFactory $ting;
-
-    public function __construct(MessageFactory $messageFactory,
-                                EventStatsRepository $eventStatsRepository,
-                                SlackNotifier $slackNotifier,
-                                RepositoryFactory $ting)
-    {
-        $this->messageFactory = $messageFactory;
-        $this->eventStatsRepository = $eventStatsRepository;
-        $this->slackNotifier = $slackNotifier;
-        $this->ting = $ting;
+    public function __construct(
+        private readonly MessageFactory $messageFactory,
+        private readonly EventStatsRepository $eventStatsRepository,
+        private readonly SlackNotifier $slackNotifier,
+        private readonly RepositoryFactory $ting,
+    ) {
         parent::__construct();
     }
     /**

--- a/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
+++ b/sources/AppBundle/Command/UpdateCompanyMemberStateCommand.php
@@ -13,12 +13,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateCompanyMemberStateCommand extends Command
 {
-    private RepositoryFactory $ting;
-
-    public function __construct(RepositoryFactory $ting)
+    public function __construct(private readonly RepositoryFactory $ting)
     {
         parent::__construct();
-        $this->ting = $ting;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
+++ b/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
@@ -15,17 +15,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateMailchimpMembersCommand extends Command
 {
-    private Mailchimp $mailchimp;
-    private RepositoryFactory $ting;
-    private string $mailchimpMembersList;
-
-    public function __construct(Mailchimp $mailchimp,
-                                RepositoryFactory $ting,
-                                string $mailchimpMembersList)
-    {
-        $this->mailchimp = $mailchimp;
-        $this->mailchimpMembersList = $mailchimpMembersList;
-        $this->ting = $ting;
+    public function __construct(
+        private readonly Mailchimp $mailchimp,
+        private readonly RepositoryFactory $ting,
+        private readonly string $mailchimpMembersList,
+    ) {
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/UpdateUserStateCommand.php
+++ b/sources/AppBundle/Command/UpdateUserStateCommand.php
@@ -13,11 +13,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdateUserStateCommand extends Command
 {
-    private RepositoryFactory $ting;
-
-    public function __construct(RepositoryFactory $ting)
+    public function __construct(private readonly RepositoryFactory $ting)
     {
-        $this->ting = $ting;
         parent::__construct();
     }
 

--- a/sources/AppBundle/Command/VideoNotifierCommand.php
+++ b/sources/AppBundle/Command/VideoNotifierCommand.php
@@ -12,13 +12,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class VideoNotifierCommand extends Command
 {
-    private Engine $engine;
-
-    public function __construct(Engine $engine)
+    public function __construct(private readonly Engine $engine)
     {
         parent::__construct();
-
-        $this->engine = $engine;
     }
 
     protected function configure(): void

--- a/sources/AppBundle/Command/VideosDataCommand.php
+++ b/sources/AppBundle/Command/VideosDataCommand.php
@@ -17,11 +17,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class VideosDataCommand extends Command
 {
-    private RepositoryFactory $ting;
-
-    public function __construct(RepositoryFactory $ting)
+    public function __construct(private readonly RepositoryFactory $ting)
     {
-        $this->ting = $ting;
         parent::__construct();
     }
 

--- a/sources/AppBundle/Compta/BankAccount/BankAccount.php
+++ b/sources/AppBundle/Compta/BankAccount/BankAccount.php
@@ -7,41 +7,6 @@ namespace AppBundle\Compta\BankAccount;
 class BankAccount
 {
     /**
-     * @var string
-     */
-    private $etablissement;
-
-    /**
-     * @var string
-     */
-    private $guichet;
-
-    /**
-     * @var string
-     */
-    private $compte;
-
-    /**
-     * @var string
-     */
-    private $cle;
-
-    /**
-     * @var string
-     */
-    private $domicialisation;
-
-    /**
-     * @var string
-     */
-    private $bic;
-
-    /**
-     * @var string
-     */
-    private $iban;
-
-    /**
      * @param string $etablissement
      * @param string $guichet
      * @param string $compte
@@ -50,15 +15,15 @@ class BankAccount
      * @param string $bic
      * @param string $iban
      */
-    public function __construct($etablissement, $guichet, $compte, $cle, $domicialisation, $bic, $iban)
-    {
-        $this->etablissement = $etablissement;
-        $this->guichet = $guichet;
-        $this->compte = $compte;
-        $this->cle = $cle;
-        $this->domicialisation = $domicialisation;
-        $this->bic = $bic;
-        $this->iban = $iban;
+    public function __construct(
+        private $etablissement,
+        private $guichet,
+        private $compte,
+        private $cle,
+        private $domicialisation,
+        private $bic,
+        private $iban,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Compta/Importer/AutoQualifier.php
+++ b/sources/AppBundle/Compta/Importer/AutoQualifier.php
@@ -14,11 +14,8 @@ class AutoQualifier
     const DEFAULT_REGLEMENT = 9;
     const DEFAULT_ATTACHMENT = 0;
 
-    protected $rules = [];
-
-    public function __construct($rules)
+    public function __construct(protected array $rules)
     {
-        $this->rules = $rules;
     }
 
     public function qualify(Operation $operation): array

--- a/sources/AppBundle/Compta/Importer/CreditMutuel.php
+++ b/sources/AppBundle/Compta/Importer/CreditMutuel.php
@@ -43,14 +43,14 @@ class CreditMutuel implements Importer
                 continue;
             }
 
-            $dateEcriture = implode('-', array_reverse(explode('/', $data[0])));
+            $dateEcriture = implode('-', array_reverse(explode('/', (string) $data[0])));
             if (!isset($nbLineByDate[$dateEcriture])) {
                 $nbLineByDate[$dateEcriture] = 0;
             }
             $nbLineByDate[$dateEcriture]++;
 
             $description = $data[4];
-            $description = implode(' ', array_filter(explode(' ', $description)));
+            $description = implode(' ', array_filter(explode(' ', (string) $description)));
 
             if ('' === $data[3]) {
                 $montant = abs((float) str_replace(',', '.', $data[2]));

--- a/sources/AppBundle/Compta/Importer/Factory.php
+++ b/sources/AppBundle/Compta/Importer/Factory.php
@@ -8,16 +8,11 @@ class Factory
 {
     public function create(string $filePath, string $code): Importer
     {
-        switch ($code) {
-            case CreditMutuel::CODE:
-                $importer = new CreditMutuel();
-                break;
-            case CreditMutuelLivret::CODE:
-                $importer = new CreditMutuelLivret();
-                break;
-            default:
-                throw new \InvalidArgumentException("Unknown importer for code '$code'");
-        }
+        $importer = match ($code) {
+            CreditMutuel::CODE => new CreditMutuel(),
+            CreditMutuelLivret::CODE => new CreditMutuelLivret(),
+            default => throw new \InvalidArgumentException("Unknown importer for code '$code'"),
+        };
 
         $importer->initialize($filePath);
 

--- a/sources/AppBundle/Compta/Importer/Operation.php
+++ b/sources/AppBundle/Compta/Importer/Operation.php
@@ -9,12 +9,6 @@ class Operation
     const DEBIT = 'debit';
     const CREDIT = 'credit';
 
-    private $dateEcriture;
-    private $description;
-    private $montant;
-    private $type;
-    private $numeroOperation;
-
     /**
      * Operation constructor.
      *
@@ -24,13 +18,13 @@ class Operation
      * @param string $type
      * @param string $numeroOperation
      */
-    public function __construct($dateEcriture, $description, $montant, $type, $numeroOperation)
-    {
-        $this->dateEcriture = $dateEcriture;
-        $this->description = $description;
-        $this->montant = $montant;
-        $this->type = $type;
-        $this->numeroOperation = $numeroOperation;
+    public function __construct(
+        private $dateEcriture,
+        private $description,
+        private $montant,
+        private $type,
+        private $numeroOperation,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Controller/Admin/Event/ArchiveAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ArchiveAction.php
@@ -8,18 +8,14 @@ use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 final class ArchiveAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-
-    public function __construct(EventRepository $eventRepository)
+    public function __construct(private readonly EventRepository $eventRepository)
     {
-        $this->eventRepository = $eventRepository;
     }
 
-    public function __invoke(Request $request, int $id): RedirectResponse
+    public function __invoke(int $id): RedirectResponse
     {
         $event = $this->eventRepository->get($id);
 

--- a/sources/AppBundle/Controller/Admin/Event/BadgesGenerateAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/BadgesGenerateAction.php
@@ -13,15 +13,10 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class BadgesGenerateAction
 {
-    private EventActionHelper $eventActionHelper;
-    private RegistrationsExportGenerator $registrationsExportGenerator;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        RegistrationsExportGenerator $registrationsExportGenerator
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly RegistrationsExportGenerator $registrationsExportGenerator,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->registrationsExportGenerator = $registrationsExportGenerator;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Event/EventAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/EventAction.php
@@ -16,14 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EventAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-    private EventCouponRepository $couponRepository;
-
-    public function __construct(EventRepository $eventRepository,
-                                EventCouponRepository $couponRepository
+    public function __construct(
+        private readonly EventRepository $eventRepository,
+        private readonly EventCouponRepository $couponRepository,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->couponRepository = $couponRepository;
     }
 
     public function __invoke(Request $request, $id): Response
@@ -53,7 +49,7 @@ class EventAction extends AbstractController
             $this->eventRepository->save($event);
 
             if ($form->get('coupons')->getData()) {
-                $eventCoupons = explode(',', $form->get('coupons')->getData());
+                $eventCoupons = explode(',', (string) $form->get('coupons')->getData());
                 $this->couponRepository->changeCouponForEvent($event, $eventCoupons);
             }
 

--- a/sources/AppBundle/Controller/Admin/Event/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ListAction.php
@@ -6,19 +6,15 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Event\Model\Repository\EventRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class ListAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-
-    public function __construct(EventRepository $eventRepository)
+    public function __construct(private readonly EventRepository $eventRepository)
     {
-        $this->eventRepository = $eventRepository;
     }
 
-    public function __invoke(Request $request): Response
+    public function __invoke(): Response
     {
         //TODO : à supprimer quand les actions via le formulaire auront été migée
         if (isset($_SESSION['flash']['message'])) {
@@ -28,11 +24,9 @@ class ListAction extends AbstractController
             $this->addFlash('error', $_SESSION['flash']['erreur']);
         }
         unset($_SESSION['flash']);
-
         $list = $this->eventRepository->getList();
-
         return $this->render('admin/event/list.html.twig', [
-            'events' => $list
+            'events' => $list,
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
@@ -26,30 +26,15 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class PendingBankwiresAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private InvoiceRepository $invoiceRepository;
-    private TicketRepository $ticketRepository;
-    private LegacyModelFactory $legacyModelFactory;
-    private Emails $emails;
-    private EventDispatcherInterface $eventDispatcher;
-    private CsrfTokenManagerInterface $csrfTokenManager;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        InvoiceRepository $invoiceRepository,
-        TicketRepository $ticketRepository,
-        LegacyModelFactory $legacyModelFactory,
-        Emails $emails,
-        EventDispatcherInterface $eventDispatcher,
-        CsrfTokenManagerInterface $csrfTokenManager
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly TicketRepository $ticketRepository,
+        private readonly LegacyModelFactory $legacyModelFactory,
+        private readonly Emails $emails,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->ticketRepository = $ticketRepository;
-        $this->legacyModelFactory = $legacyModelFactory;
-        $this->emails = $emails;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->csrfTokenManager = $csrfTokenManager;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Event/PreviousRegistrationsAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PreviousRegistrationsAction.php
@@ -13,15 +13,10 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class PreviousRegistrationsAction
 {
-    private EventRepository $eventRepository;
-    private TicketRepository $ticketRepository;
-
     public function __construct(
-        EventRepository $eventRepository,
-        TicketRepository $ticketRepository
+        private readonly EventRepository $eventRepository,
+        private readonly TicketRepository $ticketRepository,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->ticketRepository = $ticketRepository;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Event/PricesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAction.php
@@ -13,15 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PricesAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TicketEventTypeRepository $ticketEventTypeRepository
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
     ) {
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
@@ -19,21 +19,12 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class PricesAddAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private TicketTypeRepository $ticketTypeRepository;
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-    private ValidatorInterface $validator;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TicketTypeRepository $ticketTypeRepository,
-        TicketEventTypeRepository $ticketEventTypeRepository,
-        ValidatorInterface $validator
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TicketTypeRepository $ticketTypeRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly ValidatorInterface $validator,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->ticketTypeRepository = $ticketTypeRepository;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
-        $this->validator = $validator;
     }
 
     public function __invoke(Request $request): Response
@@ -60,8 +51,8 @@ class PricesAddAction extends AbstractController
                 new UniqueEntity([
                     'fields' => ['ticketTypeId', 'eventId'],
                     'repository' => $this->ticketEventTypeRepository,
-                    'message' => 'Ce type de ticket existe déjà pour cet évènement.'
-                ])
+                    'message' => 'Ce type de ticket existe déjà pour cet évènement.',
+                ]),
             ]);
             foreach ($violations as $violation) {
                 $form->get('ticketType')->addError(new FormError($violation->getMessage()));
@@ -73,7 +64,7 @@ class PricesAddAction extends AbstractController
                 $this->addFlash('notice', 'Le tarif a été ajouté');
 
                 return $this->redirectToRoute('admin_event_prices', [
-                    'id' => $event->getId()
+                    'id' => $event->getId(),
                 ]);
             }
         }

--- a/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class PricesEditAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private TicketTypeRepository $ticketTypeRepository;
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TicketTypeRepository $ticketTypeRepository,
-        TicketEventTypeRepository $ticketEventTypeRepository
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TicketTypeRepository $ticketTypeRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->ticketTypeRepository = $ticketTypeRepository;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
     }
 
     public function __invoke(Request $request, $event, $id)
@@ -54,7 +47,7 @@ class PricesEditAction extends AbstractController
             $this->addFlash('notice', 'Le tarif a été modifié');
 
             return $this->redirectToRoute('admin_event_prices', [
-                'id' => $event->getId()
+                'id' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Event/RemoveEventAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RemoveEventAction.php
@@ -7,23 +7,18 @@ namespace AppBundle\Controller\Admin\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class RemoveEventAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-    private CsrfTokenManagerInterface $csrfTokenManager;
-
-    public function __construct(EventRepository $eventRepository,
-                                CsrfTokenManagerInterface $csrfTokenManager)
-    {
-        $this->eventRepository = $eventRepository;
-        $this->csrfTokenManager = $csrfTokenManager;
+    public function __construct(
+        private readonly EventRepository $eventRepository,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+    ) {
     }
 
-    public function __invoke(int $id, string $token, Request $request): RedirectResponse
+    public function __invoke(int $id, string $token): RedirectResponse
     {
         if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken('forum_delete', $token))) {
             $this->addFlash('error', 'Token invalide');

--- a/sources/AppBundle/Controller/Admin/Event/ResendSponsorTokenAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ResendSponsorTokenAction.php
@@ -13,18 +13,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class ResendSponsorTokenAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private SponsorTicketRepository $sponsorTicketRepository;
-    private SponsorTokenMail $sponsorTokenMail;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SponsorTicketRepository $sponsorTicketRepository,
-        SponsorTokenMail $sponsorTokenMail
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SponsorTicketRepository $sponsorTicketRepository,
+        private readonly SponsorTokenMail $sponsorTokenMail,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->sponsorTicketRepository = $sponsorTicketRepository;
-        $this->sponsorTokenMail = $sponsorTokenMail;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -39,7 +32,7 @@ class ResendSponsorTokenAction extends AbstractController
         $this->addFlash('notice', 'Le mail a été renvoyé');
 
         return $this->redirectToRoute('admin_event_sponsor_ticket', [
-            'id' => $event->getId()
+            'id' => $event->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/RestoreAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RestoreAction.php
@@ -8,18 +8,14 @@ use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 final class RestoreAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-
-    public function __construct(EventRepository $eventRepository)
+    public function __construct(private readonly EventRepository $eventRepository)
     {
-        $this->eventRepository = $eventRepository;
     }
 
-    public function __invoke(Request $request, int $id): RedirectResponse
+    public function __invoke(int $id): RedirectResponse
     {
         $event = $this->eventRepository->get($id);
 
@@ -33,7 +29,7 @@ final class RestoreAction extends AbstractController
         $this->eventRepository->save($event);
 
         return $this->redirectToRoute('admin_event_edit', [
-            'id' => $id
+            'id' => $id,
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/RoomAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RoomAction.php
@@ -18,18 +18,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class RoomAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private FormFactoryInterface $formFactory;
-    private RoomRepository $roomRepository;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        FormFactoryInterface $formFactory,
-        RoomRepository $roomRepository
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly RoomRepository $roomRepository,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->formFactory = $formFactory;
-        $this->roomRepository = $roomRepository;
     }
 
     public function __invoke(Request $request)
@@ -53,7 +46,7 @@ class RoomAction extends AbstractController
                 }
 
                 return $this->redirectToRoute('admin_event_room', [
-                    'id' => $event->getId()
+                    'id' => $event->getId(),
                 ]);
             }
         }
@@ -70,7 +63,7 @@ class RoomAction extends AbstractController
             $this->addFlash('notice', sprintf('La salle "%s" a été ajoutée.', $newRoom->getName()));
 
             return $this->redirectToRoute('admin_event_room', [
-                'id' => $event->getId()
+                'id' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Event/SendLastCallSponsorTokenAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SendLastCallSponsorTokenAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SendLastCallSponsorTokenAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private SponsorTicketRepository $sponsorTicketRepository;
-    private SponsorTokenMail $sponsorTokenMail;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SponsorTicketRepository $sponsorTicketRepository,
-        SponsorTokenMail $sponsorTokenMail
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SponsorTicketRepository $sponsorTicketRepository,
+        private readonly SponsorTokenMail $sponsorTokenMail,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->sponsorTicketRepository = $sponsorTicketRepository;
-        $this->sponsorTokenMail = $sponsorTokenMail;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -45,7 +38,7 @@ class SendLastCallSponsorTokenAction extends AbstractController
         $this->addFlash('notice', sprintf('%s mails de relance ont été envoyés', $mailSent));
 
         return $this->redirectToRoute('admin_event_sponsor_ticket', [
-            'id' => $event->getId()
+            'id' => $event->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SendTestInscriptionEmailAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SendTestInscriptionEmailAction.php
@@ -12,15 +12,10 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class SendTestInscriptionEmailAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private Emails $emails;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        Emails $emails
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly Emails $emails,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->emails = $emails;
     }
 
     public function __invoke(int $id): RedirectResponse
@@ -30,7 +25,7 @@ class SendTestInscriptionEmailAction extends AbstractController
         $this->addFlash('notice', 'Mail de test envoyé');
 
         return $this->redirectToRoute('admin_event_edit', [
-            'id' => $event->getId()
+            'id' => $event->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SpeakerInfosAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakerInfosAction.php
@@ -11,18 +11,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SpeakerInfosAction
 {
-    private EventActionHelper $eventActionHelper;
-    private SpeakerRepository $speakerRepository;
-    private SpeakerPage $speakerPage;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SpeakerRepository $speakerRepository,
-        SpeakerPage $speakerPage
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly SpeakerPage $speakerPage,
     ) {
-        $this->speakerRepository = $speakerRepository;
-        $this->speakerPage = $speakerPage;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SpeakersExpensesAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private SpeakerRepository $speakerRepository;
-    private SpeakersExpensesStorage $speakersExpensesStorage;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SpeakerRepository $speakerRepository,
-        SpeakersExpensesStorage $speakersExpensesStorage
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly SpeakersExpensesStorage $speakersExpensesStorage,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->speakerRepository = $speakerRepository;
-        $this->speakersExpensesStorage = $speakersExpensesStorage;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SpeakersManagementAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private SpeakerRepository $speakerRepository;
-    private SpeakersExpensesStorage $speakersExpensesStorage;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SpeakerRepository $speakerRepository,
-        SpeakersExpensesStorage $speakersExpensesStorage
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly SpeakersExpensesStorage $speakersExpensesStorage,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->speakerRepository = $speakerRepository;
-        $this->speakersExpensesStorage = $speakersExpensesStorage;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
@@ -17,15 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SpecialPriceAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private TicketSpecialPriceRepository $ticketSpecialPriceRepository;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TicketSpecialPriceRepository $ticketSpecialPriceRepository
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TicketSpecialPriceRepository $ticketSpecialPriceRepository,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->ticketSpecialPriceRepository = $ticketSpecialPriceRepository;
     }
 
     public function __invoke(Request $request): Response
@@ -57,7 +52,7 @@ class SpecialPriceAction extends AbstractController
             $this->addFlash('notice', 'Le token a été enregistré');
 
             return $this->redirectToRoute('admin_event_special_price', [
-                'id' => $event->getId()
+                'id' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
@@ -18,18 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SponsorTicketAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private SponsorTicketRepository $sponsorTicketRepository;
-    private SponsorTokenMail $sponsorTokenMail;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SponsorTicketRepository $sponsorTicketRepository,
-        SponsorTokenMail $sponsorTokenMail
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SponsorTicketRepository $sponsorTicketRepository,
+        private readonly SponsorTokenMail $sponsorTokenMail,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->sponsorTicketRepository = $sponsorTicketRepository;
-        $this->sponsorTokenMail = $sponsorTokenMail;
     }
 
     public function __invoke(Request $request): Response
@@ -65,7 +58,7 @@ class SponsorTicketAction extends AbstractController
             $this->addFlash('notice', 'Le token a été enregistré');
 
             return $this->redirectToRoute('admin_event_sponsor_ticket', [
-                'id' => $event->getId()
+                'id' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Event/StatsAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/StatsAction.php
@@ -19,27 +19,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StatsAction extends AbstractController
 {
-    private EventActionHelper $eventActionHelper;
-    private LegacyModelFactory $legacyModelFactory;
-    private TicketRepository $ticketRepository;
-    private TicketTypeRepository $ticketTypeRepository;
-    private EventStatsRepository $eventStatsRepository;
-    private EventRepository $eventRepository;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        LegacyModelFactory $legacyModelFactory,
-        TicketRepository $ticketRepository,
-        TicketTypeRepository $ticketTypeRepository,
-        EventStatsRepository $eventStatsRepository,
-        EventRepository $eventRepository
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly LegacyModelFactory $legacyModelFactory,
+        private readonly TicketRepository $ticketRepository,
+        private readonly TicketTypeRepository $ticketTypeRepository,
+        private readonly EventStatsRepository $eventStatsRepository,
+        private readonly EventRepository $eventRepository,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->legacyModelFactory = $legacyModelFactory;
-        $this->ticketRepository = $ticketRepository;
-        $this->ticketTypeRepository = $ticketTypeRepository;
-        $this->eventStatsRepository = $eventStatsRepository;
-        $this->eventRepository = $eventRepository;
     }
 
     public function __invoke(Request $request): Response
@@ -55,7 +42,7 @@ class StatsAction extends AbstractController
             'event_id' => $event->getId(),
             'compared_event_id' => $comparedEvent->getId(),
         ], [
-            'events' => $this->eventRepository->getAll()
+            'events' => $this->eventRepository->getAll(),
         ]);
 
         $legacyInscriptions = $this->legacyModelFactory->createObject(Inscriptions::class);

--- a/sources/AppBundle/Controller/Admin/GetMenuAction.php
+++ b/sources/AppBundle/Controller/Admin/GetMenuAction.php
@@ -11,19 +11,12 @@ use Twig\Environment;
 
 class GetMenuAction
 {
-    /** @var array<string, mixed> */
-    private array $backOfficePages;
-    private Environment $twig;
-    private RequestStack $requestStack;
-
     public function __construct(
-        RequestStack $requestStack,
-        Environment $twig,
-        array $backOfficePages
+        private readonly RequestStack $requestStack,
+        private readonly Environment $twig,
+        /** @var array<string, mixed> */
+        private readonly array $backOfficePages,
     ) {
-        $this->backOfficePages = $backOfficePages;
-        $this->requestStack = $requestStack;
-        $this->twig = $twig;
     }
 
     public function __invoke(): Response

--- a/sources/AppBundle/Controller/Admin/GithubUser/GithubUserAddAction.php
+++ b/sources/AppBundle/Controller/Admin/GithubUser/GithubUserAddAction.php
@@ -16,14 +16,10 @@ class GithubUserAddAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private GithubUserRepository $githubUserRepository;
-    private GithubClient $githubClient;
-
-    public function __construct(GithubUserRepository $githubUserRepository,
-                                GithubClient $githubClient
+    public function __construct(
+        private GithubUserRepository $githubUserRepository,
+        private GithubClient $githubClient,
     ) {
-        $this->githubUserRepository = $githubUserRepository;
-        $this->githubClient = $githubClient;
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/GithubUser/GithubUserListAction.php
+++ b/sources/AppBundle/Controller/Admin/GithubUser/GithubUserListAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class GithubUserListAction
 {
-    private GithubUserRepository $githubUserRepository;
-    private Environment $twig;
-
     public function __construct(
-        GithubUserRepository $githubUserRepository,
-        Environment $twig
+        private readonly GithubUserRepository $githubUserRepository,
+        private readonly Environment $twig,
     ) {
-        $this->githubUserRepository = $githubUserRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/HealthcheckController.php
+++ b/sources/AppBundle/Controller/Admin/HealthcheckController.php
@@ -14,11 +14,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class HealthcheckController extends AbstractController
 {
-    private RepositoryFactory $ting;
-
-    public function __construct(RepositoryFactory $ting)
+    public function __construct(private readonly RepositoryFactory $ting)
     {
-        $this->ting = $ting;
     }
 
     public function __invoke(): Response
@@ -40,12 +37,12 @@ class HealthcheckController extends AbstractController
                 'php' => $php->format(\DateTime::ATOM),
                 'mysql_bdd' => $mysqlBdd->format(\DateTime::ATOM),
                 'mysql_ting' => $mysqlTing->format(\DateTime::ATOM),
-                'diff' => $diff
+                'diff' => $diff,
             ],
             'versions' => [
                 'php' => phpversion(),
-                'symfony' => Kernel::VERSION
-            ]
+                'symfony' => Kernel::VERSION,
+            ],
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/HomeAction.php
+++ b/sources/AppBundle/Controller/Admin/HomeAction.php
@@ -17,27 +17,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class HomeAction extends AbstractController
 {
-    private EventRepository $eventRepository;
-    private EventStatsRepository $eventStatsRepository;
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-    private TechletterSubscriptionsRepository $techletterSubscriptionsRepository;
-    private StatisticsComputer $statisticsComputer;
-    private GeneralMeetingRepository $generalMeetingRepository;
-
     public function __construct(
-        EventRepository $eventRepository,
-        EventStatsRepository $eventStatsRepository,
-        TicketEventTypeRepository $ticketEventTypeRepository,
-        TechletterSubscriptionsRepository $techletterSubscriptionsRepository,
-        GeneralMeetingRepository $generalMeetingRepository,
-        StatisticsComputer $statisticsComputer
+        private readonly EventRepository $eventRepository,
+        private readonly EventStatsRepository $eventStatsRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly TechletterSubscriptionsRepository $techletterSubscriptionsRepository,
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
+        private readonly StatisticsComputer $statisticsComputer,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->eventStatsRepository = $eventStatsRepository;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
-        $this->techletterSubscriptionsRepository = $techletterSubscriptionsRepository;
-        $this->statisticsComputer = $statisticsComputer;
-        $this->generalMeetingRepository = $generalMeetingRepository;
     }
 
     public function __invoke(): Response

--- a/sources/AppBundle/Controller/Admin/LoginAction.php
+++ b/sources/AppBundle/Controller/Admin/LoginAction.php
@@ -11,15 +11,10 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class LoginAction
 {
-    private AuthenticationUtils $authenticationUtils;
-    private ViewRenderer $view;
-
     public function __construct(
-        AuthenticationUtils $authenticationUtils,
-        ViewRenderer $view
+        private readonly AuthenticationUtils $authenticationUtils,
+        private readonly ViewRenderer $view,
     ) {
-        $this->authenticationUtils = $authenticationUtils;
-        $this->view = $view;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/LostPasswordAction.php
+++ b/sources/AppBundle/Controller/Admin/LostPasswordAction.php
@@ -14,14 +14,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LostPasswordAction extends AbstractController
 {
-    private ViewRenderer $view;
-    private UserService $userPasswordService;
-
-    public function __construct(UserService $userPasswordService,
-                                ViewRenderer $view
+    public function __construct(
+        private readonly UserService $userPasswordService,
+        private readonly ViewRenderer $view,
     ) {
-        $this->userPasswordService = $userPasswordService;
-        $this->view = $view;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/BadgeListAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/BadgeListAction.php
@@ -12,18 +12,11 @@ use Twig\Environment;
 
 class BadgeListAction
 {
-    private BadgeRepository $badgeRepository;
-    private UserRepository $userRepository;
-    private Environment $twig;
-
     public function __construct(
-        BadgeRepository $badgeRepository,
-        UserRepository $userRepository,
-        Environment $twig
+        private readonly BadgeRepository $badgeRepository,
+        private readonly UserRepository $userRepository,
+        private readonly Environment $twig,
     ) {
-        $this->badgeRepository = $badgeRepository;
-        $this->userRepository = $userRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/BadgeNewAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/BadgeNewAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BadgeNewAction extends AbstractController
 {
-    private BadgeRepository $badgeRepository;
-    private string $storageDir;
-    private Filesystem $filesystem;
-
     public function __construct(
-        BadgeRepository $badgeRepository,
-        Filesystem $filesystem,
-        string $storageDir
+        private readonly BadgeRepository $badgeRepository,
+        private readonly Filesystem $filesystem,
+        private readonly string $storageDir,
     ) {
-        $this->badgeRepository = $badgeRepository;
-        $this->storageDir = $storageDir;
-        $this->filesystem = $filesystem;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/CompanyAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/CompanyAction.php
@@ -17,15 +17,10 @@ class CompanyAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private CompanyMemberRepository $companyMemberRepository;
-    private UserRepository $userRepository;
-
     public function __construct(
-        CompanyMemberRepository $companyMemberRepository,
-        UserRepository $userRepository
+        private CompanyMemberRepository $companyMemberRepository,
+        private UserRepository $userRepository,
     ) {
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->userRepository = $userRepository;
     }
 
     public function __invoke(Request $request, ?int $id)
@@ -46,7 +41,7 @@ class CompanyAction extends AbstractController
                 $this->addFlash('notice', 'La personne morale a été ' . ($id ? 'modifiée' : 'ajoutée'));
 
                 return $this->redirectToRoute('admin_members_company_list', ['filter' => $company->getCompanyName()]);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 $this->addFlash('error', 'Une erreur est survenue lors de l\'ajout de la personne morale');
             }
         }

--- a/sources/AppBundle/Controller/Admin/Members/CompanyDeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/CompanyDeleteAction.php
@@ -16,12 +16,8 @@ class CompanyDeleteAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private CompanyMemberRepository $companyMemberRepository;
-
-    public function __construct(
-        CompanyMemberRepository $companyMemberRepository
-    ) {
-        $this->companyMemberRepository = $companyMemberRepository;
+    public function __construct(private CompanyMemberRepository $companyMemberRepository)
+    {
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -36,7 +32,7 @@ class CompanyDeleteAction extends AbstractController
             $this->addFlash('notice', 'La personne morale a été supprimée');
         } catch (InvalidArgumentException $e) {
             $this->addFlash('error', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->addFlash('error', 'Une erreur est survenue lors de la suppression de la personne morale');
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/CompanyListAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/CompanyListAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class CompanyListAction
 {
-    private CompanyMemberRepository $companyMemberRepository;
-    private Environment $twig;
-
     public function __construct(
-        CompanyMemberRepository $companyMemberRepository,
-        Environment $twig
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly Environment $twig,
     ) {
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/EditAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/EditAction.php
@@ -16,12 +16,8 @@ class EditAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private GeneralMeetingRepository $generalMeetingRepository;
-
-    public function __construct(
-        GeneralMeetingRepository $generalMeetingRepository)
+    public function __construct(private GeneralMeetingRepository $generalMeetingRepository)
     {
-        $this->generalMeetingRepository = $generalMeetingRepository;
     }
 
     public function __invoke(Request $request): Response
@@ -41,7 +37,7 @@ class EditAction extends AbstractController
 
             $this->addFlash('success', 'Description enregistrée');
             return $this->redirectToRoute('admin_members_general_meeting_edit', [
-                'date' => $date->getTimestamp()
+                'date' => $date->getTimestamp(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ListAction.php
@@ -15,18 +15,12 @@ class ListAction
 {
     const VALID_SORTS = ['nom', 'date_consultation', 'presence', 'personnes_avec_pouvoir_nom'];
     const VALID_DIRECTIONS = ['asc', 'desc'];
-    private UserRepository $userRepository;
-    private GeneralMeetingRepository $generalMeetingRepository;
-    private Environment $twig;
 
     public function __construct(
-        UserRepository $userRepository,
-        GeneralMeetingRepository $generalMeetingRepository,
-        Environment $twig
+        private readonly UserRepository $userRepository,
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
+        private readonly Environment $twig,
     ) {
-        $this->userRepository = $userRepository;
-        $this->generalMeetingRepository = $generalMeetingRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ListingAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ListingAction.php
@@ -14,11 +14,8 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ListingAction
 {
-    private GeneralMeetingRepository $generalMeetingRepository;
-
-    public function __construct(GeneralMeetingRepository $generalMeetingRepository)
+    public function __construct(private readonly GeneralMeetingRepository $generalMeetingRepository)
     {
-        $this->generalMeetingRepository = $generalMeetingRepository;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/PrepareAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/PrepareAction.php
@@ -16,12 +16,8 @@ class PrepareAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private GeneralMeetingRepository $generalMeetingRepository;
-
-    public function __construct(
-        GeneralMeetingRepository $generalMeetingRepository
-    ) {
-        $this->generalMeetingRepository = $generalMeetingRepository;
+    public function __construct(private GeneralMeetingRepository $generalMeetingRepository)
+    {
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeeting/ReportsAction.php
@@ -59,7 +59,7 @@ class ReportsAction extends AbstractController
 
         return $this->render('admin/members/general_meeting/reports.html.twig', [
             'form' => $form->createView(),
-            'reports' => $reports
+            'reports' => $reports,
         ]);
     }
 
@@ -86,8 +86,8 @@ class ReportsAction extends AbstractController
                             'application/x-pdf',
                         ],
                         'mimeTypesMessage' => 'Uniquement des fichiers PDF.',
-                    ])
-                ]
+                    ]),
+                ],
             ])
             ->add('submit', SubmitType::class, [
                 'label' => 'Envoyer',

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/AddAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/AddAction.php
@@ -14,15 +14,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class AddAction extends AbstractController
 {
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-    private GeneralMeetingRepository $generalMeetingRepository;
-
     public function __construct(
-        GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
-        GeneralMeetingRepository $generalMeetingRepository
+        private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
     ) {
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
-        $this->generalMeetingRepository = $generalMeetingRepository;
     }
 
     public function __invoke(Request $request, $date): Response
@@ -44,7 +39,7 @@ class AddAction extends AbstractController
             $this->addFlash('notice', 'La question a été ajoutée');
 
             return $this->redirectToRoute('admin_members_general_vote_list', [
-                'date' =>  $question->getDate()->format('U')
+                'date' =>  $question->getDate()->format('U'),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/DeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/DeleteAction.php
@@ -9,22 +9,16 @@ use AppBundle\Association\Model\Repository\GeneralMeetingQuestionRepository;
 use AppBundle\Association\Model\Repository\GeneralMeetingVoteRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class DeleteAction extends AbstractController
 {
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-    private GeneralMeetingVoteRepository $generalMeetingVoteRepository;
-
     public function __construct(
-        GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
-        GeneralMeetingVoteRepository $generalMeetingVoteRepository
+        private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
+        private readonly GeneralMeetingVoteRepository $generalMeetingVoteRepository,
     ) {
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
-        $this->generalMeetingVoteRepository = $generalMeetingVoteRepository;
     }
 
-    public function __invoke(Request $request, $id): RedirectResponse
+    public function __invoke($id): RedirectResponse
     {
         /** @var GeneralMeetingQuestion $question */
         $question = $this->generalMeetingQuestionRepository->get($id);
@@ -42,7 +36,7 @@ class DeleteAction extends AbstractController
         $this->addFlash('notice', 'La question a été supprimée');
 
         return $this->redirectToRoute('admin_members_general_vote_list', [
-            'date' => $question->getDate()->format('U')
+            'date' => $question->getDate()->format('U'),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/EditAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingQuestion/EditAction.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class EditAction extends AbstractController
 {
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-    public function __construct(
-        GeneralMeetingQuestionRepository $generalMeetingQuestionRepository
-    ) {
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
+    public function __construct(private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository)
+    {
     }
 
     public function __invoke(Request $request, $id)
@@ -39,7 +36,7 @@ class EditAction extends AbstractController
             $this->addFlash('notice', 'La question a été modifiée');
 
             return $this->redirectToRoute('admin_members_general_vote_list', [
-                'date' => $question->getDate()->format('U')
+                'date' => $question->getDate()->format('U'),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/CloseAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/CloseAction.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CloseAction extends AbstractController
 {
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-
-    public function __construct(GeneralMeetingQuestionRepository $generalMeetingQuestionRepository)
+    public function __construct(private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository)
     {
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -39,7 +36,7 @@ class CloseAction extends AbstractController
         $this->addFlash('notice', 'Le vote a été fermée');
 
         return $this->redirectToRoute('admin_members_general_vote_list', [
-            'date' => $question->getDate()->format('U')
+            'date' => $question->getDate()->format('U'),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/ListAction.php
@@ -14,24 +14,12 @@ use Twig\Environment;
 
 class ListAction
 {
-    private GeneralMeetingRepository $generalMeetingRepository;
-
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-
-    private GeneralMeetingVoteRepository $generalMeetingVoteRepository;
-
-    private Environment $twig;
-
     public function __construct(
-        GeneralMeetingRepository $generalMeetingRepository,
-        GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
-        GeneralMeetingVoteRepository $generalMeetingVoteRepository,
-        Environment $twig
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
+        private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
+        private readonly GeneralMeetingVoteRepository $generalMeetingVoteRepository,
+        private readonly Environment $twig,
     ) {
-        $this->generalMeetingRepository = $generalMeetingRepository;
-        $this->twig = $twig;
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
-        $this->generalMeetingVoteRepository = $generalMeetingVoteRepository;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/OpenAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/GeneralMeetingVote/OpenAction.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class OpenAction extends AbstractController
 {
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-
-    public function __construct(GeneralMeetingQuestionRepository $generalMeetingQuestionRepository)
+    public function __construct(private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository)
     {
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -39,7 +36,7 @@ class OpenAction extends AbstractController
         $this->addFlash('notice', 'Le vote a été ouvert');
 
         return $this->redirectToRoute('admin_members_general_vote_list', [
-            'date' => $question->getDate()->format('U')
+            'date' => $question->getDate()->format('U'),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Members/UserAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserAddAction.php
@@ -19,18 +19,11 @@ class UserAddAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private UserRepository $userRepository;
-    private UserService $userService;
-    private UserPasswordHasherInterface $passwordHasher;
-
     public function __construct(
-        UserRepository $userRepository,
-        UserService $userService,
-        UserPasswordHasherInterface $passwordHasher
+        private UserRepository $userRepository,
+        private UserService $userService,
+        private UserPasswordHasherInterface $passwordHasher,
     ) {
-        $this->userRepository = $userRepository;
-        $this->userService = $userService;
-        $this->passwordHasher = $passwordHasher;
     }
 
     public function __invoke(Request $request): Response
@@ -61,7 +54,7 @@ class UserAddAction extends AbstractController
             $this->addFlash('notice', 'La personne physique a été ajoutée');
 
             return $this->redirectToRoute('admin_members_user_list', [
-                'filter' => $user->getEmail()
+                'filter' => $user->getEmail(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/UserBadgeDeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserBadgeDeleteAction.php
@@ -10,11 +10,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class UserBadgeDeleteAction
 {
-    private UserBadgeRepository $userBadgeRepository;
-
-    public function __construct(UserBadgeRepository $userBadgeRepository)
+    public function __construct(private readonly UserBadgeRepository $userBadgeRepository)
     {
-        $this->userBadgeRepository = $userBadgeRepository;
     }
 
     public function __invoke(Request $request): RedirectResponse

--- a/sources/AppBundle/Controller/Admin/Members/UserBadgeNewAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserBadgeNewAction.php
@@ -14,18 +14,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class UserBadgeNewAction
 {
-    private UserRepository $userRepository;
-    private FormFactoryInterface $formFactory;
-    private UserBadgeRepository $userBadgeRepository;
-
     public function __construct(
-        UserRepository $userRepository,
-        FormFactoryInterface $formFactory,
-        UserBadgeRepository $userBadgeRepository
+        private readonly UserRepository $userRepository,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly UserBadgeRepository $userBadgeRepository,
     ) {
-        $this->userRepository = $userRepository;
-        $this->formFactory = $formFactory;
-        $this->userBadgeRepository = $userBadgeRepository;
     }
 
     public function __invoke(Request $request): RedirectResponse

--- a/sources/AppBundle/Controller/Admin/Members/UserDeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserDeleteAction.php
@@ -16,12 +16,8 @@ class UserDeleteAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private UserRepository $userRepository;
-
-    public function __construct(
-        UserRepository $userRepository
-    ) {
-        $this->userRepository = $userRepository;
+    public function __construct(private UserRepository $userRepository)
+    {
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -37,7 +33,7 @@ class UserDeleteAction extends AbstractController
             $this->addFlash('notice', 'La personne physique a été supprimée');
         } catch (InvalidArgumentException $e) {
             $this->addFlash('error', $e->getMessage());
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->addFlash('error', 'Une erreur est survenue lors de la suppression de la personne physique');
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/UserEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserEditAction.php
@@ -18,18 +18,11 @@ class UserEditAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private UserRepository $userRepository;
-    private UserBadgeRepository $userBadgeRepository;
-    private UserPasswordHasherInterface $passwordHasher;
-
     public function __construct(
-        UserRepository $userRepository,
-        UserBadgeRepository $userBadgeRepository,
-        UserPasswordHasherInterface $passwordHasher
+        private UserRepository $userRepository,
+        private UserBadgeRepository $userBadgeRepository,
+        private UserPasswordHasherInterface $passwordHasher,
     ) {
-        $this->userRepository = $userRepository;
-        $this->userBadgeRepository = $userBadgeRepository;
-        $this->passwordHasher = $passwordHasher;
     }
 
     public function __invoke(Request $request): Response
@@ -54,7 +47,7 @@ class UserEditAction extends AbstractController
             $this->addFlash('notice', 'La personne physique a été modifiée');
 
             return $this->redirectToRoute('admin_members_user_list', [
-                'filter' => $user->getEmail()
+                'filter' => $user->getEmail(),
             ]);
         }
 
@@ -62,7 +55,7 @@ class UserEditAction extends AbstractController
         $userBadgeForm = $this->createForm(UserBadgeType::class, [], [
             'user' => $user,
             'action' => $this->generateUrl('admin_members_user_badge_new', [
-                'user_id' => $user->getId()
+                'user_id' => $user->getId(),
             ]),
         ]);
 

--- a/sources/AppBundle/Controller/Admin/Members/UserExportAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserExportAction.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class UserExportAction
 {
-    private UserRepository $userRepository;
-
-    public function __construct(UserRepository $userRepository)
+    public function __construct(private readonly UserRepository $userRepository)
     {
-        $this->userRepository = $userRepository;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Members/UserListAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserListAction.php
@@ -12,18 +12,11 @@ use Twig\Environment;
 
 class UserListAction
 {
-    private UserRepository $userRepository;
-    private AntennesCollection $antennesCollection;
-    private Environment $twig;
-
     public function __construct(
-        UserRepository $userRepository,
-        AntennesCollection $antennesCollection,
-        Environment $twig
+        private readonly UserRepository $userRepository,
+        private readonly AntennesCollection $antennesCollection,
+        private readonly Environment $twig,
     ) {
-        $this->userRepository = $userRepository;
-        $this->antennesCollection = $antennesCollection;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Members/UserResetPasswordAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserResetPasswordAction.php
@@ -16,15 +16,10 @@ class UserResetPasswordAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private UserRepository $userRepository;
-    private UserService $userPasswordService;
-
     public function __construct(
-        UserRepository $userRepository,
-        UserService $userPasswordService
+        private UserRepository $userRepository,
+        private UserService $userPasswordService,
     ) {
-        $this->userRepository = $userRepository;
-        $this->userPasswordService = $userPasswordService;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -37,7 +32,7 @@ class UserResetPasswordAction extends AbstractController
             $this->userPasswordService->resetPassword($user);
             $this->log('Envoi d\'un nouveau mot de passe à la personne physique ' . $user->getId());
             $this->addFlash('notice', 'Un nouveau mot de passe a été envoyé à la personne physique');
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->addFlash('error', 'Une erreur est survenue lors de l\'envoi d\'un nouveau mot de passe à la personne physique');
         }
 

--- a/sources/AppBundle/Controller/Admin/Members/UserSendWelcomeAction.php
+++ b/sources/AppBundle/Controller/Admin/Members/UserSendWelcomeAction.php
@@ -16,15 +16,10 @@ class UserSendWelcomeAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private UserRepository $userRepository;
-    private UserService $userService;
-
     public function __construct(
-        UserRepository $userRepository,
-        UserService $userService
+        private UserRepository $userRepository,
+        private UserService $userService,
     ) {
-        $this->userRepository = $userRepository;
-        $this->userService = $userService;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -37,7 +32,7 @@ class UserSendWelcomeAction extends AbstractController
             $this->userService->sendWelcomeEmail($user);
             $this->log('Envoi d\'un message de bienvenue à la personne physique ' . $user->getId());
             $this->addFlash('notice', 'Un mail de bienvenue a été envoyé à la personne physique');
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->addFlash('error', 'Une erreur est survenue lors de l\'envoi du mail de bienvenue à la personne physique');
         }
 

--- a/sources/AppBundle/Controller/Admin/Membership/ReminderLogAction.php
+++ b/sources/AppBundle/Controller/Admin/Membership/ReminderLogAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class ReminderLogAction
 {
-    private SubscriptionReminderLogRepository $subscriptionReminderLogRepository;
-    private Environment $twig;
-
     public function __construct(
-        SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
-        Environment $twig
+        private readonly SubscriptionReminderLogRepository $subscriptionReminderLogRepository,
+        private readonly Environment $twig,
     ) {
-        $this->subscriptionReminderLogRepository = $subscriptionReminderLogRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Planete/FeedAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedAddAction.php
@@ -15,11 +15,8 @@ class FeedAddAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private FeedRepository $feedRepository;
-
-    public function __construct(FeedRepository $feedRepository
-    ) {
-        $this->feedRepository = $feedRepository;
+    public function __construct(private FeedRepository $feedRepository)
+    {
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/Planete/FeedArticleListAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedArticleListAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class FeedArticleListAction
 {
-    private FeedArticleRepository $feedArticleRepository;
-    private Environment $twig;
-
     public function __construct(
-        FeedArticleRepository $feedArticleRepository,
-        Environment $twig
+        private readonly FeedArticleRepository $feedArticleRepository,
+        private readonly Environment $twig,
     ) {
-        $this->feedArticleRepository = $feedArticleRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Planete/FeedDeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedDeleteAction.php
@@ -14,11 +14,8 @@ class FeedDeleteAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private FeedRepository $feedRepository;
-
-    public function __construct(FeedRepository $feedRepository)
+    public function __construct(private FeedRepository $feedRepository)
     {
-        $this->feedRepository = $feedRepository;
     }
 
     public function __invoke(Request $request): RedirectResponse

--- a/sources/AppBundle/Controller/Admin/Planete/FeedEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedEditAction.php
@@ -15,11 +15,8 @@ class FeedEditAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private FeedRepository $feedRepository;
-
-    public function __construct(FeedRepository $feedRepository)
+    public function __construct(private FeedRepository $feedRepository)
     {
-        $this->feedRepository = $feedRepository;
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Admin/Planete/FeedListAction.php
+++ b/sources/AppBundle/Controller/Admin/Planete/FeedListAction.php
@@ -14,15 +14,10 @@ use Twig\Environment;
 
 class FeedListAction
 {
-    private FeedRepository $feedRepository;
-    private Environment $twig;
-
     public function __construct(
-        FeedRepository $feedRepository,
-        Environment $twig
+        private readonly FeedRepository $feedRepository,
+        private readonly Environment $twig,
     ) {
-        $this->feedRepository = $feedRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -59,7 +54,7 @@ class FeedListAction
                 try {
                     new SimpleXmlElement(file_get_contents($f->getFeed()));
                     $results[$f->getId()] = true;
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $results[$f->getId()] = false;
                 }
             }

--- a/sources/AppBundle/Controller/Admin/Site/AddRubriqueAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/AddRubriqueAction.php
@@ -16,15 +16,10 @@ class AddRubriqueAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private RubriqueRepository $rubriqueRepository;
-    private string $storageDir;
-
     public function __construct(
-        RubriqueRepository $rubriqueRepository,
-        string $storageDir
+        private readonly RubriqueRepository $rubriqueRepository,
+        private string $storageDir,
     ) {
-        $this->rubriqueRepository =  $rubriqueRepository;
-        $this->storageDir = $storageDir;
     }
 
     public function __invoke(Request $request): Response
@@ -37,7 +32,7 @@ class AddRubriqueAction extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('icone')->getData();
             if ($file) {
-                $originalFilename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+                $originalFilename = pathinfo((string) $file->getClientOriginalName(), PATHINFO_FILENAME);
                 $safeFilename = hash('sha1', $originalFilename);
                 $newFilename = $safeFilename . '.' . $file->guessExtension();
                 $file->move($this->storageDir, $newFilename);
@@ -47,7 +42,7 @@ class AddRubriqueAction extends AbstractController
             $this->log('Ajout de la rubrique ' . $rubrique->getNom());
             $this->addFlash('notice', 'La rubrique ' . $rubrique->getNom() . ' a été ajoutée');
             return $this->redirectToRoute('admin_site_rubriques_list', [
-                'filter' => $rubrique->getNom()
+                'filter' => $rubrique->getNom(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Site/DeleteRubriqueAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/DeleteRubriqueAction.php
@@ -8,7 +8,6 @@ use Afup\Site\Logger\DbLoggerTrait;
 use AppBundle\Site\Model\Repository\RubriqueRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
@@ -16,19 +15,13 @@ class DeleteRubriqueAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private CsrfTokenManagerInterface $csrfTokenManager;
-
-    private RubriqueRepository $rubriqueRepository;
-
     public function __construct(
-        RubriqueRepository $rubriqueRepository,
-        CsrfTokenManagerInterface $csrfTokenManager
+        private RubriqueRepository $rubriqueRepository,
+        private CsrfTokenManagerInterface $csrfTokenManager,
     ) {
-        $this->rubriqueRepository =  $rubriqueRepository;
-        $this->csrfTokenManager = $csrfTokenManager;
     }
 
-    public function __invoke(int $id, string $token, Request $request): RedirectResponse
+    public function __invoke(int $id, string $token): RedirectResponse
     {
         if (false === $this->csrfTokenManager->isTokenValid(new CsrfToken('rubrique_delete', $token))) {
             $this->addFlash('error', 'Token invalide');

--- a/sources/AppBundle/Controller/Admin/Site/EditRubriqueAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/EditRubriqueAction.php
@@ -15,14 +15,10 @@ class EditRubriqueAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private RubriqueRepository $rubriqueRepository;
-
-    private string $storageDir;
-
-    public function __construct(RubriqueRepository $rubriqueRepository, string $storageDir)
-    {
-        $this->rubriqueRepository =  $rubriqueRepository;
-        $this->storageDir = $storageDir;
+    public function __construct(
+        private RubriqueRepository $rubriqueRepository,
+        private string $storageDir,
+    ) {
     }
 
     public function __invoke(int $id,Request $request): Response
@@ -33,7 +29,7 @@ class EditRubriqueAction extends AbstractController
         if ($form->isSubmitted() && $form->isValid()) {
             $file = $form->get('icone')->getData();
             if ($file) {
-                $originalFilename = pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME);
+                $originalFilename = pathinfo((string) $file->getClientOriginalName(), PATHINFO_FILENAME);
                 $safeFilename = hash('sha1', $originalFilename);
                 $newFilename = $safeFilename . '.' . $file->guessExtension();
                 $file->move($this->storageDir, $newFilename);
@@ -43,7 +39,7 @@ class EditRubriqueAction extends AbstractController
             $this->log('Modification de la Rubrique ' . $rubrique->getNom());
             $this->addFlash('notice', 'La rubrique ' . $rubrique->getNom() . ' a été modifiée');
             return $this->redirectToRoute('admin_site_rubriques_list', [
-                'filter' => $rubrique->getNom()
+                'filter' => $rubrique->getNom(),
             ]);
         }
         $icone = $rubrique->getIcone() !== null ? '/templates/site/images/' . $rubrique->getIcone() : false;

--- a/sources/AppBundle/Controller/Admin/Site/ListRubriquesAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/ListRubriquesAction.php
@@ -11,14 +11,10 @@ use Twig\Environment;
 
 class ListRubriquesAction
 {
-    private Environment $twig;
-
-    private RubriqueRepository $rubriqueRepository;
-
-    public function __construct(RubriqueRepository $rubriqueRepository, Environment $twig)
-    {
-        $this->rubriqueRepository = $rubriqueRepository;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly RubriqueRepository $rubriqueRepository,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/SlackMembers/CheckMembersAction.php
+++ b/sources/AppBundle/Controller/Admin/SlackMembers/CheckMembersAction.php
@@ -10,15 +10,10 @@ use Twig\Environment;
 
 class CheckMembersAction
 {
-    private UsersChecker $usersChecker;
-    private Environment $twig;
-
     public function __construct(
-        UsersChecker $usersChecker,
-        Environment $twig
+        private readonly UsersChecker $usersChecker,
+        private readonly Environment $twig,
     ) {
-        $this->usersChecker = $usersChecker;
-        $this->twig = $twig;
     }
 
     public function __invoke(): Response

--- a/sources/AppBundle/Controller/Admin/Speaker/ExportAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/ExportAction.php
@@ -14,15 +14,10 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ExportAction
 {
-    private EventRepository $eventRepository;
-    private ExportGenerator $exportGenerator;
-
     public function __construct(
-        EventRepository $eventRepository,
-        ExportGenerator $exportGenerator
+        private readonly EventRepository $eventRepository,
+        private readonly ExportGenerator $exportGenerator,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->exportGenerator = $exportGenerator;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerAddAction.php
@@ -21,18 +21,11 @@ class SpeakerAddAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private EventRepository $eventRepository;
-    private SpeakerRepository $speakerRepository;
-    private PhotoStorage $photoStorage;
-
     public function __construct(
-        EventRepository $eventRepository,
-        SpeakerRepository $speakerRepository,
-        PhotoStorage $photoStorage
+        private EventRepository $eventRepository,
+        private SpeakerRepository $speakerRepository,
+        private PhotoStorage $photoStorage,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->photoStorage = $photoStorage;
     }
 
     public function __invoke(Request $request): Response
@@ -42,7 +35,7 @@ class SpeakerAddAction extends AbstractController
         Assertion::notNull($event);
         $data = new SpeakerFormData();
         $form = $this->createForm(SpeakerType::class, $data, [
-            SpeakerType::OPT_USER_GITHUB => true
+            SpeakerType::OPT_USER_GITHUB => true,
         ]);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -71,7 +64,7 @@ class SpeakerAddAction extends AbstractController
             $this->addFlash('notice', 'Le conférencier a été ajouté');
 
             return $this->redirectToRoute('admin_speaker_list', [
-                'eventId' => $event->getId()
+                'eventId' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerDeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerDeleteAction.php
@@ -16,12 +16,8 @@ class SpeakerDeleteAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private SpeakerRepository $speakerRepository;
-
-    public function __construct(
-        SpeakerRepository $speakerRepository
-    ) {
-        $this->speakerRepository = $speakerRepository;
+    public function __construct(private SpeakerRepository $speakerRepository)
+    {
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -35,12 +31,12 @@ class SpeakerDeleteAction extends AbstractController
             $this->speakerRepository->delete($speaker);
             $this->log('Suppression du conférencier ' . $speaker->getId());
             $this->addFlash('notice', 'Le conférencier a été supprimé');
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->addFlash('error', 'Une erreur est survenue lors de la suppression du conférencier');
         }
 
         return $this->redirectToRoute('admin_speaker_list', [
-            'eventId' => $speaker->getEventId()
+            'eventId' => $speaker->getEventId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerEditAction.php
@@ -24,24 +24,14 @@ class SpeakerEditAction extends AbstractController
     use DbLoggerTrait;
 
     const ID_FORUM_PHOTO_STORAGE = 16;
-    private SpeakerRepository $speakerRepository;
-    private TalkRepository $talkRepository;
-    private EventRepository $eventRepository;
-    private PhotoStorage $photoStorage;
-    private SpeakerFormDataFactory $speakerFormDataFactory;
 
     public function __construct(
-        SpeakerRepository $speakerRepository,
-        TalkRepository $talkRepository,
-        EventRepository $eventRepository,
-        PhotoStorage $photoStorage,
-        SpeakerFormDataFactory $speakerFormDataFactory
+        private SpeakerRepository $speakerRepository,
+        private TalkRepository $talkRepository,
+        private EventRepository $eventRepository,
+        private PhotoStorage $photoStorage,
+        private SpeakerFormDataFactory $speakerFormDataFactory,
     ) {
-        $this->speakerRepository = $speakerRepository;
-        $this->talkRepository = $talkRepository;
-        $this->eventRepository = $eventRepository;
-        $this->photoStorage = $photoStorage;
-        $this->speakerFormDataFactory = $speakerFormDataFactory;
     }
 
     public function __invoke(Request $request)
@@ -104,7 +94,7 @@ class SpeakerEditAction extends AbstractController
             $this->addFlash('notice', 'Le conférencier a été modifié');
 
             return $this->redirectToRoute('admin_speaker_list', [
-                'eventId' => $event->getId()
+                'eventId' => $event->getId(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerLinkGravatarAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerLinkGravatarAction.php
@@ -13,15 +13,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SpeakerLinkGravatarAction extends AbstractController
 {
-    private SpeakerRepository $speakerRepository;
-    private PhotoStorage $photoStorage;
-
     public function __construct(
-        SpeakerRepository $speakerRepository,
-        PhotoStorage $photoStorage
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly PhotoStorage $photoStorage,
     ) {
-        $this->speakerRepository = $speakerRepository;
-        $this->photoStorage = $photoStorage;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -40,7 +35,7 @@ class SpeakerLinkGravatarAction extends AbstractController
         }
 
         return $this->redirectToRoute('admin_speaker_edit', [
-            'id' => $speaker->getId()
+            'id' => $speaker->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
@@ -19,24 +19,14 @@ class SpeakerListAction
 {
     const VALID_SORTS = ['name', 'company'];
     const VALID_DIRECTIONS = ['asc', 'desc'];
-    private EventActionHelper $eventActionHelper;
-    private EventRepository $eventRepository;
-    private SpeakerRepository $speakerRepository;
-    private TalkRepository $talkRepository;
-    private Environment $twig;
 
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        EventRepository $eventRepository,
-        SpeakerRepository $speakerRepository,
-        TalkRepository $talkRepository,
-        Environment $twig
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly EventRepository $eventRepository,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly TalkRepository $talkRepository,
+        private readonly Environment $twig,
     ) {
-        $this->eventActionHelper = $eventActionHelper;
-        $this->eventRepository = $eventRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->talkRepository = $talkRepository;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerRegisterAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerRegisterAction.php
@@ -23,27 +23,14 @@ class SpeakerRegisterAction extends AbstractController
 {
     use DbLoggerTrait;
 
-    private SpeakerRepository $speakerRepository;
-    private EventActionHelper $eventActionHelper;
-    private TalkRepository $talkRepository;
-    private TicketRepository $ticketRepository;
-    private InvoiceService $invoiceService;
-    private InvoiceRepository $invoiceRepository;
-
     public function __construct(
-        SpeakerRepository $speakerRepository,
-        EventActionHelper $eventActionHelper,
-        TalkRepository $talkRepository,
-        TicketRepository $ticketRepository,
-        InvoiceService $invoiceService,
-        InvoiceRepository $invoiceRepository
+        private SpeakerRepository $speakerRepository,
+        private EventActionHelper $eventActionHelper,
+        private TalkRepository $talkRepository,
+        private TicketRepository $ticketRepository,
+        private InvoiceService $invoiceService,
+        private InvoiceRepository $invoiceRepository,
     ) {
-        $this->speakerRepository = $speakerRepository;
-        $this->eventActionHelper = $eventActionHelper;
-        $this->talkRepository = $talkRepository;
-        $this->ticketRepository = $ticketRepository;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->invoiceService = $invoiceService;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -80,7 +67,7 @@ class SpeakerRegisterAction extends AbstractController
                 $ticket->setInvoiceStatus(Ticket::INVOICE_TODO);
                 try {
                     $this->ticketRepository->save($ticket);
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $this->addFlash('error', 'Une erreur est survenue lors de l\'ajout de l\'inscription');
 
                     return $this->redirectToRoute('admin_speaker_list');
@@ -107,11 +94,11 @@ class SpeakerRegisterAction extends AbstractController
                     );
                     $this->log('Ajout inscription conférencier ' . $speaker->getId());
                     $nbSpeakers++;
-                } catch (Exception $e) {
+                } catch (Exception) {
                     $this->addFlash('error', 'Une erreur est survenue lors de l\'ajout de la facturation');
 
                     return $this->redirectToRoute('admin_speaker_list', [
-                        'eventId' => $event->getId()
+                        'eventId' => $event->getId(),
                     ]);
                 }
             }
@@ -119,7 +106,7 @@ class SpeakerRegisterAction extends AbstractController
         $this->addFlash('notice', $nbSpeakers . ' conférenciers ont été ajoutés dans les inscriptions');
 
         return $this->redirectToRoute('admin_speaker_list', [
-            'eventId' => $event->getId()
+            'eventId' => $event->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Talk/ExportAction.php
+++ b/sources/AppBundle/Controller/Admin/Talk/ExportAction.php
@@ -13,15 +13,10 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ExportAction
 {
-    private EventRepository $eventRepository;
-    private ExportGenerator $exportGenerator;
-
     public function __construct(
-        EventRepository $eventRepository,
-        ExportGenerator $exportGenerator
+        private readonly EventRepository $eventRepository,
+        private readonly ExportGenerator $exportGenerator,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->exportGenerator = $exportGenerator;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Admin/Talk/UpdateIndexationAction.php
+++ b/sources/AppBundle/Controller/Admin/Talk/UpdateIndexationAction.php
@@ -11,11 +11,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class UpdateIndexationAction extends AbstractController
 {
-    private Runner $runner;
-
-    public function __construct(Runner $runner)
+    public function __construct(private readonly Runner $runner)
     {
-        $this->runner = $runner;
     }
 
     public function __invoke(Request $request): RedirectResponse

--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -23,27 +23,14 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class TechLetterGenerateController extends AbstractController
 {
-    private SendingRepository $sendingRepository;
-    private TechletterSubscriptionsRepository $techletterSubscriptionsRepository;
-    private Mailer $mailer;
-    private Mailchimp $mailchimp;
-    private string $techletterTestEmailAddress;
-    private string $mailchimpTechletterList;
-
     public function __construct(
-        SendingRepository $sendingRepository,
-        TechletterSubscriptionsRepository $techletterSubscriptionsRepository,
-        Mailer $mailer,
-        Mailchimp $mailchimp,
-        string $techletterTestEmailAddress,
-        string $mailchimpTechletterList
+        private readonly SendingRepository $sendingRepository,
+        private readonly TechletterSubscriptionsRepository $techletterSubscriptionsRepository,
+        private readonly Mailer $mailer,
+        private readonly Mailchimp $mailchimp,
+        private readonly string $techletterTestEmailAddress,
+        private readonly string $mailchimpTechletterList,
     ) {
-        $this->sendingRepository = $sendingRepository;
-        $this->techletterSubscriptionsRepository = $techletterSubscriptionsRepository;
-        $this->mailer = $mailer;
-        $this->mailchimp = $mailchimp;
-        $this->techletterTestEmailAddress = $techletterTestEmailAddress;
-        $this->mailchimpTechletterList = $mailchimpTechletterList;
     }
 
     public function index(Request $request)
@@ -83,7 +70,7 @@ class TechLetterGenerateController extends AbstractController
                 $history[] = $defaultColumns + [
                     'type' => 'First news',
                     'url' => $url,
-                    'title' => $firstNews->getTitle()
+                    'title' => $firstNews->getTitle(),
                 ];
             }
 
@@ -160,7 +147,7 @@ class TechLetterGenerateController extends AbstractController
                     'admin/techletter/mail_template.html.twig',
                     [
                         'tech_letter' => $techLetter,
-                        'preview' => false
+                        'preview' => false,
                     ]
                 )
                 ->getContent();
@@ -210,7 +197,7 @@ class TechLetterGenerateController extends AbstractController
             [
                 'title' => "Veille de l'AFUP",
                 'sending' => $sending,
-                'tech_letter' => $techLetter
+                'tech_letter' => $techLetter,
             ]
         );
     }
@@ -253,7 +240,7 @@ class TechLetterGenerateController extends AbstractController
 
         return $this->render('admin/techletter/mail_template.html.twig', [
             'preview' => true,
-            'tech_letter' => $techletter
+            'tech_letter' => $techletter,
         ]);
     }
 
@@ -294,7 +281,7 @@ class TechLetterGenerateController extends AbstractController
         $subscribers = $this->techletterSubscriptionsRepository->getAllSubscriptionsWithUser();
         return $this->render('admin/techletter/members.html.twig', [
             'subscribers' => $subscribers,
-            'title' => 'Liste des abonnés à la techletter'
+            'title' => 'Liste des abonnés à la techletter',
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/VoteController.php
+++ b/sources/AppBundle/Controller/Admin/VoteController.php
@@ -28,18 +28,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 class VoteController extends AbstractController
 {
     private ?FormBuilderInterface $formBuilder = null;
-    private RequestStack $requestStack;
-    private EventDispatcherInterface $eventDispatcher;
-    private RepositoryFactory $repositoryFactory;
-    private SlackNotifier $slackNotifier;
-    private EventActionHelper $eventActionHelper;
-    public function __construct(RequestStack $requestStack, EventDispatcherInterface $eventDispatcher, RepositoryFactory $repositoryFactory, SlackNotifier $slackNotifier, EventActionHelper $eventActionHelper)
-    {
-        $this->requestStack = $requestStack;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->slackNotifier = $slackNotifier;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly RequestStack $requestStack,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly SlackNotifier $slackNotifier,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
 
     /**
@@ -75,7 +70,7 @@ class VoteController extends AbstractController
                  */
                 yield [
                     'form' => $this->createVoteForm($eventSlug, $talk['sessions']->getId(), $myVote)->createView(),
-                    'talk' => $talk['sessions']
+                    'talk' => $talk['sessions'],
                 ];
             }
         };
@@ -88,7 +83,7 @@ class VoteController extends AbstractController
                 'page' => $page,
                 'talks' => $forms(),
                 'event' => $event,
-                'all' => $all
+                'all' => $all,
             ]
         );
     }

--- a/sources/AppBundle/Controller/Event/BlogController.php
+++ b/sources/AppBundle/Controller/Event/BlogController.php
@@ -18,14 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BlogController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    private JsonLd $jsonLd;
-    private EventActionHelper $eventActionHelper;
-    public function __construct(RepositoryFactory $repositoryFactory, JsonLd $jsonLd, EventActionHelper $eventActionHelper)
-    {
-        $this->repositoryFactory = $repositoryFactory;
-        $this->jsonLd = $jsonLd;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly JsonLd $jsonLd,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
 
     public function program(Request $request, $eventSlug): Response
@@ -169,7 +166,7 @@ class BlogController extends AbstractController
          */
         $talkRepository = $this->repositoryFactory->get(TalkRepository::class);
 
-        $talks = $talkRepository->getBy(['id' => explode(',', $request->get('ids'))]);
+        $talks = $talkRepository->getBy(['id' => explode(',', (string) $request->get('ids'))]);
 
         $speakers = [];
         $talksInfos = [];
@@ -187,7 +184,7 @@ class BlogController extends AbstractController
             [
                 'talks_infos' => $talksInfos,
                 'speakers' => $speakers,
-                'widget_type' => $request->get('type', 'all')
+                'widget_type' => $request->get('type', 'all'),
             ]
         );
     }

--- a/sources/AppBundle/Controller/Event/CFP/EditAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/EditAction.php
@@ -28,42 +28,19 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class EditAction extends AbstractController
 {
-    private SpeakerFactory $speakerFactory;
-    private TranslatorInterface $translator;
-    private TalkFormHandler $talkFormHandler;
-    private TalkRepository $talkRepository;
-    private TalkInvitationRepository $talkInvitationRepository;
-    private SpeakerRepository $speakerRepository;
-    private VoteRepository $voteRepository;
-    private SidebarRenderer $sidebarRenderer;
-    private EventActionHelper $eventActionHelper;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private InvitationFormHandler $invitationFormHandler;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TalkRepository $talkRepository,
-        TalkInvitationRepository $talkInvitationRepository,
-        TalkFormHandler $talkFormHandler,
-        InvitationFormHandler $invitationFormHandler,
-        SpeakerFactory $speakerFactory,
-        TranslatorInterface $translator,
-        SpeakerRepository $speakerRepository,
-        VoteRepository $voteRepository,
-        AuthorizationCheckerInterface $authorizationChecker,
-        SidebarRenderer $sidebarRenderer
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TalkRepository $talkRepository,
+        private readonly TalkInvitationRepository $talkInvitationRepository,
+        private readonly TalkFormHandler $talkFormHandler,
+        private readonly InvitationFormHandler $invitationFormHandler,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly TranslatorInterface $translator,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly VoteRepository $voteRepository,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly SidebarRenderer $sidebarRenderer,
     ) {
-        $this->speakerFactory = $speakerFactory;
-        $this->translator = $translator;
-        $this->talkFormHandler = $talkFormHandler;
-        $this->talkRepository = $talkRepository;
-        $this->talkInvitationRepository = $talkInvitationRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->voteRepository = $voteRepository;
-        $this->sidebarRenderer = $sidebarRenderer;
-        $this->eventActionHelper = $eventActionHelper;
-        $this->invitationFormHandler = $invitationFormHandler;
-        $this->authorizationChecker = $authorizationChecker;
     }
 
     public function __invoke(Request $request)
@@ -78,7 +55,7 @@ class EditAction extends AbstractController
             $this->addFlash('error', $this->translator->trans('Vous devez remplir votre profil conférencier afin de pouvoir soumettre un sujet.'));
 
             return $this->redirectToRoute('cfp_speaker', [
-                'eventSlug' => $event->getPath()
+                'eventSlug' => $event->getPath(),
             ]);
         }
         $talkId = (int) $request->attributes->get('talkId');

--- a/sources/AppBundle/Controller/Event/CFP/IndexAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/IndexAction.php
@@ -20,27 +20,15 @@ use Symfony\Component\HttpFoundation\Response;
 class IndexAction extends AbstractController
 {
     const MAX_EVENTS_HISTORY = 50;
-    private TalkRepository $talkRepository;
-    private SpeakerFactory $speakerFactory;
-    private PhotoStorage $photoStorage;
-    private SidebarRenderer $sidebarRenderer;
-    private EventActionHelper $eventActionHelper;
-    private EventRepository $eventRepository;
 
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        EventRepository $eventRepository,
-        TalkRepository $talkRepository,
-        SpeakerFactory $speakerFactory,
-        PhotoStorage $photoStorage,
-        SidebarRenderer $sidebarRenderer
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly EventRepository $eventRepository,
+        private readonly TalkRepository $talkRepository,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly PhotoStorage $photoStorage,
+        private readonly SidebarRenderer $sidebarRenderer,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->speakerFactory = $speakerFactory;
-        $this->photoStorage = $photoStorage;
-        $this->sidebarRenderer = $sidebarRenderer;
-        $this->eventActionHelper = $eventActionHelper;
-        $this->eventRepository = $eventRepository;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Event/CFP/InviteAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/InviteAction.php
@@ -18,27 +18,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InviteAction extends AbstractController
 {
-    private TalkRepository $talkRepository;
-    private SpeakerFactory $speakerFactory;
-    private TranslatorInterface $translator;
-    private TalkInvitationRepository $talkInvitationRepository;
-    private TalkToSpeakersRepository $talkToSpeakersRepository;
-    private EventActionHelper $eventActionHelper;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        TalkRepository $talkRepository,
-        SpeakerFactory $speakerFactory,
-        TalkInvitationRepository $talkInvitationRepository,
-        TalkToSpeakersRepository $talkToSpeakersRepository,
-        TranslatorInterface $translator
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly TalkRepository $talkRepository,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly TalkInvitationRepository $talkInvitationRepository,
+        private readonly TalkToSpeakersRepository $talkToSpeakersRepository,
+        private readonly TranslatorInterface $translator,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->speakerFactory = $speakerFactory;
-        $this->translator = $translator;
-        $this->talkInvitationRepository = $talkInvitationRepository;
-        $this->talkToSpeakersRepository = $talkToSpeakersRepository;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request): RedirectResponse
@@ -60,7 +47,7 @@ class InviteAction extends AbstractController
             $this->addFlash('pendingInvitation', ['talkId' => $talkId, 'token' => $token, 'eventSlug' => $event->getPath()]);
 
             return $this->redirectToRoute('cfp_speaker', [
-                'eventSlug' => $event->getPath()
+                'eventSlug' => $event->getPath(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Event/CFP/ProposeAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/ProposeAction.php
@@ -18,24 +18,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ProposeAction extends AbstractController
 {
-    private SpeakerFactory $speakerFactory;
-    private TranslatorInterface $translator;
-    private TalkFormHandler $talkFormHandler;
-    private SidebarRenderer $sidebarRenderer;
-    private EventActionHelper $eventActionHelper;
-
     public function __construct(
-        TalkFormHandler $talkFormHandler,
-        SpeakerFactory $speakerFactory,
-        TranslatorInterface $translator,
-        SidebarRenderer $sidebarRenderer,
-        EventActionHelper $eventActionHelper
+        private readonly TalkFormHandler $talkFormHandler,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly TranslatorInterface $translator,
+        private readonly SidebarRenderer $sidebarRenderer,
+        private readonly EventActionHelper $eventActionHelper,
     ) {
-        $this->speakerFactory = $speakerFactory;
-        $this->translator = $translator;
-        $this->talkFormHandler = $talkFormHandler;
-        $this->sidebarRenderer = $sidebarRenderer;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request): Response
@@ -43,7 +32,7 @@ class ProposeAction extends AbstractController
         $event = $this->eventActionHelper->getEvent($request->attributes->get('eventSlug'));
         if ($event->getDateEndCallForPapers() < new DateTime()) {
             return $this->render('event/cfp/closed.html.twig', [
-                'event' => $event
+                'event' => $event,
             ]);
         }
         $speaker = $this->speakerFactory->getSpeaker($event);
@@ -51,14 +40,14 @@ class ProposeAction extends AbstractController
             $this->addFlash('error', $this->translator->trans('Vous devez remplir votre profil conférencier afin de pouvoir soumettre un sujet.'));
 
             return $this->redirectToRoute('cfp_speaker', [
-                'eventSlug' => $event->getPath()
+                'eventSlug' => $event->getPath(),
             ]);
         }
 
         $talk = new Talk();
         $talk->setForumId($event->getId());
         $form = $this->createForm(TalkType::class, $talk, [
-            TalkType::IS_AFUP_DAY => $event->isAfupDay()
+            TalkType::IS_AFUP_DAY => $event->isAfupDay(),
         ]);
         if ($event->isCfpOpen()) {
             $form->add('save', SubmitType::class, ['label' => 'Sauvegarder']);

--- a/sources/AppBundle/Controller/Event/CFP/SidebarRenderer.php
+++ b/sources/AppBundle/Controller/Event/CFP/SidebarRenderer.php
@@ -12,18 +12,11 @@ use Twig\Environment;
 
 class SidebarRenderer
 {
-    private TalkRepository $talkRepository;
-    private SpeakerFactory $speakerFactory;
-    private Environment $twig;
-
     public function __construct(
-        TalkRepository $talkRepository,
-        SpeakerFactory $speakerFactory,
-        Environment $twig
+        private readonly TalkRepository $talkRepository,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly Environment $twig,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->speakerFactory = $speakerFactory;
-        $this->twig = $twig;
     }
 
     /**

--- a/sources/AppBundle/Controller/Event/CFP/SpeakerAction.php
+++ b/sources/AppBundle/Controller/Event/CFP/SpeakerAction.php
@@ -19,27 +19,14 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SpeakerAction extends AbstractController
 {
-    private SpeakerFactory $speakerFactory;
-    private PhotoStorage $photoStorage;
-    private SpeakerRepository $speakerRepository;
-    private TranslatorInterface $translator;
-    private SidebarRenderer $sidebarRenderer;
-    private EventActionHelper $eventActionHelper;
-
     public function __construct(
-        EventActionHelper $eventActionHelper,
-        SpeakerFactory $speakerFactory,
-        SpeakerRepository $speakerRepository,
-        TranslatorInterface $translator,
-        PhotoStorage $photoStorage,
-        SidebarRenderer $sidebarRenderer
+        private readonly EventActionHelper $eventActionHelper,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly TranslatorInterface $translator,
+        private readonly PhotoStorage $photoStorage,
+        private readonly SidebarRenderer $sidebarRenderer,
     ) {
-        $this->speakerFactory = $speakerFactory;
-        $this->photoStorage = $photoStorage;
-        $this->speakerRepository = $speakerRepository;
-        $this->translator = $translator;
-        $this->sidebarRenderer = $sidebarRenderer;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request): Response
@@ -47,7 +34,7 @@ class SpeakerAction extends AbstractController
         $event = $this->eventActionHelper->getEvent($request->attributes->get('eventSlug'));
         if ($event->getDateEndCallForPapers() < new DateTime()) {
             return $this->render('event/cfp/closed.html.twig', [
-                'event' => $event
+                'event' => $event,
             ]);
         }
         $speaker = $this->speakerFactory->getSpeaker($event);
@@ -75,7 +62,7 @@ class SpeakerAction extends AbstractController
             }
 
             return $this->redirectToRoute('cfp_speaker', [
-                'eventSlug' => $event->getPath()
+                'eventSlug' => $event->getPath(),
             ]);
         }
 

--- a/sources/AppBundle/Controller/Event/EventActionHelper.php
+++ b/sources/AppBundle/Controller/Event/EventActionHelper.php
@@ -13,15 +13,10 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 
 class EventActionHelper
 {
-    protected EventRepository $eventRepository;
-    private TokenStorageInterface $tokenStorage;
-
     public function __construct(
-        EventRepository $eventRepository,
-        TokenStorageInterface $tokenStorage
+        protected EventRepository $eventRepository,
+        private readonly TokenStorageInterface $tokenStorage,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->tokenStorage = $tokenStorage;
     }
 
     /**

--- a/sources/AppBundle/Controller/Event/EventController.php
+++ b/sources/AppBundle/Controller/Event/EventController.php
@@ -19,14 +19,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EventController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    private PhotoStorage $photoStorage;
-    private EventActionHelper $eventActionHelper;
-    public function __construct(RepositoryFactory $repositoryFactory, PhotoStorage $photoStorage, EventActionHelper $eventActionHelper)
-    {
-        $this->repositoryFactory = $repositoryFactory;
-        $this->photoStorage = $photoStorage;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly PhotoStorage $photoStorage,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
     public function index()
     {

--- a/sources/AppBundle/Controller/Event/LeadController.php
+++ b/sources/AppBundle/Controller/Event/LeadController.php
@@ -21,19 +21,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class LeadController extends AbstractController
 {
-    private Mailer $mailer;
-    private EventDispatcherInterface $eventDispatcher;
-    private SponsorshipLeadMail $sponsorshipLeadMail;
-    private RepositoryFactory $repositoryFactory;
-    private EventActionHelper $eventActionHelper;
-
-    public function __construct(Mailer $mailer, EventDispatcherInterface $eventDispatcher, SponsorshipLeadMail $sponsorshipLeadMail, RepositoryFactory $repositoryFactory, EventActionHelper $eventActionHelper)
-    {
-        $this->mailer = $mailer;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->sponsorshipLeadMail = $sponsorshipLeadMail;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly SponsorshipLeadMail $sponsorshipLeadMail,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
 
     public function becomeSponsor($eventSlug, Request $request)
@@ -62,7 +56,7 @@ class LeadController extends AbstractController
 
         return $this->render('event/sponsorship_file/form.html.twig', [
             'event' => $event,
-            'leadForm' => $leadForm->createView()
+            'leadForm' => $leadForm->createView(),
         ]);
     }
 

--- a/sources/AppBundle/Controller/Event/SpeakerFilesAction.php
+++ b/sources/AppBundle/Controller/Event/SpeakerFilesAction.php
@@ -12,18 +12,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class SpeakerFilesAction
 {
-    private SpeakersExpensesStorage $speakersExpensesStorage;
-    private SpeakerRepository $speakerRepository;
-    private EventActionHelper $eventActionHelper;
-
     public function __construct(
-        SpeakersExpensesStorage $speakersExpensesStorage,
-        SpeakerRepository $speakerRepository,
-        EventActionHelper $eventActionHelper
+        private readonly SpeakersExpensesStorage $speakersExpensesStorage,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly EventActionHelper $eventActionHelper,
     ) {
-        $this->speakersExpensesStorage = $speakersExpensesStorage;
-        $this->speakerRepository = $speakerRepository;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request): BinaryFileResponse

--- a/sources/AppBundle/Controller/Event/SpeakerPageAction.php
+++ b/sources/AppBundle/Controller/Event/SpeakerPageAction.php
@@ -10,18 +10,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SpeakerPageAction
 {
-    private SpeakerPage $speakerPage;
-    private SpeakerFactory $speakerFactory;
-    private EventActionHelper $eventActionHelper;
-
     public function __construct(
-        SpeakerPage $speakerPage,
-        SpeakerFactory $speakerFactory,
-        EventActionHelper $eventActionHelper
+        private readonly SpeakerPage $speakerPage,
+        private readonly SpeakerFactory $speakerFactory,
+        private readonly EventActionHelper $eventActionHelper,
     ) {
-        $this->speakerPage = $speakerPage;
-        $this->speakerFactory = $speakerFactory;
-        $this->eventActionHelper = $eventActionHelper;
     }
 
     public function __invoke(Request $request)

--- a/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
+++ b/sources/AppBundle/Controller/Event/SpeakerSuggestionController.php
@@ -18,15 +18,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SpeakerSuggestionController extends AbstractController
 {
-    private Mailer $mailer;
-    private RepositoryFactory $repositoryFactory;
-    private EventActionHelper $eventActionHelper;
-
-    public function __construct(Mailer $mailer, RepositoryFactory $repositoryFactory, EventActionHelper $eventActionHelper)
-    {
-        $this->mailer = $mailer;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Controller/Event/SponsorScanController.php
+++ b/sources/AppBundle/Controller/Event/SponsorScanController.php
@@ -21,12 +21,10 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class SponsorScanController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    private EventActionHelper $eventActionHelper;
-    public function __construct(RepositoryFactory $repositoryFactory, EventActionHelper $eventActionHelper)
-    {
-        $this->repositoryFactory = $repositoryFactory;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
     public function index(Request $request, $eventSlug)
     {

--- a/sources/AppBundle/Controller/Event/TicketController.php
+++ b/sources/AppBundle/Controller/Event/TicketController.php
@@ -39,35 +39,21 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class TicketController extends AbstractController
 {
-    private EventDispatcherInterface $eventDispatcher;
-    private LoggerInterface $logger;
-    private RepositoryFactory $repositoryFactory;
-    private ActionThrottling $actionThrottling;
-    private TicketFactory $ticketFactory;
-    private SponsorTicketHelper $sponsorTicketHelper;
-    private Emails $emails;
-    private PurchaseTypeFactory $purchaseTypeFactory;
-    private InvoiceRepository $invoiceRepository;
-    private LegacyModelFactory $legacyModelFactory;
-    private TicketRepository $ticketRepository;
-    private PayboxFactory $payboxFactory;
-    private EventActionHelper $eventActionHelper;
-
-    public function __construct(EventDispatcherInterface $eventDispatcher, LoggerInterface $logger, RepositoryFactory $repositoryFactory, ActionThrottling $actionThrottling, TicketFactory $ticketFactory, SponsorTicketHelper $sponsorTicketHelper, Emails $emails, PurchaseTypeFactory $purchaseTypeFactory, InvoiceRepository $invoiceRepository, LegacyModelFactory $legacyModelFactory, TicketRepository $ticketRepository, PayboxFactory $payboxFactory, EventActionHelper $eventActionHelper)
-    {
-        $this->eventDispatcher = $eventDispatcher;
-        $this->logger = $logger;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->actionThrottling = $actionThrottling;
-        $this->ticketFactory = $ticketFactory;
-        $this->sponsorTicketHelper = $sponsorTicketHelper;
-        $this->emails = $emails;
-        $this->purchaseTypeFactory = $purchaseTypeFactory;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->legacyModelFactory = $legacyModelFactory;
-        $this->ticketRepository = $ticketRepository;
-        $this->payboxFactory = $payboxFactory;
-        $this->eventActionHelper = $eventActionHelper;
+    public function __construct(
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly LoggerInterface $logger,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly ActionThrottling $actionThrottling,
+        private readonly TicketFactory $ticketFactory,
+        private readonly SponsorTicketHelper $sponsorTicketHelper,
+        private readonly Emails $emails,
+        private readonly PurchaseTypeFactory $purchaseTypeFactory,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly LegacyModelFactory $legacyModelFactory,
+        private readonly TicketRepository $ticketRepository,
+        private readonly PayboxFactory $payboxFactory,
+        private readonly EventActionHelper $eventActionHelper,
+    ) {
     }
 
     public function sponsorTicket(Request $request, $eventSlug)
@@ -323,7 +309,7 @@ class TicketController extends AbstractController
             'amount' => $amount,
             'tickets' => $this->ticketRepository->getByInvoiceWithDetail(
                 $invoice
-            )
+            ),
         ];
 
         if ($invoice->isFree()) {
@@ -453,7 +439,7 @@ class TicketController extends AbstractController
             'event' => $event,
             'invoice' => $invoice,
             'payboxResponse' => $payboxResponse,
-            'status' => $request->get('status')
+            'status' => $request->get('status'),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/GithubController.php
+++ b/sources/AppBundle/Controller/GithubController.php
@@ -11,10 +11,8 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 
 class GithubController extends AbstractController
 {
-    private ClientRegistry $clientRegistry;
-    public function __construct(ClientRegistry $clientRegistry)
+    public function __construct(private readonly ClientRegistry $clientRegistry)
     {
-        $this->clientRegistry = $clientRegistry;
     }
     /**
      * Link to this controller to start the "connect" process

--- a/sources/AppBundle/Controller/Legacy/Forum2008ConferenciersAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2008ConferenciersAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2008ConferenciersAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Legacy/Forum2008ResumesAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2008ResumesAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2008ResumesAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response
@@ -26,7 +23,7 @@ class Forum2008ResumesAction
 
         foreach ($sessions as $index => $session) {
             $sessions[$index]['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $sessions[$index]['journees'] = explode(" ", $session['journee']);
+            $sessions[$index]['journees'] = explode(" ", (string) $session['journee']);
         }
 
         return new Response($this->twig->render('legacy/forumphp2008/resumes.html.twig', [

--- a/sources/AppBundle/Controller/Legacy/Forum2008SessionsAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2008SessionsAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2008SessionsAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response
@@ -26,7 +23,7 @@ class Forum2008SessionsAction
 
         foreach ($sessions as $index => $session) {
             $sessions[$index]['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $sessions[$index]['journees'] = explode(" ", $session['journee']);
+            $sessions[$index]['journees'] = explode(" ", (string) $session['journee']);
         }
 
         return new Response($this->twig->render('legacy/forumphp2008/sessions.html.twig', [

--- a/sources/AppBundle/Controller/Legacy/Forum2009AgendaAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2009AgendaAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2009AgendaAction
 {
-    private Forum $forum;
-    private Environment $twig;
-
-    public function __construct(Forum $forum, Environment $twig)
-    {
-        $this->forum = $forum;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly Forum $forum,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Legacy/Forum2009ConferenciersAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2009ConferenciersAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2009ConferenciersAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Legacy/Forum2009ProjetsPhpAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2009ProjetsPhpAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2009ProjetsPhpAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response
@@ -33,7 +30,7 @@ class Forum2009ProjetsPhpAction
 
         foreach ($sessions as $index => $session) {
             $sessions[$index]['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $sessions[$index]['journees'] = explode(" ", $session['journee']);
+            $sessions[$index]['journees'] = explode(" ", (string) $session['journee']);
         }
 
         return new Response($this->twig->render('legacy/forumphp2009/projets-php.html.twig', [

--- a/sources/AppBundle/Controller/Legacy/Forum2009ResumesAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2009ResumesAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2009ResumesAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response
@@ -26,7 +23,7 @@ class Forum2009ResumesAction
 
         foreach ($sessions as $index => $session) {
             $sessions[$index]['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $sessions[$index]['journees'] = explode(" ", $session['journee']);
+            $sessions[$index]['journees'] = explode(" ", (string) $session['journee']);
         }
 
         return new Response($this->twig->render('legacy/forumphp2009/resumes.html.twig', [

--- a/sources/AppBundle/Controller/Legacy/Forum2009SessionsAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2009SessionsAction.php
@@ -11,13 +11,10 @@ use Twig\Environment;
 
 class Forum2009SessionsAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
-    public function __construct(AppelConferencier $appelConferencier, Environment $twig)
-    {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
+    ) {
     }
 
     public function __invoke(Request $request): Response
@@ -26,7 +23,7 @@ class Forum2009SessionsAction
 
         foreach ($sessions as $index => $session) {
             $sessions[$index]['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $sessions[$index]['journees'] = explode(" ", $session['journee']);
+            $sessions[$index]['journees'] = explode(" ", (string) $session['journee']);
         }
 
         return new Response($this->twig->render('legacy/forumphp2009/sessions.html.twig', [

--- a/sources/AppBundle/Controller/Legacy/Forum2016ConferenciersAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2016ConferenciersAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class Forum2016ConferenciersAction
 {
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
     public function __construct(
-        AppelConferencier $appelConferencier,
-        Environment $twig
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
     ) {
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -36,8 +31,8 @@ class Forum2016ConferenciersAction
                 }
 
                 if (!isset($conferenciers[$conferencier['conferencier_id']])) {
-                    $conferencier['prenom'] = ucfirst(strtolower($conferencier['prenom']));
-                    $conferencier['nom'] = strtoupper($conferencier['nom']);
+                    $conferencier['prenom'] = ucfirst(strtolower((string) $conferencier['prenom']));
+                    $conferencier['nom'] = strtoupper((string) $conferencier['nom']);
                     $conferenciers[$conferencier['conferencier_id']] = $conferencier;
                 }
 

--- a/sources/AppBundle/Controller/Legacy/Forum2016PlanningAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2016PlanningAction.php
@@ -12,18 +12,11 @@ use Twig\Environment;
 
 class Forum2016PlanningAction
 {
-    private Forum $forum;
-    private AppelConferencier $appelConferencier;
-    private Environment $twig;
-
     public function __construct(
-        Forum $forum,
-        AppelConferencier $appelConferencier,
-        Environment $twig
+        private readonly Forum $forum,
+        private readonly AppelConferencier $appelConferencier,
+        private readonly Environment $twig,
     ) {
-        $this->forum = $forum;
-        $this->appelConferencier = $appelConferencier;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Legacy/Forum2016SessionsAction.php
+++ b/sources/AppBundle/Controller/Legacy/Forum2016SessionsAction.php
@@ -12,18 +12,11 @@ use Twig\Environment;
 
 class Forum2016SessionsAction
 {
-    private AppelConferencier $appelConferencier;
-    private TranslatorInterface $translator;
-    private Environment $twig;
-
     public function __construct(
-        AppelConferencier $appelConferencier,
-        TranslatorInterface $translator,
-        Environment $twig
+        private readonly AppelConferencier $appelConferencier,
+        private readonly TranslatorInterface $translator,
+        private readonly Environment $twig,
     ) {
-        $this->appelConferencier = $appelConferencier;
-        $this->translator = $translator;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -38,7 +31,7 @@ class Forum2016SessionsAction
         ];
         foreach ($sessions as $session) {
             $session['conferenciers'] = $this->appelConferencier->obtenirConferenciersPourSession($session['session_id']);
-            $session['journees'] = explode(' ', $session['journee']);
+            $session['journees'] = explode(' ', (string) $session['journee']);
 
             if ('27' === date('d', (int) $session['debut'])) {
                 $journees[$day1key][] = $session;

--- a/sources/AppBundle/Controller/Legacy/LegacyEventAction.php
+++ b/sources/AppBundle/Controller/Legacy/LegacyEventAction.php
@@ -14,11 +14,8 @@ use Twig\Error\LoaderError;
 
 class LegacyEventAction
 {
-    private Environment $twig;
-
-    public function __construct(Environment $twig)
+    public function __construct(private readonly Environment $twig)
     {
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response
@@ -29,7 +26,7 @@ class LegacyEventAction
             Assertion::inArray($year, [2005, 2006, 2007, 2008, 2009]);
             Assertion::regex($page, '/[a-z0-9_]+/');
             $template = $this->twig->load(sprintf('legacy/forumphp%d/%s.html.twig', $year, $page));
-        } catch (AssertionFailedException|LoaderError $e) {
+        } catch (AssertionFailedException|LoaderError) {
             throw new NotFoundHttpException('Page introuvable');
         }
 

--- a/sources/AppBundle/Controller/LegacyController.php
+++ b/sources/AppBundle/Controller/LegacyController.php
@@ -29,63 +29,25 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class LegacyController extends AbstractController
 {
-    private TokenStorageInterface $tokenStorage;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private RequestStack $requestStack;
-
-    // Services utilisés dans les anciens controller (htdocs/pages/administration/*)
-    private EventRepository $eventRepository;
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-    private TicketTypeAvailability $ticketTypeAvailability;
-    private InvoiceService $invoiceService;
-    private InvoiceRepository $invoiceRepository;
-    private UrlGeneratorInterface $urlGenerator;
-    private EventStatsRepository $eventStatsRepository;
-    private TicketRepository $ticketRepository;
-    private UserRepository $userRepository;
-    private CompanyMemberRepository $companyMemberRepository;
-    private Mailer $mailer;
-    private SpeakerRepository $speakerRepository;
-    private TalkRepository $talkRepository;
-    // Fn des Services
-
-    private array $backOfficePages;
-
-    public function __construct(TokenStorageInterface $tokenStorage,
-                                AuthorizationCheckerInterface $authorizationChecker,
-                                RequestStack $requestStack,
-                                EventRepository $eventRepository,
-                                TicketEventTypeRepository $ticketEventTypeRepository,
-                                TicketTypeAvailability $ticketTypeAvailability,
-                                InvoiceService $invoiceService,
-                                InvoiceRepository $invoiceRepository,
-                                UrlGeneratorInterface $urlGenerator,
-                                EventStatsRepository $eventStatsRepository,
-                                TicketRepository $ticketRepository,
-                                UserRepository $userRepository,
-                                CompanyMemberRepository $companyMemberRepository,
-                                Mailer $mailer,
-                                SpeakerRepository $speakerRepository,
-                                TalkRepository $talkRepository,
-                                array $backOfficePages
+    public function __construct(
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly RequestStack $requestStack,
+        private readonly EventRepository $eventRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly TicketTypeAvailability $ticketTypeAvailability,
+        private readonly InvoiceService $invoiceService,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly EventStatsRepository $eventStatsRepository,
+        private readonly TicketRepository $ticketRepository,
+        private readonly UserRepository $userRepository,
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly Mailer $mailer,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly TalkRepository $talkRepository,
+        private readonly array $backOfficePages,
     ) {
-        $this->tokenStorage = $tokenStorage;
-        $this->authorizationChecker = $authorizationChecker;
-        $this->requestStack = $requestStack;
-        $this->backOfficePages = $backOfficePages;
-        $this->eventRepository = $eventRepository;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
-        $this->ticketTypeAvailability = $ticketTypeAvailability;
-        $this->invoiceService = $invoiceService;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->urlGenerator = $urlGenerator;
-        $this->eventStatsRepository = $eventStatsRepository;
-        $this->ticketRepository = $ticketRepository;
-        $this->userRepository = $userRepository;
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->mailer = $mailer;
-        $this->speakerRepository = $speakerRepository;
-        $this->talkRepository = $talkRepository;
     }
     public function void()
     {

--- a/sources/AppBundle/Controller/MembershipAdmin/ReportingAction.php
+++ b/sources/AppBundle/Controller/MembershipAdmin/ReportingAction.php
@@ -11,15 +11,10 @@ use Twig\Environment;
 
 class ReportingAction
 {
-    private StatisticsComputer $statisticsComputer;
-    private Environment $twig;
-
     public function __construct(
-        StatisticsComputer $statisticsComputer,
-        Environment $twig
+        private readonly StatisticsComputer $statisticsComputer,
+        private readonly Environment $twig,
     ) {
-        $this->statisticsComputer = $statisticsComputer;
-        $this->twig = $twig;
     }
 
     public function __invoke(Request $request): Response

--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -9,14 +9,10 @@ use PlanetePHP\FeedArticleRepository;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ArticlesController
+final readonly class ArticlesController
 {
-    private FeedArticleRepository $feedArticleRepository;
-
-    public function __construct(
-        FeedArticleRepository $feedArticleRepository
-    ) {
-        $this->feedArticleRepository = $feedArticleRepository;
+    public function __construct(private FeedArticleRepository $feedArticleRepository)
+    {
     }
 
     public function __invoke(Request $request): Response
@@ -68,7 +64,7 @@ final class ArticlesController
         }
 
         if (!str_starts_with($url, 'http')) {
-            $feedUrl = rtrim($article->getFeedUrl(), '/');
+            $feedUrl = rtrim((string) $article->getFeedUrl(), '/');
             $articleUrl = ltrim($url, '/');
 
             return implode('/', [$feedUrl, $articleUrl]);

--- a/sources/AppBundle/Controller/Planete/FeedsController.php
+++ b/sources/AppBundle/Controller/Planete/FeedsController.php
@@ -7,13 +7,10 @@ namespace AppBundle\Controller\Planete;
 use PlanetePHP\FeedRepository;
 use Symfony\Component\HttpFoundation\Response;
 
-final class FeedsController
+final readonly class FeedsController
 {
-    private FeedRepository $feedRepository;
-
-    public function __construct(FeedRepository $feedRepository)
+    public function __construct(private FeedRepository $feedRepository)
     {
-        $this->feedRepository = $feedRepository;
     }
 
     public function __invoke(): Response

--- a/sources/AppBundle/Controller/Website/BadgeController.php
+++ b/sources/AppBundle/Controller/Website/BadgeController.php
@@ -11,14 +11,10 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class BadgeController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    private string $storageDir;
-
-    public function __construct(RepositoryFactory $repositoryFactory,
-                                string $storageDir)
-    {
-        $this->repositoryFactory = $repositoryFactory;
-        $this->storageDir = $storageDir;
+    public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly string $storageDir,
+    ) {
     }
     public function badge($id)
     {

--- a/sources/AppBundle/Controller/Website/CmsPageController.php
+++ b/sources/AppBundle/Controller/Website/CmsPageController.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CmsPageController extends AbstractController
 {
-    private ViewRenderer $view;
-
-    public function __construct(ViewRenderer $view)
+    public function __construct(private readonly ViewRenderer $view)
     {
-        $this->view = $view;
     }
 
     public function display($code): Response

--- a/sources/AppBundle/Controller/Website/CompanyPublicProfileController.php
+++ b/sources/AppBundle/Controller/Website/CompanyPublicProfileController.php
@@ -17,21 +17,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CompanyPublicProfileController extends AbstractController
 {
-    private ViewRenderer $view;
-    private BadgesComputer $badgesComputer;
-    private RepositoryFactory $repositoryFactory;
-    private string $storageDir;
-
     public function __construct(
-        ViewRenderer $view,
-        BadgesComputer $badgesComputer,
-        RepositoryFactory $repositoryFactory,
-        string $storageDir
+        private readonly ViewRenderer $view,
+        private readonly BadgesComputer $badgesComputer,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly string $storageDir,
     ) {
-        $this->view = $view;
-        $this->badgesComputer = $badgesComputer;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->storageDir = $storageDir;
     }
 
     public function index($id, $slug): Response

--- a/sources/AppBundle/Controller/Website/CompanyPublicProfileListController.php
+++ b/sources/AppBundle/Controller/Website/CompanyPublicProfileListController.php
@@ -13,13 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CompanyPublicProfileListController extends AbstractController
 {
-    private ViewRenderer $view;
-    private RepositoryFactory $repositoryFactory;
-
-    public function __construct(ViewRenderer $view, RepositoryFactory $repositoryFactory)
-    {
-        $this->view = $view;
-        $this->repositoryFactory = $repositoryFactory;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly RepositoryFactory $repositoryFactory,
+    ) {
     }
 
     public function index(): Response

--- a/sources/AppBundle/Controller/Website/HomeController.php
+++ b/sources/AppBundle/Controller/Website/HomeController.php
@@ -24,26 +24,15 @@ class HomeController extends AbstractController
 {
     public const MAX_ARTICLES = 5;
     public const MAX_MEETUPS = 10;
-    private ViewRenderer $view;
-    private LoggerInterface $logger;
-    private RepositoryFactory $repositoryFactory;
-    private CacheItemPoolInterface $cache;
-    private SearchClient $client;
-    private bool $homeAlgoliaEnabled;
 
-    public function __construct(ViewRenderer $view,
-                                LoggerInterface $logger,
-                                RepositoryFactory $repositoryFactory,
-                                CacheItemPoolInterface $cache,
-                                SearchClient $client,
-                                bool $homeAlgoliaEnabled)
-    {
-        $this->view = $view;
-        $this->logger = $logger;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->cache = $cache;
-        $this->client = $client;
-        $this->homeAlgoliaEnabled = $homeAlgoliaEnabled;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly LoggerInterface $logger,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly CacheItemPoolInterface $cache,
+        private readonly SearchClient $client,
+        private readonly bool $homeAlgoliaEnabled,
+    ) {
     }
 
     public function display(): Response

--- a/sources/AppBundle/Controller/Website/HtmlSitemapController.php
+++ b/sources/AppBundle/Controller/Website/HtmlSitemapController.php
@@ -17,14 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class HtmlSitemapController extends AbstractController
 {
-    private ViewRenderer $view;
-    private RepositoryFactory $repositoryFactory;
-
-    public function __construct(ViewRenderer $view,
-                                RepositoryFactory $repositoryFactory
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly RepositoryFactory $repositoryFactory,
     ) {
-        $this->view = $view;
-        $this->repositoryFactory = $repositoryFactory;
     }
 
     public function display(): Response
@@ -46,7 +42,7 @@ class HtmlSitemapController extends AbstractController
 
         $pages = [];
         foreach ($leafs as $leaf) {
-            if (!$leaf['lien'] || str_starts_with($leaf['lien'], 'http')) {
+            if (!$leaf['lien'] || str_starts_with((string) $leaf['lien'], 'http')) {
                 continue;
             }
             $pages[] = [
@@ -75,7 +71,7 @@ class HtmlSitemapController extends AbstractController
 
             $members[] = [
                 'name' => $member->getCompanyName(),
-                'url' => $url
+                'url' => $url,
             ];
         }
         return $members;
@@ -94,7 +90,7 @@ class HtmlSitemapController extends AbstractController
 
             $news[] = [
                 'name' => $newsItem->getTitle(),
-                'url' => $url
+                'url' => $url,
             ];
         }
 
@@ -117,7 +113,7 @@ class HtmlSitemapController extends AbstractController
 
             $talks[] = [
                 'name' => $talk->getTitle(),
-                'url' => $url
+                'url' => $url,
             ];
         }
 

--- a/sources/AppBundle/Controller/Website/MeetupsController.php
+++ b/sources/AppBundle/Controller/Website/MeetupsController.php
@@ -11,17 +11,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class MeetupsController extends AbstractController
 {
-    private ViewRenderer $view;
-    private string $algoliaAppId;
-    private string $algoliaFrontendApikey;
-
-    public function __construct(ViewRenderer $view,
-                                string $algoliaAppId,
-                                string $algoliaFrontendApikey)
-    {
-        $this->view = $view;
-        $this->algoliaAppId = $algoliaAppId;
-        $this->algoliaFrontendApikey = $algoliaFrontendApikey;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly string $algoliaAppId,
+        private readonly string $algoliaFrontendApikey,
+    ) {
     }
 
     public function list(Request $request): Response

--- a/sources/AppBundle/Controller/Website/Member/CompanyController.php
+++ b/sources/AppBundle/Controller/Website/Member/CompanyController.php
@@ -15,15 +15,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CompanyController extends AbstractController
 {
-    private CompanyMemberRepository $companyMemberRepository;
-    private ViewRenderer $view;
-
     public function __construct(
-        CompanyMemberRepository $companyMemberRepository,
-        ViewRenderer            $view
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly ViewRenderer $view,
     ) {
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->view = $view;
     }
 
     public function __invoke(Request $request)
@@ -46,7 +41,7 @@ class CompanyController extends AbstractController
             try {
                 $this->companyMemberRepository->save($member);
                 $this->addFlash('notice', 'Les modifications ont bien été enregistrées.');
-            } catch (Exception $exception) {
+            } catch (Exception) {
                 $this->addFlash('error', 'Une erreur est survenue. Merci de nous contacter.');
             }
 

--- a/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
+++ b/sources/AppBundle/Controller/Website/Member/CompanyPublicProfileController.php
@@ -15,13 +15,10 @@ use Symfony\Component\HttpFoundation\Request;
 
 class CompanyPublicProfileController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    private string $storageDir;
-
-    public function __construct(RepositoryFactory $repositoryFactory, string $storageDir)
-    {
-        $this->repositoryFactory = $repositoryFactory;
-        $this->storageDir = $storageDir;
+    public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly string $storageDir,
+    ) {
     }
     public function index(Request $request)
     {

--- a/sources/AppBundle/Controller/Website/Member/MembersController.php
+++ b/sources/AppBundle/Controller/Website/Member/MembersController.php
@@ -28,36 +28,17 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 class MembersController extends AbstractController
 {
-    private CompanyMemberRepository $companyMemberRepository;
-    private UserRepository $userRepository;
-    private CompanyMemberInvitationRepository $companyMemberInvitationRepository;
-    private ViewRenderer $view;
-    private CollectionFilter $collectionFilter;
-    private UserCompany $userCompany;
-    private CsrfTokenManagerInterface $csrfTokenManager;
-    private InvitationMail $invitationMail;
-    private EventDispatcherInterface $eventDispatcher;
-
     public function __construct(
-        CompanyMemberRepository $companyMemberRepository,
-        UserRepository $userRepository,
-        CompanyMemberInvitationRepository $companyMemberInvitationRepository,
-        ViewRenderer $view,
-        CollectionFilter $collectionFilter,
-        UserCompany $userCompany,
-        CsrfTokenManagerInterface $csrfTokenManager,
-        InvitationMail $invitationMail,
-        EventDispatcherInterface $eventDispatcher
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly UserRepository $userRepository,
+        private readonly CompanyMemberInvitationRepository $companyMemberInvitationRepository,
+        private readonly ViewRenderer $view,
+        private readonly CollectionFilter $collectionFilter,
+        private readonly UserCompany $userCompany,
+        private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly InvitationMail $invitationMail,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->userRepository = $userRepository;
-        $this->companyMemberInvitationRepository = $companyMemberInvitationRepository;
-        $this->view = $view;
-        $this->collectionFilter = $collectionFilter;
-        $this->userCompany = $userCompany;
-        $this->csrfTokenManager = $csrfTokenManager;
-        $this->invitationMail = $invitationMail;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function __invoke(Request $request): Response
@@ -125,7 +106,7 @@ class MembersController extends AbstractController
         CompanyMember $company,
         CompanyMemberInvitation $invitation,
         CollectionInterface $users,
-        CollectionInterface $pendingInvitations
+        CollectionInterface $pendingInvitations,
     ): void {
         // Check if there is already a pending invitation for this email and this company
         $matchingUser = $this->collectionFilter->findOne($users, 'getEmail', $invitation->getEmail());
@@ -166,7 +147,7 @@ class MembersController extends AbstractController
 
     private function resendInvitation($emailToSend,
                                       CollectionInterface $pendingInvitations,
-                                      CompanyMember $company
+                                      CompanyMember $company,
     ): void {
         /** @var CompanyMemberInvitation $invitationToSend */
         $invitationToSend = $this->collectionFilter->findOne($pendingInvitations, 'getEmail', $emailToSend);
@@ -179,7 +160,7 @@ class MembersController extends AbstractController
     }
 
     private function promoteUser($emailToPromote,
-                                 CollectionInterface $users
+                                 CollectionInterface $users,
     ): void {
         /** @var User $user */
         $user = $this->collectionFilter->findOne($users, 'getEmail', $emailToPromote);
@@ -192,7 +173,7 @@ class MembersController extends AbstractController
     }
 
     private function disproveUser($emailToDisapprove,
-                                  CollectionInterface $users
+                                  CollectionInterface $users,
     ): void {
         /** @var User $user */
         $user = $this->collectionFilter->findOne($users, 'getEmail', $emailToDisapprove);
@@ -210,7 +191,7 @@ class MembersController extends AbstractController
         }
     }
 
-    private function removeUser($emailToRemove, CollectionInterface $users
+    private function removeUser($emailToRemove, CollectionInterface $users,
     ): void {
         /** @var User $user */
         $user = $this->collectionFilter->findOne($users, 'getEmail', $emailToRemove);

--- a/sources/AppBundle/Controller/Website/MemberController.php
+++ b/sources/AppBundle/Controller/Website/MemberController.php
@@ -19,21 +19,14 @@ class MemberController extends AbstractController
 {
     const DAYS_BEFORE_CALL_TO_UPDATE = 15;
 
-    private ViewRenderer $view;
-    private GeneralMeetingRepository $generalMeetingRepository;
-    private UserService $userService;
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-    private BadgesComputer $badgesComputer;
-    private RepositoryFactory $repositoryFactory;
-
-    public function __construct(ViewRenderer $view, GeneralMeetingRepository $generalMeetingRepository, UserService $userService, GeneralMeetingQuestionRepository $generalMeetingQuestionRepository, BadgesComputer $badgesComputer, RepositoryFactory $repositoryFactory)
-    {
-        $this->view = $view;
-        $this->generalMeetingRepository = $generalMeetingRepository;
-        $this->userService = $userService;
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
-        $this->badgesComputer = $badgesComputer;
-        $this->repositoryFactory = $repositoryFactory;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly GeneralMeetingRepository $generalMeetingRepository,
+        private readonly UserService $userService,
+        private readonly GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
+        private readonly BadgesComputer $badgesComputer,
+        private readonly RepositoryFactory $repositoryFactory,
+    ) {
     }
 
     public function index(): Response

--- a/sources/AppBundle/Controller/Website/MemberShipController.php
+++ b/sources/AppBundle/Controller/Website/MemberShipController.php
@@ -68,84 +68,38 @@ class MemberShipController extends AbstractController
 {
     use DbLoggerTrait;
 
-    private ViewRenderer $view;
-    private EventDispatcherInterface $eventDispatcher;
-    private TokenStorageInterface $tokenStorage;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private CsrfTokenManagerInterface $csrfTokenManager;
-    private UserFactory $userFactory;
-    private UserRepository $userRepository;
-    private CompanyMemberRepository $companyMemberRepository;
-    private UserService $userService;
-    private UserAuthenticatorInterface $userAuthenticator;
-    private FormLoginAuthenticator $formLoginAuthenticator;
-    private RepositoryFactory $repositoryFactory;
-    private InvitationMail $invitationMail;
-    private SubscriptionManagement $subscriptionManagement;
-    private LegacyModelFactory $legacyModelFactory;
-    private PayboxFactory $payboxFactory;
-    private LegacyClient $legacyClient;
-    private Mailer $mailer;
-    private GeneralMeetingRepository $generalMeetingRepository;
-    private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository;
-    private GeneralMeetingVoteRepository $generalMeetingVoteRepository;
-    private string $storageDir;
-    private UserPasswordHasherInterface $passwordHasher;
-
-    public function __construct(ViewRenderer $view,
-                                EventDispatcherInterface $eventDispatcher,
-                                TokenStorageInterface $tokenStorage,
-                                AuthorizationCheckerInterface $authorizationChecker,
-                                CsrfTokenManagerInterface $csrfTokenManager,
-                                UserFactory $userFactory,
-                                UserRepository $userRepository,
-                                CompanyMemberRepository $companyMemberRepository,
-                                UserService $userService,
-                                UserAuthenticatorInterface $userAuthenticatorInterface,
-                                FormLoginAuthenticator $formLoginAuthenticator,
-                                RepositoryFactory $repositoryFactory,
-                                InvitationMail $invitationMail,
-                                SubscriptionManagement $subscriptionManagement,
-                                LegacyModelFactory $legacyModelFactory,
-                                PayboxFactory $payboxFactory,
-                                LegacyClient $legacyClient,
-                                Mailer $mailer,
-                                GeneralMeetingRepository $generalMeetingRepository,
-                                GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
-                                GeneralMeetingVoteRepository $generalMeetingVoteRepository,
-                                string $storageDir,
-                                UserPasswordHasherInterface $passwordHasher
+    public function __construct(
+        private ViewRenderer $view,
+        private EventDispatcherInterface $eventDispatcher,
+        private TokenStorageInterface $tokenStorage,
+        private AuthorizationCheckerInterface $authorizationChecker,
+        private CsrfTokenManagerInterface $csrfTokenManager,
+        private UserFactory $userFactory,
+        private UserRepository $userRepository,
+        private CompanyMemberRepository $companyMemberRepository,
+        private UserService $userService,
+        private UserAuthenticatorInterface $userAuthenticator,
+        private FormLoginAuthenticator $formLoginAuthenticator,
+        private RepositoryFactory $repositoryFactory,
+        private InvitationMail $invitationMail,
+        private SubscriptionManagement $subscriptionManagement,
+        private LegacyModelFactory $legacyModelFactory,
+        private PayboxFactory $payboxFactory,
+        private LegacyClient $legacyClient,
+        private Mailer $mailer,
+        private GeneralMeetingRepository $generalMeetingRepository,
+        private GeneralMeetingQuestionRepository $generalMeetingQuestionRepository,
+        private GeneralMeetingVoteRepository $generalMeetingVoteRepository,
+        private string $storageDir,
+        private UserPasswordHasherInterface $passwordHasher,
     ) {
-        $this->view = $view;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->tokenStorage = $tokenStorage;
-        $this->authorizationChecker = $authorizationChecker;
-        $this->csrfTokenManager = $csrfTokenManager;
-        $this->userFactory = $userFactory;
-        $this->userRepository = $userRepository;
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->userService = $userService;
-        $this->userAuthenticator = $userAuthenticatorInterface;
-        $this->formLoginAuthenticator = $formLoginAuthenticator;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->invitationMail = $invitationMail;
-        $this->subscriptionManagement = $subscriptionManagement;
-        $this->legacyModelFactory = $legacyModelFactory;
-        $this->payboxFactory = $payboxFactory;
-        $this->legacyClient = $legacyClient;
-        $this->mailer = $mailer;
-        $this->generalMeetingRepository = $generalMeetingRepository;
-        $this->generalMeetingQuestionRepository = $generalMeetingQuestionRepository;
-        $this->generalMeetingVoteRepository = $generalMeetingVoteRepository;
-        $this->storageDir = $storageDir;
-        $this->passwordHasher = $passwordHasher;
     }
 
     public function becomeMember(): Response
     {
         return $this->view->render('site/become_member.html.twig', [
             'membership_fee_natural_person' => AFUP_COTISATION_PERSONNE_PHYSIQUE,
-            'membership_fee_legal_entity' => AFUP_COTISATION_PERSONNE_MORALE
+            'membership_fee_legal_entity' => AFUP_COTISATION_PERSONNE_MORALE,
         ]);
     }
 
@@ -171,7 +125,7 @@ class MemberShipController extends AbstractController
         }
 
         return $this->view->render('admin/association/membership/register.html.twig', [
-            'form' => $form->createView()
+            'form' => $form->createView(),
         ]);
     }
 
@@ -179,7 +133,7 @@ class MemberShipController extends AbstractController
     {
         $data = new CompanyMember();
         $data->setInvitations([
-            (new CompanyMemberInvitation())->setManager(true)
+            (new CompanyMemberInvitation())->setManager(true),
         ]);
 
         $subscribeForm = $this->createForm(CompanyMemberType::class, $data);
@@ -226,7 +180,7 @@ class MemberShipController extends AbstractController
         }
 
         return $this->view->render('site/company_membership/adhesion_entreprise.html.twig', [
-            'form' => $subscribeForm->createView()
+            'form' => $subscribeForm->createView(),
         ]);
     }
 
@@ -265,8 +219,8 @@ class MemberShipController extends AbstractController
                 'raison_sociale' => AFUP_RAISON_SOCIALE,
                 'adresse' => AFUP_ADRESSE,
                 'code_postal' => AFUP_CODE_POSTAL,
-                'ville' => AFUP_VILLE
-            ]
+                'ville' => AFUP_VILLE,
+            ],
         ]);
     }
 
@@ -348,7 +302,7 @@ class MemberShipController extends AbstractController
 
         return $this->view->render('site/company_membership/member_invitation.html.twig', [
             'company' => $company,
-            'form' => $userForm->createView()
+            'form' => $userForm->createView(),
         ]);
     }
 
@@ -438,7 +392,7 @@ class MemberShipController extends AbstractController
 
         return $this->view->render('admin/association/membership/member_contact_details.html.twig', [
             'title' => 'Mes coordonnées',
-            'form' => $userForm->createView()
+            'form' => $userForm->createView(),
         ]);
     }
 
@@ -659,15 +613,15 @@ class MemberShipController extends AbstractController
                                 ;
                             }
                         }]
-                    )
-                ]
+                    ),
+                ],
             ])
             ->add('presence', ChoiceType::class, [
                 'expanded' => true,
                 'choices' => [
                     'Je participe' => 1,
-                    'Je ne participe pas' => 2
-                ]
+                    'Je ne participe pas' => 2,
+                ],
             ])
             ->add('id_personne_avec_pouvoir', ChoiceType::class, [
                 'choices' => array_flip($generalMeetingRepository->getPowerSelectionList($latestDate, $user->getUsername())),
@@ -675,7 +629,7 @@ class MemberShipController extends AbstractController
                 'required' => false,
             ])
             ->add('save', SubmitType::class, [
-                'label' => 'Confirmer'
+                'label' => 'Confirmer',
             ])
             ->getForm();
 

--- a/sources/AppBundle/Controller/Website/NewsController.php
+++ b/sources/AppBundle/Controller/Website/NewsController.php
@@ -19,20 +19,12 @@ class NewsController extends AbstractController
 {
     public const ARTICLES_PER_PAGE = 5;
 
-    private ViewRenderer $view;
-    private AuthorizationCheckerInterface $authorizationChecker;
-    private RepositoryFactory $repositoryFactory;
-    private string $projectDir;
-
-    public function __construct(ViewRenderer $view,
-                                AuthorizationCheckerInterface $authorizationChecker,
-                                RepositoryFactory $repositoryFactory,
-                                string $projectDir)
-    {
-        $this->view = $view;
-        $this->authorizationChecker = $authorizationChecker;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->projectDir = $projectDir;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly string $projectDir,
+    ) {
     }
 
     public function display($code): Response

--- a/sources/AppBundle/Controller/Website/NewsletterController.php
+++ b/sources/AppBundle/Controller/Website/NewsletterController.php
@@ -15,23 +15,17 @@ use Symfony\Component\HttpFoundation\Response;
 
 class NewsletterController extends AbstractController
 {
-    private ViewRenderer $view;
-    private Mailchimp $mailchimp;
-    private string $mailchimpSubscribersList;
-
-    public function __construct(ViewRenderer $view,
-                                Mailchimp $mailchimp,
-                                string $mailchimpSubscribersList)
-    {
-        $this->view = $view;
-        $this->mailchimp = $mailchimp;
-        $this->mailchimpSubscribersList = $mailchimpSubscribersList;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly Mailchimp $mailchimp,
+        private readonly string $mailchimpSubscribersList,
+    ) {
     }
 
     public function subscribeForm(): Response
     {
         return $this->render('site/newsletter/subscribe.html.twig', [
-            'form' => $this->getSubscriberType()->createView()
+            'form' => $this->getSubscriberType()->createView(),
         ]);
     }
 
@@ -47,11 +41,11 @@ class NewsletterController extends AbstractController
                     $subscribeForm->getData()['email']
                 );
                 $success = true;
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $success = false;
             }
             return $this->view->render('site/newsletter/postsubscribe.html.twig', [
-                'success' => $success
+                'success' => $success,
             ]);
         }
 
@@ -63,7 +57,7 @@ class NewsletterController extends AbstractController
         return $this
             ->createForm(SubscriberType::class, null, [
                 'action' => $this->generateUrl('newsletter_subscribe'),
-                'method' => Request::METHOD_POST
+                'method' => Request::METHOD_POST,
             ])
         ;
     }

--- a/sources/AppBundle/Controller/Website/PayboxRedirectController.php
+++ b/sources/AppBundle/Controller/Website/PayboxRedirectController.php
@@ -12,11 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class PayboxRedirectController extends AbstractController
 {
-    private ViewRenderer $view;
-
-    public function __construct(ViewRenderer $view)
+    public function __construct(private readonly ViewRenderer $view)
     {
-        $this->view = $view;
     }
 
     public function index(Request $request, $type = 'success'): Response
@@ -26,7 +23,7 @@ class PayboxRedirectController extends AbstractController
         return $this->view->render('site/company_membership/paybox_redirect.html.twig', [
             'payboxResponse' => $payboxResponse,
             'status' => $request->get('status'),
-            'return_type' => $type
+            'return_type' => $type,
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Website/RssFeedController.php
+++ b/sources/AppBundle/Controller/Website/RssFeedController.php
@@ -12,10 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RssFeedController extends AbstractController
 {
-    private RepositoryFactory $repositoryFactory;
-    public function __construct(RepositoryFactory $repositoryFactory)
+    public function __construct(private readonly RepositoryFactory $repositoryFactory)
     {
-        $this->repositoryFactory = $repositoryFactory;
     }
     public function __invoke(): Response
     {

--- a/sources/AppBundle/Controller/Website/SecondaryMenuController.php
+++ b/sources/AppBundle/Controller/Website/SecondaryMenuController.php
@@ -12,10 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SecondaryMenuController extends AbstractController
 {
-    private RequestStack $requestStack;
-    public function __construct(RequestStack $requestStack)
+    public function __construct(private readonly RequestStack $requestStack)
     {
-        $this->requestStack = $requestStack;
     }
     public function display(Request $request): Response
     {
@@ -49,7 +47,7 @@ class SecondaryMenuController extends AbstractController
     {
         $url = $masterRequest->getUri();
 
-        $pattern = '/' . preg_quote($feuille['lien'], '/') . '/';
+        $pattern = '/' . preg_quote((string) $feuille['lien'], '/') . '/';
 
         if (preg_match($pattern, $url)) {
             return true;
@@ -57,7 +55,7 @@ class SecondaryMenuController extends AbstractController
 
         $isCurrent = false;
         if ($feuille['patterns']) {
-            foreach (explode(PHP_EOL, $feuille['patterns']) as $pattern) {
+            foreach (explode(PHP_EOL, (string) $feuille['patterns']) as $pattern) {
                 $pattern = trim($pattern);
                 if ($pattern === '') {
                     continue;

--- a/sources/AppBundle/Controller/Website/StaticController.php
+++ b/sources/AppBundle/Controller/Website/StaticController.php
@@ -13,13 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class StaticController extends AbstractController
 {
-    private ViewRenderer $view;
-    private string $superAperoCsvUrl;
-
-    public function __construct(ViewRenderer $view, string $superAperoCsvUrl)
-    {
-        $this->view = $view;
-        $this->superAperoCsvUrl = $superAperoCsvUrl;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly string $superAperoCsvUrl,
+    ) {
     }
 
     public function offices(): Response
@@ -42,18 +39,18 @@ class StaticController extends AbstractController
         $aperos = [];
 
         while (false !== ($row = fgetcsv($fp))) {
-            if (trim($row[0]) === '') {
+            if (trim((string) $row[0]) === '') {
                 continue;
             }
 
             [$code, $meeetupId, $content] = $row;
 
             $apero = [
-                'code' => mb_strtolower($code),
+                'code' => mb_strtolower((string) $code),
                 'content' => $content,
             ];
 
-            if (strlen(trim($meeetupId)) !== 0) {
+            if (strlen(trim((string) $meeetupId)) !== 0) {
                 $apero['meetup_id'] = $meeetupId;
             }
 

--- a/sources/AppBundle/Controller/Website/TalksController.php
+++ b/sources/AppBundle/Controller/Website/TalksController.php
@@ -22,27 +22,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class TalksController extends AbstractController
 {
-    private ViewRenderer $view;
-    private RepositoryFactory $repositoryFactory;
-    private JoindinComments $joindinComments;
-    private JoindinTalk $joindinTalk;
-    private string $algoliaAppId;
-    private string $algoliaFrontendApikey;
-
     public function __construct(
-        ViewRenderer $view,
-        RepositoryFactory $repositoryFactory,
-        JoindinComments $joindinComments,
-        JoindinTalk $joindinTalk,
-        string $algoliaAppId,
-        string $algoliaFrontendApikey
+        private readonly ViewRenderer $view,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly JoindinComments $joindinComments,
+        private readonly JoindinTalk $joindinTalk,
+        private readonly string $algoliaAppId,
+        private readonly string $algoliaFrontendApikey,
     ) {
-        $this->view = $view;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->joindinComments = $joindinComments;
-        $this->joindinTalk = $joindinTalk;
-        $this->algoliaAppId = $algoliaAppId;
-        $this->algoliaFrontendApikey = $algoliaFrontendApikey;
     }
 
     public function list(Request $request): Response

--- a/sources/AppBundle/Controller/Website/TechletterController.php
+++ b/sources/AppBundle/Controller/Website/TechletterController.php
@@ -13,17 +13,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TechletterController extends AbstractController
 {
-    private ViewRenderer $view;
-    private RepositoryFactory $repositoryFactory;
-    private string $mailchimpTechletterWebhookKey;
-
-    public function __construct(ViewRenderer $view,
-                                RepositoryFactory $repositoryFactory,
-                                string $mailchimpTechletterWebhookKey)
-    {
-        $this->view = $view;
-        $this->repositoryFactory = $repositoryFactory;
-        $this->mailchimpTechletterWebhookKey = $mailchimpTechletterWebhookKey;
+    public function __construct(
+        private readonly ViewRenderer $view,
+        private readonly RepositoryFactory $repositoryFactory,
+        private readonly string $mailchimpTechletterWebhookKey,
+    ) {
     }
 
     public function index(): Response

--- a/sources/AppBundle/Controller/Website/TechnoWatchController.php
+++ b/sources/AppBundle/Controller/Website/TechnoWatchController.php
@@ -11,14 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TechnoWatchController extends AbstractController
 {
-    private string $technoWatchCalendarKey;
-    private string $technoWatchCalendarUrl;
-
-    public function __construct(string $technoWatchCalendarKey,
-                                string $technoWatchCalendarUrl)
-    {
-        $this->technoWatchCalendarKey = $technoWatchCalendarKey;
-        $this->technoWatchCalendarUrl = $technoWatchCalendarUrl;
+    public function __construct(
+        private readonly string $technoWatchCalendarKey,
+        private readonly string $technoWatchCalendarUrl,
+    ) {
     }
 
     public function calendar(Request $request): Response

--- a/sources/AppBundle/Email/Emails.php
+++ b/sources/AppBundle/Email/Emails.php
@@ -14,13 +14,10 @@ use InvalidArgumentException;
 
 class Emails
 {
-    private Mailer $mailer;
-
     private array $tempFiles = [];
 
-    public function __construct(Mailer $mailer)
+    public function __construct(private readonly Mailer $mailer)
     {
-        $this->mailer = $mailer;
     }
 
     public function __destruct()

--- a/sources/AppBundle/Email/Mailer/Adapter/PhpMailerAdapter.php
+++ b/sources/AppBundle/Email/Mailer/Adapter/PhpMailerAdapter.php
@@ -12,19 +12,13 @@ use UnexpectedValueException;
 
 class PhpMailerAdapter implements MailerAdapter
 {
-    private ?string $smtpServer;
-    private ?string $tls;
-    private ?string $username;
-    private ?string $password;
-    private ?string $port;
-
-    public function __construct($smtpServer, $tls, $username, $password, $port)
-    {
-        $this->smtpServer = $smtpServer;
-        $this->tls = $tls;
-        $this->username = $username;
-        $this->password = $password;
-        $this->port = $port;
+    public function __construct(
+        private readonly ?string $smtpServer,
+        private readonly ?string $tls,
+        private readonly ?string $username,
+        private readonly ?string $password,
+        private readonly ?string $port,
+    ) {
     }
 
     public static function createFromConfiguration(Configuration $configuration): self

--- a/sources/AppBundle/Email/Mailer/Attachment.php
+++ b/sources/AppBundle/Email/Mailer/Attachment.php
@@ -6,24 +6,18 @@ namespace AppBundle\Email\Mailer;
 
 class Attachment
 {
-    /** @var string */
-    private $name;
-    /** @var string */
-    private $encoding;
-    /** @var string */
-    private $path;
-    /** @var string */
-    private $type;
-
     /**
      * @param string $name
+     * @param string $encoding
+     * @param string $path
+     * @param string $type
      */
-    public function __construct($path, $name, $encoding, $type)
-    {
-        $this->path = $path;
-        $this->name = $name;
-        $this->encoding = $encoding;
-        $this->type = $type;
+    public function __construct(
+        private $path,
+        private $name,
+        private $encoding,
+        private $type,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Email/Mailer/MailUser.php
+++ b/sources/AppBundle/Email/Mailer/MailUser.php
@@ -9,19 +9,14 @@ class MailUser
     const DEFAULT_SENDER_NAME = 'Bureau AFUP';
     const DEFAULT_SENDER_EMAIL = 'bureau@afup.org';
 
-    /** @var string */
-    private $email;
-    /** @var string */
-    private $name;
-
     /**
      * @param string $email
      * @param string $name
      */
-    public function __construct($email, $name = '')
-    {
-        $this->email = $email;
-        $this->name = $name;
+    public function __construct(
+        private $email,
+        private $name = '',
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Email/Mailer/Mailer.php
+++ b/sources/AppBundle/Email/Mailer/Mailer.php
@@ -14,23 +14,17 @@ use Twig\Environment;
  */
 class Mailer
 {
-    private LoggerInterface $logger;
-    private Environment $twig;
-    private MailerAdapter $adapter;
     /** @var string|null */
     private $forcedRecipient;
     /** @var string[] */
-    private array $defaultBccs;
+    private readonly array $defaultBccs;
 
     public function __construct(
-        LoggerInterface $logger,
-        Environment $twig,
-        MailerAdapter $adapter,
-        Configuration $configuration
+        private readonly LoggerInterface $logger,
+        private readonly Environment $twig,
+        private readonly MailerAdapter $adapter,
+        Configuration $configuration,
     ) {
-        $this->logger = $logger;
-        $this->twig = $twig;
-        $this->adapter = $adapter;
         $this->forcedRecipient = $configuration->obtenir('mailer_force_recipients');
         $defaultBccs = $configuration->obtenir('mailer_bcc');
         $this->defaultBccs = is_array($defaultBccs) ? $defaultBccs : [$defaultBccs];

--- a/sources/AppBundle/Email/Mailer/Message.php
+++ b/sources/AppBundle/Email/Mailer/Message.php
@@ -6,15 +6,12 @@ namespace AppBundle\Email\Mailer;
 
 class Message
 {
-    private ?MailUser $from;
     /** @var MailUser[] */
     private ?array $recipients = null;
     /** @var MailUser[] */
     private array $cc = [];
     /** @var MailUser[] */
     private array $bcc = [];
-    /** @var string */
-    private $subject;
     /** @var string */
     private $content = '';
     /** @var bool */
@@ -25,10 +22,11 @@ class Message
     /**
      * @param string $subject
      */
-    public function __construct($subject, MailUser $from = null, MailUser ...$recipients)
-    {
-        $this->subject = $subject;
-        $this->from = $from;
+    public function __construct(
+        private $subject,
+        private ?MailUser $from = null,
+        MailUser ...$recipients,
+    ) {
         foreach ($recipients as $recipient) {
             $this->addRecipient($recipient);
         }

--- a/sources/AppBundle/Event/Form/EventCompareSelectType.php
+++ b/sources/AppBundle/Event/Form/EventCompareSelectType.php
@@ -15,7 +15,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EventCompareSelectType extends AbstractType
 {
-    private EventHelper $eventHelper;
+    private readonly EventHelper $eventHelper;
 
     public function __construct()
     {
@@ -48,7 +48,7 @@ class EventCompareSelectType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
         $resolver->setRequired([
             'events',

--- a/sources/AppBundle/Event/Form/EventSelectType.php
+++ b/sources/AppBundle/Event/Form/EventSelectType.php
@@ -16,12 +16,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class EventSelectType extends AbstractType
 {
-    private EventRepository $eventRepository;
-    private EventHelper $eventHelper;
+    private readonly EventHelper $eventHelper;
 
-    public function __construct(EventRepository $eventRepository)
+    public function __construct(private readonly EventRepository $eventRepository)
     {
-        $this->eventRepository = $eventRepository;
         $this->eventHelper = new EventHelper();
     }
 
@@ -47,7 +45,7 @@ class EventSelectType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Event::class,
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/EventType.php
+++ b/sources/AppBundle/Event/Form/EventType.php
@@ -25,12 +25,12 @@ class EventType extends AbstractType
         $builder
             ->add('title', TextType::class, [
                 'label' => 'Titre de l\'événément',
-                'constraints' => [new Assert\NotBlank(['message' => 'Titre du forum manquant'])]
+                'constraints' => [new Assert\NotBlank(['message' => 'Titre du forum manquant'])],
             ])
             ->add('path', TextType::class, [
                 'label' => 'Chemin du template',
                 'help' => 'Le path sert également à déterminer le nom du template de mail à utiliser sur mandrill, sous la forme confirmation-inscription-{PATH}',
-                'constraints' => [new Assert\NotBlank()]
+                'constraints' => [new Assert\NotBlank()],
             ])
             ->add('logoUrl', UrlType::class, [
                 'label' => 'URL du logo de l\'événement',
@@ -38,7 +38,7 @@ class EventType extends AbstractType
             ])
             ->add('seats', NumberType::class, [
                 'label' => 'Nombre de places',
-                'constraints' => [new Assert\NotBlank(['message' => 'Nombre de places manquant'])]
+                'constraints' => [new Assert\NotBlank(['message' => 'Nombre de places manquant'])],
             ])
             ->add('placeName', TextType::class, [
                 'label' => 'Nom du lieu',
@@ -120,7 +120,7 @@ class EventType extends AbstractType
                 'required' => false,
             ])
             ->add('CFP', EventCFPTextType::class, [
-                'label' => false
+                'label' => false,
             ])
             ->add('speakersDinerEnabled', CheckboxType::class, [
                 'label' => 'Activer le repas des speakers',
@@ -135,7 +135,7 @@ class EventType extends AbstractType
                 'label' => 'Liste des coupons',
                 'attr' => [
                     'placeholder' => 'Ici c\'est une liste de coupons séparées par des virgules',
-                    'title' => 'Ici c\'est une liste de coupons séparées par des virgules'
+                    'title' => 'Ici c\'est une liste de coupons séparées par des virgules',
                 ],
                 'required' => false,
             ])
@@ -149,24 +149,24 @@ class EventType extends AbstractType
                 'required' => false,
                 'mapped' => false,
                 'constraints' => [
-                    new Assert\File(['mimeTypes'=> 'application/pdf'])
-                ]
+                    new Assert\File(['mimeTypes'=> 'application/pdf']),
+                ],
             ])
             ->add('sponsor_file_fr', FileType::class, [
                 'label' => ' Dossier de sponsoring (FR)',
                 'required' => false,
                 'mapped' => false,
                 'constraints' => [
-                    new Assert\File(['mimeTypes'=> 'application/pdf'])
-                ]
+                    new Assert\File(['mimeTypes'=> 'application/pdf']),
+                ],
             ])
             ->add('sponsor_file_en', FileType::class, [
                 'label' => 'Dossier de sponsoring (EN)',
                 'required' => false,
                 'mapped' => false,
                 'constraints' => [
-                    new Assert\File(['mimeTypes'=> 'application/pdf'])
-                ]
+                    new Assert\File(['mimeTypes'=> 'application/pdf']),
+                ],
             ])
         ;
     }

--- a/sources/AppBundle/Event/Form/GithubUserFormData.php
+++ b/sources/AppBundle/Event/Form/GithubUserFormData.php
@@ -10,9 +10,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 class GithubUserFormData
 {
     /**
-     * @Assert\NotNull(message="L'utilisateur n'existe pas")
      * @var null|GithubUser
      */
+    #[Assert\NotNull(message: "L'utilisateur n'existe pas")]
     public $user;
 
     /**

--- a/sources/AppBundle/Event/Form/GithubUserType.php
+++ b/sources/AppBundle/Event/Form/GithubUserType.php
@@ -29,10 +29,10 @@ class GithubUserType extends AbstractType
                 'constraints' => [
                     new UniqueEntity([
                         'repository' => $options['github_user_repository'],
-                        'fields' => ['login']
-                    ])
+                        'fields' => ['login'],
+                    ]),
                 ],
-                'invalid_message' => 'Impossible de charger les informations de l\'utilisateur GitHub.'
+                'invalid_message' => 'Impossible de charger les informations de l\'utilisateur GitHub.',
             ])
             ->add('afupCrew', CheckboxType::class, [
                 'required' => false,
@@ -78,7 +78,7 @@ class GithubUserType extends AbstractType
             ->setAllowedTypes('github_user_repository', GithubUserRepository::class)
             ->setRequired([
                 'github_client',
-                'github_user_repository'
+                'github_user_repository',
             ])
         ;
     }

--- a/sources/AppBundle/Event/Form/LeadType.php
+++ b/sources/AppBundle/Event/Form/LeadType.php
@@ -29,14 +29,14 @@ class LeadType extends AbstractType
             ->add('email', EmailType::class)
             ->add('language', ChoiceType::class, [
                 'choices' => ['fr' => 'fr', 'en' => 'en'],
-                'multiple' => false
+                'multiple' => false,
             ])
             ->add('recaptcha', EWZRecaptchaType::class, [
                 'label' => 'Vérification',
                 'mapped' => false,
                 'constraints' => [
-                    new RecaptchaIsValid()
-                ]
+                    new RecaptchaIsValid(),
+                ],
             ])
         ;
     }
@@ -44,7 +44,7 @@ class LeadType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => Lead::class
+            'data_class' => Lead::class,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/PurchaseType.php
+++ b/sources/AppBundle/Event/Form/PurchaseType.php
@@ -24,14 +24,10 @@ class PurchaseType extends AbstractType
 {
     const MAX_NB_PERSONNES = 15;
 
-    private Pays $country;
-
-    private TokenStorageInterface $tokenStorage;
-
-    public function __construct(Pays $pays, TokenStorageInterface $tokenStorage)
-    {
-        $this->country = $pays;
-        $this->tokenStorage = $tokenStorage;
+    public function __construct(
+        private readonly Pays $country,
+        private readonly TokenStorageInterface $tokenStorage,
+    ) {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -49,7 +45,7 @@ class PurchaseType extends AbstractType
                 'multiple' => false,
                 'expanded' => false,
                 'mapped' => false,
-                'data' => 1
+                'data' => 1,
             ])
             ->add('tickets', CollectionType::class, [
                 'entry_type' => TicketType::class,
@@ -61,16 +57,16 @@ class PurchaseType extends AbstractType
                     'is_cfp_submitter' => $options['is_cfp_submitter'],
                     'special_price_token' => $options['special_price_token'],
                     'error_bubbling' => false,
-                ]
+                ],
             ])
             ->add('paymentType', ChoiceType::class, [
                 'label' => 'Règlement',
                 'choices' => [
                     'Carte bancaire' => Ticket::PAYMENT_CREDIT_CARD,
-                    'Virement' => Ticket::PAYMENT_BANKWIRE
+                    'Virement' => Ticket::PAYMENT_BANKWIRE,
                 ],
                 'expanded' => true,
-                'multiple' => false
+                'multiple' => false,
             ])
             ->add('firstname', TextType::class)
             ->add('lastname', TextType::class)
@@ -81,12 +77,12 @@ class PurchaseType extends AbstractType
             ->add('city', TextType::class)
             ->add('countryId', ChoiceType::class, [
                 'label' => 'Country',
-                'choices' => array_flip($this->country->obtenirPays())
+                'choices' => array_flip($this->country->obtenirPays()),
             ])
             ->add('companyCitation', CheckboxType::class, [
                 'label'    => 'J\'accepte que ma société soit citée comme participant à la conférence',
                 'required' => false,
-                'mapped' => false
+                'mapped' => false,
             ])
             ->add('cgv', CheckboxType::class, [
                 'required' => true,
@@ -100,7 +96,7 @@ class PurchaseType extends AbstractType
             ->add('newsletterAfup', CheckboxType::class, [
                 'label' => 'Je souhaite être tenu au courant des rencontres de l\'AFUP sur des sujets afférents à PHP',
                 'required' => false,
-                'mapped' => false
+                'mapped' => false,
             ])
         ;
     }

--- a/sources/AppBundle/Event/Form/RoomType.php
+++ b/sources/AppBundle/Event/Form/RoomType.php
@@ -23,7 +23,7 @@ class RoomType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => Room::class
+            'data_class' => Room::class,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/SpeakerFormData.php
+++ b/sources/AppBundle/Event/Form/SpeakerFormData.php
@@ -11,25 +11,25 @@ use Symfony\Component\Validator\Constraints as Assert;
 class SpeakerFormData
 {
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     public $civility;
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     public $firstname;
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     public $lastname;
     /**
-     * @Assert\NotBlank()
-     * @Assert\Email()
      * @var string
      */
+    #[Assert\NotBlank]
+    #[Assert\Email]
     public $email;
     /**
      * @var string
@@ -40,9 +40,9 @@ class SpeakerFormData
      */
     public $locality;
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     public $biography;
     /**
      * @var string
@@ -56,9 +56,9 @@ class SpeakerFormData
     public ?string $bluesky = null;
 
     /**
-     * @Assert\File(mimeTypes={"image/jpeg","image/png"})
      * @var UploadedFile|null
      */
+    #[Assert\File(mimeTypes: ['image/jpeg', 'image/png'])]
     public $photoFile;
 
     /**

--- a/sources/AppBundle/Event/Form/SpeakerType.php
+++ b/sources/AppBundle/Event/Form/SpeakerType.php
@@ -30,18 +30,11 @@ class SpeakerType extends AbstractType
     public const OPT_PHOTO_REQUIRED = 'photo_required';
     public const OPT_USER_GITHUB = 'user_github';
 
-    private GithubUserRepository $githubUserRepository;
-    private SpeakerRepository $speakerRepository;
-    private TokenStorageInterface $tokenStorage;
-
     public function __construct(
-        GithubUserRepository $githubUserRepository,
-        SpeakerRepository $speakerRepository,
-        TokenStorageInterface $tokenStorage
+        private readonly GithubUserRepository $githubUserRepository,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly TokenStorageInterface $tokenStorage,
     ) {
-        $this->githubUserRepository = $githubUserRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->tokenStorage = $tokenStorage;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -72,7 +65,7 @@ class SpeakerType extends AbstractType
                         'property_path' => 'githubUser',
                         'label' => 'Utilisateur GitHub',
                         'required' => false,
-                        'choice_label' => fn (GithubUser $user) => $user->getLabel(),
+                        'choice_label' => fn (GithubUser $user): string => $user->getLabel(),
                         'choice_value' => function ($choice) {
                             if ($choice instanceof GithubUser) {
                                 return $choice->getId();

--- a/sources/AppBundle/Event/Form/SponsorTicketType.php
+++ b/sources/AppBundle/Event/Form/SponsorTicketType.php
@@ -22,17 +22,17 @@ class SponsorTicketType extends AbstractType
                 'label' => 'Civilité',
                 'choices' => [
                     'M.' => 'M.',
-                    'Mme' => 'Mme'
-                ]
+                    'Mme' => 'Mme',
+                ],
             ])
             ->add('firstname', TextType::class, [
-                'label' => 'Prénom'
+                'label' => 'Prénom',
             ])
             ->add('lastname', TextType::class, [
-                'label' => 'Nom'
+                'label' => 'Nom',
             ])
             ->add('email', EmailType::class, [
-                'label' => 'Email'
+                'label' => 'Email',
             ]);
 
         if ($options['with_transport']) {
@@ -52,7 +52,7 @@ class SponsorTicketType extends AbstractType
                     'placeholder' => '',
                     'required' => true,
                     'constraints' => [new NotBlank()],
-                    'choices' => array_flip(Ticket::TRANSPORT_DISTANCES)
+                    'choices' => array_flip(Ticket::TRANSPORT_DISTANCES),
                 ]);
         }
     }
@@ -61,7 +61,7 @@ class SponsorTicketType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Ticket::class,
-            'with_transport' => false
+            'with_transport' => false,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/SponsorTokenType.php
+++ b/sources/AppBundle/Event/Form/SponsorTokenType.php
@@ -19,18 +19,18 @@ class SponsorTokenType extends AbstractType
     {
         $builder
             ->add('company', TextType::class, [
-                'label' => 'Sponsor (société)'
+                'label' => 'Sponsor (société)',
             ])
             ->add('contactEmail', EmailType::class, [
-                'label' => 'Email de contact'
+                'label' => 'Email de contact',
             ])
             ->add('token', TextType::class)
             ->add('maxInvitations', IntegerType::class, [
-                'label' => 'Nombre d\'invitations'
+                'label' => 'Nombre d\'invitations',
             ])
             ->add('qrCodesScannerAvailable', CheckboxType::class, [
                 'label' => 'Autoriser le scan de QR Codes',
-                'required' => false
+                'required' => false,
             ])
         ;
     }
@@ -38,7 +38,7 @@ class SponsorTokenType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => SponsorTicket::class
+            'data_class' => SponsorTicket::class,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/TalkType.php
+++ b/sources/AppBundle/Event/Form/TalkType.php
@@ -38,7 +38,7 @@ class TalkType extends AbstractType
                 'choices' => [
                     'Conférence plénière (40 mn)' => Talk::TYPE_FULL_LONG,
                     'Conférence plénière (20 mn)' => Talk::TYPE_FULL_SHORT,
-                ]
+                ],
             ])
             ->add('skill', ChoiceType::class, [
                 'label' => 'Niveau requis',
@@ -47,7 +47,7 @@ class TalkType extends AbstractType
                     'Intermédiaire' => Talk::SKILL_MEDIOR,
                     'Avancé' => Talk::SKILL_SENIOR,
                     'N/A' => Talk::SKILL_NA,
-                ]
+                ],
             ]);
 
         if (!$options[self::IS_AFUP_DAY]) {
@@ -63,13 +63,13 @@ class TalkType extends AbstractType
 
         $builder->add('needsMentoring', CheckboxType::class, [
                 'label' => "Je souhaite profiter du programme d'accompagnement des jeunes speakers",
-                'required' => false
+                'required' => false,
             ])
             ->add('codeOfConduct', CheckboxType::class, [
                 'label' => 'J\'accepte le code de conduite et les conditions générales de participation (1)',
                 'mapped' => false,
                 'required' => true,
-                'data' => $options[self::OPT_COC_CHECKED]
+                'data' => $options[self::OPT_COC_CHECKED],
             ])
             ->add('hasAllowedToSharingWithLocalOffices', ChoiceType::class, [
                 'choices' => [
@@ -79,7 +79,7 @@ class TalkType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'label' => 'Autoriser l’AFUP à transmettre ma proposition de conférence à ses antennes locales ?',
-                'help' => 'cfp_propose_workshop'
+                'help' => 'cfp_propose_workshop',
             ]);
     }
 

--- a/sources/AppBundle/Event/Form/TicketSpecialPriceType.php
+++ b/sources/AppBundle/Event/Form/TicketSpecialPriceType.php
@@ -23,8 +23,8 @@ class TicketSpecialPriceType extends AbstractType
             ->add('token', TextType::class, [
                 'constraints' => [
                     new NotBlank(),
-                    new Length(['max' => 255])
-                ]
+                    new Length(['max' => 255]),
+                ],
             ])
             ->add('dateStart', DateType::class, [
                 'label' => 'Date de début',
@@ -35,15 +35,15 @@ class TicketSpecialPriceType extends AbstractType
             ->add('price', IntegerType::class, [
                 'label' => 'Prix (TTC)',
                 'constraints' => [
-                    new GreaterThan(['value' => 0])
-                ]
+                    new GreaterThan(['value' => 0]),
+                ],
             ])
             ->add('description', TextType::class, [
                 'label' => 'Description (interne)',
                 'constraints' => [
                     new NotBlank(),
-                    new Length(['max' => 255])
-                ]
+                    new Length(['max' => 255]),
+                ],
             ])
         ;
     }
@@ -51,7 +51,7 @@ class TicketSpecialPriceType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'data_class' => TicketSpecialPrice::class
+            'data_class' => TicketSpecialPrice::class,
         ]);
     }
 }

--- a/sources/AppBundle/Event/Form/TicketType.php
+++ b/sources/AppBundle/Event/Form/TicketType.php
@@ -29,30 +29,15 @@ class TicketType extends AbstractType
     const MEMBER_PERSONAL = 1;
     const MEMBER_CORPORATE = 2;
 
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-
-    private EventRepository $eventRepository;
-
-    private TicketTypeAvailability $ticketTypeAvailability;
-
-    private TicketSpecialPriceRepository $ticketSpecialPriceRepository;
-
-    private TicketTypeRepository $ticketTypeRepository;
-
-    private AntennesCollection $antennesCollection;
+    private readonly AntennesCollection $antennesCollection;
 
     public function __construct(
-        EventRepository $eventRepository,
-        TicketEventTypeRepository $ticketEventTypeRepository,
-        TicketTypeAvailability $ticketTypeAvailability,
-        TicketSpecialPriceRepository $ticketSpecialPriceRepository,
-        TicketTypeRepository $ticketTypeRepository
+        private readonly EventRepository $eventRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly TicketTypeAvailability $ticketTypeAvailability,
+        private readonly TicketSpecialPriceRepository $ticketSpecialPriceRepository,
+        private readonly TicketTypeRepository $ticketTypeRepository,
     ) {
-        $this->eventRepository = $eventRepository;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
-        $this->ticketTypeAvailability = $ticketTypeAvailability;
-        $this->ticketSpecialPriceRepository = $ticketSpecialPriceRepository;
-        $this->ticketTypeRepository = $ticketTypeRepository;
         $this->antennesCollection = new AntennesCollection();
     }
 
@@ -74,21 +59,21 @@ class TicketType extends AbstractType
                 'label' => 'Civilité',
                 'choices' => [
                     'M.' => 'M.',
-                    'Mme' => 'Mme'
-                ]
+                    'Mme' => 'Mme',
+                ],
             ])
             ->add('firstname', TextType::class, [
-                'label' => 'Prénom'
+                'label' => 'Prénom',
             ])
             ->add('lastname', TextType::class, [
-                'label' => 'Nom'
+                'label' => 'Nom',
             ])
             ->add('email', EmailType::class, [
-                'label' => 'Email'
+                'label' => 'Email',
             ])
             ->add('phoneNumber', TextType::class, [
                 'label' => 'Téléphone',
-                'required' => false
+                'required' => false,
             ])
             ->add('nearestOffice', ChoiceType::class, [
                 'label' => 'Antenne de prédilection',
@@ -141,7 +126,7 @@ class TicketType extends AbstractType
                         'data-members-only' => (int) $type->getTicketType()->getIsRestrictedToMembers(),
                         'data-max-tickets' => $type->getMaxTickets(),
                         'data-stock' => $this->ticketTypeAvailability->getStock($type, $event),
-                        'data-label' => $type->getTicketType()->getPrettyName()
+                        'data-label' => $type->getTicketType()->getPrettyName(),
                     ];
 
                     if (
@@ -152,7 +137,7 @@ class TicketType extends AbstractType
                         $attr['disabled'] = 'disabled';
                     }
                     return $attr;
-                }
+                },
             ])
             ;
         });

--- a/sources/AppBundle/Event/Invoice/InvoiceService.php
+++ b/sources/AppBundle/Event/Invoice/InvoiceService.php
@@ -11,15 +11,10 @@ use AppBundle\Event\Model\Ticket;
 
 class InvoiceService
 {
-    private InvoiceRepository $invoiceRepository;
-    private TicketRepository $ticketRepository;
-
     public function __construct(
-        InvoiceRepository $invoiceRepository,
-        TicketRepository $ticketRepository
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly TicketRepository $ticketRepository,
     ) {
-        $this->invoiceRepository = $invoiceRepository;
-        $this->ticketRepository = $ticketRepository;
     }
 
     public function handleInvoicing(
@@ -39,7 +34,7 @@ class InvoiceService
         $oldReference = null,
         $authorization = null,
         $transaction = null,
-        $status = Ticket::STATUS_CREATED
+        $status = Ticket::STATUS_CREATED,
     ): void {
         $tickets = $this->ticketRepository->getByReference($reference);
         $amount = 0.0;

--- a/sources/AppBundle/Event/JsonLd.php
+++ b/sources/AppBundle/Event/JsonLd.php
@@ -16,28 +16,13 @@ use Symfony\Component\Asset\Packages;
 
 class JsonLd
 {
-    private TalkRepository $talkRepository;
-
-    private TicketEventTypeRepository $ticketEventTypeRepository;
-
-    private TicketTypeAvailability $ticketTypeAvailability;
-
-    private Packages $packages;
-
-    private PhotoStorage $photoStorage;
-
     public function __construct(
-        TalkRepository $talkRepository,
-        TicketEventTypeRepository $ticketEventTypeRepository,
-        TicketTypeAvailability $ticketTypeAvailability,
-        Packages $packages,
-        PhotoStorage $photoStorage
+        private readonly TalkRepository $talkRepository,
+        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly TicketTypeAvailability $ticketTypeAvailability,
+        private readonly Packages $packages,
+        private readonly PhotoStorage $photoStorage,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->ticketTypeAvailability = $ticketTypeAvailability;
-        $this->packages = $packages;
-        $this->photoStorage = $photoStorage;
-        $this->ticketEventTypeRepository = $ticketEventTypeRepository;
     }
 
     public function getDataForEvent(Event $event): array
@@ -59,18 +44,18 @@ class JsonLd
                     '@type' => 'Person',
                     'name' => $speaker->getLabel(),
                     'image' => $url ? $this->packages->getUrl($url) : '',
-                    'url' => $speaker->getTwitter() !== null ? 'https://twitter.com/' . $speaker->getTwitter() : null
+                    'url' => $speaker->getTwitter() !== null ? 'https://twitter.com/' . $speaker->getTwitter() : null,
                 ];
             }
 
             $subEvent = [
                 '@type' => 'Event',
                 'name' => $talkInfo['talk']->getTitle(),
-                'description' => html_entity_decode(strip_tags($talkInfo['talk']->getDescription())),
+                'description' => html_entity_decode(strip_tags((string) $talkInfo['talk']->getDescription())),
                 'location' => [
                     '@type' => 'Place',
                     'name' => $talkInfo['room'] ? $talkInfo['room']->getName() : '',
-                    'address' => $event->getPlaceAddress()
+                    'address' => $event->getPlaceAddress(),
                 ],
                 'performers' => $performers,
 
@@ -92,11 +77,11 @@ class JsonLd
 
         $available = [
             '@type' => 'ItemAvailability',
-            'name' => 'In stock'
+            'name' => 'In stock',
         ];
         $notAvailable = [
             '@type' => 'ItemAvailability',
-            'name' => 'Out of stock'
+            'name' => 'Out of stock',
         ];
 
         foreach ($eventTickets as $eventTicket) {
@@ -108,7 +93,7 @@ class JsonLd
                 'price' => $eventTicket->getPrice(),
                 'validFrom' => $eventTicket->getDateStart()->format('c'),
                 'validThrough' => $eventTicket->getDateEnd()->format('c'),
-                'availability' => $this->ticketTypeAvailability->getStock($eventTicket, $event) > 0 ? $available : $notAvailable
+                'availability' => $this->ticketTypeAvailability->getStock($eventTicket, $event) > 0 ? $available : $notAvailable,
             ];
         }
 
@@ -121,20 +106,20 @@ class JsonLd
             'location' => [
                 "@type" => "Place",
                 "name" => $event->getPlaceName(),
-                'address' => $event->getPlaceAddress()
+                'address' => $event->getPlaceAddress(),
             ],
             'isAccessibleForFree' => false,
             'organizer' => [
                 '@type' => 'Organization',
                 'name' => 'AFUP',
                 'logo' => 'https://afup.org/uploads/speakers/17/thumbnails/1754.png', // @todo do not depend of "uploads" folder
-                'url' => 'https://afup.org'
+                'url' => 'https://afup.org',
             ],
             'startDate' => $event->getDateStart()->format('c'),
             'endDate' => $event->getDateEnd()->format('c'),
             'offers' => $offers,
             'image' => 'https://afup.org//templates/site/images/logoFPHP2017-420x207.png',
-            'subEvents' => $subEvents
+            'subEvents' => $subEvents,
         ];
     }
 

--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -623,7 +623,7 @@ class Event implements NotifyPropertyInterface
 
     public function isAfupDay(): bool
     {
-        return str_starts_with($this->getTitle(), 'AFUP Day');
+        return str_starts_with((string) $this->getTitle(), 'AFUP Day');
     }
 
     /**

--- a/sources/AppBundle/Event/Model/GithubUser.php
+++ b/sources/AppBundle/Event/Model/GithubUser.php
@@ -9,7 +9,7 @@ use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-class GithubUser implements NotifyPropertyInterface, UserInterface, EquatableInterface
+class GithubUser implements NotifyPropertyInterface, UserInterface, EquatableInterface, \Stringable
 {
     use NotifyProperty;
 
@@ -29,7 +29,7 @@ class GithubUser implements NotifyPropertyInterface, UserInterface, EquatableInt
 
     private bool $afupCrew = false;
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getLabel();
     }

--- a/sources/AppBundle/Event/Model/Invoice.php
+++ b/sources/AppBundle/Event/Model/Invoice.php
@@ -40,8 +40,8 @@ class Invoice implements NotifyPropertyInterface
 
     /**
      * @var string
-     * @Assert\Email()
      */
+    #[Assert\Email]
     private $email;
 
     /**
@@ -51,38 +51,38 @@ class Invoice implements NotifyPropertyInterface
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $lastname;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $firstname;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $address;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $zipcode;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $city;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $countryId = Pays::DEFAULT_ID;
 
     /**
@@ -112,11 +112,11 @@ class Invoice implements NotifyPropertyInterface
 
     /**
      * @var Ticket[]
-     * @Assert\Valid()
      * @AfupAssert\CorporateMember(groups={"corporate"})
      * @AfupAssert\TicketsCfpSubmitter()
      * @AfupAssert\EarlyBirdTicket()
      */
+    #[Assert\Valid]
     private array $tickets = [];
 
 

--- a/sources/AppBundle/Event/Model/InvoiceFactory.php
+++ b/sources/AppBundle/Event/Model/InvoiceFactory.php
@@ -8,11 +8,8 @@ use AppBundle\Event\Model\Repository\InvoiceRepository;
 
 class InvoiceFactory
 {
-    private InvoiceRepository $invoiceRepository;
-
-    public function __construct(InvoiceRepository $invoiceRepository)
+    public function __construct(private readonly InvoiceRepository $invoiceRepository)
     {
-        $this->invoiceRepository = $invoiceRepository;
     }
 
     public function createInvoiceFromSponsorTicket(SponsorTicket $sponsorTicket)

--- a/sources/AppBundle/Event/Model/Lead.php
+++ b/sources/AppBundle/Event/Model/Lead.php
@@ -10,45 +10,45 @@ class Lead implements \JsonSerializable
 {
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $firstname;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $lastname;
 
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Email()
      */
+    #[Assert\NotBlank]
+    #[Assert\Email]
     private $email;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $company;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $phone;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $language;
 
     /**
      * @var string
-     * @Assert\Url()
      */
+    #[Assert\Url]
     private $website;
 
     private ?Event $event = null;
@@ -211,7 +211,7 @@ class Lead implements \JsonSerializable
             'website' => $this->website,
             'company' => $this->company,
             'language' => $this->language,
-            'email' => $this->email
+            'email' => $this->email,
         ];
     }
 

--- a/sources/AppBundle/Event/Model/Planning.php
+++ b/sources/AppBundle/Event/Model/Planning.php
@@ -13,20 +13,16 @@ class Planning implements NotifyPropertyInterface
     use NotifyProperty;
     private ?int $id = null;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private ?int $talkId = null;
 
     private ?\DateTime $start = null;
 
     private ?\DateTime $end = null;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private ?int $eventId = null;
 
     /**

--- a/sources/AppBundle/Event/Model/Repository/BadgeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/BadgeRepository.php
@@ -33,17 +33,17 @@ class BadgeRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'label',
                 'fieldName' => 'label',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'url',
                 'fieldName' => 'url',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/EventCouponRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventCouponRepository.php
@@ -28,17 +28,17 @@ class EventCouponRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary' => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'idEvent',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'texte',
                 'fieldName' => 'text',
-                'type' => 'string'
+                'type' => 'string',
             ]);
 
         return $metadata;
@@ -48,12 +48,12 @@ class EventCouponRepository extends Repository implements MetadataInitializer
     {
         $query = $this->getQuery('DELETE FROM afup_forum_coupon WHERE id_forum = :id');
         $query->setParams([
-            'id' => $event->getId()
+            'id' => $event->getId(),
         ]);
         $query->execute();
 
         foreach ($coupons as $coupon) {
-            $coupon = trim($coupon);
+            $coupon = trim((string) $coupon);
             if (empty($coupon) === true) {
                 continue;
             }
@@ -65,7 +65,7 @@ class EventCouponRepository extends Repository implements MetadataInitializer
     {
         $query = $this->getQuery('SELECT * FROM afup_forum_coupon WHERE id_forum = :id');
         $query->setParams([
-            'id' => $event->getId()
+            'id' => $event->getId(),
         ]);
         return $query->query($this->getCollection(new HydratorSingleObject()));
     }

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -87,7 +87,10 @@ class EventRepository extends Repository implements MetadataInitializer
         return $events->first();
     }
 
-    public function getList($id = null)
+    /**
+     * @return list
+     */
+    public function getList($id = null): array
     {
         $sql = <<<ENDSQL
 SELECT f.id, f.titre, f.path, f.nb_places, f.date_debut, f.date_fin, f.date_fin_appel_conferencier, f.date_fin_vente, f.archived_at
@@ -200,7 +203,7 @@ SQL;
     public function getLastYearEvent(Event $event): Event
     {
         // Recherche de l'année dans le nom
-        preg_match('#\d{4}#', $event->getTitle(), $matches);
+        preg_match('#\d{4}#', (string) $event->getTitle(), $matches);
         if (!$matches) {
             return $this->getLastEvent();
         }
@@ -268,25 +271,25 @@ SQL;
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'titre',
                 'fieldName' => 'title',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nb_places',
                 'fieldName' => 'seats',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date_debut',
                 'fieldName' => 'dateStart',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => false]
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => false],
+                ],
 
             ])
             ->addField([
@@ -294,8 +297,8 @@ SQL;
                 'fieldName' => 'dateEnd',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => false]
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => false],
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_appel_projet',
@@ -305,7 +308,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_debut_appel_conferencier',
@@ -314,7 +317,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_appel_conferencier',
@@ -324,12 +327,12 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_vote',
                 'fieldName' => 'dateEndVote',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'date_fin_prevente',
@@ -339,7 +342,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_vente',
@@ -349,7 +352,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_vente_token_sponsor',
@@ -359,7 +362,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_saisie_repas_speakers',
@@ -369,7 +372,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_annonce_planning',
@@ -379,7 +382,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_fin_saisie_nuites_hotel',
@@ -389,7 +392,7 @@ SQL;
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'text',
@@ -397,51 +400,51 @@ SQL;
                 'type' => 'json',
                 'serializer_options' => [
                     'unserialize' => ['assoc' => true],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'path',
                 'fieldName' => 'path',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'logo_url',
                 'fieldName' => 'logoUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'place_name',
                 'fieldName' => 'placeName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'place_address',
                 'fieldName' => 'placeAddress',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'vote_enabled',
                 'fieldName' => 'voteEnabled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'has_prices_defined_with_vat',
                 'fieldName' => 'hasPricesDefinedWithVat',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'speakers_diner_enabled',
                 'fieldName' => 'speakersDinerEnabled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'accomodation_enabled',
                 'fieldName' => 'accomodationEnabled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'waiting_list_url',
@@ -452,7 +455,7 @@ SQL;
                 'columnName' => 'transport_information_enabled',
                 'fieldName' => 'transportInformationEnabled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'archived_at',

--- a/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
@@ -15,11 +15,9 @@ class EventStatsRepository
     const DAY_ONE = 'one';
     const DAY_TWO = 'two';
     const DAYS = [self::DAY_ONE, self::DAY_TWO];
-    private Connection $connection;
 
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/sources/AppBundle/Event/Model/Repository/GithubUserRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/GithubUserRepository.php
@@ -34,43 +34,43 @@ class GithubUserRepository extends Repository implements MetadataInitializer, Us
                 'fieldName' => 'id',
                 'primary' => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'github_id',
                 'fieldName' => 'githubId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'login',
                 'fieldName' => 'login',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'name',
                 'fieldName' => 'name',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'company',
                 'fieldName' => 'company',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'profile_url',
                 'fieldName' => 'profileUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'avatar_url',
                 'fieldName' => 'avatarUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'afup_crew',
                 'fieldName' => 'afupCrew',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ]);
 
         return $metadata;

--- a/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
@@ -115,7 +115,7 @@ class InvoiceRepository extends Repository implements MetadataInitializer
             ->setParams([
                 'event_id' => $event->getId(),
                 'paymentType' => Ticket::PAYMENT_BANKWIRE,
-                'state' => Ticket::STATUS_CREATED
+                'state' => Ticket::STATUS_CREATED,
             ])
             ->query($this->getCollection($hydrator))
         ;
@@ -138,7 +138,7 @@ class InvoiceRepository extends Repository implements MetadataInitializer
                 'columnName' => 'reference',
                 'fieldName' => 'reference',
                 'primary'       => true,
-                'type' => 'false'
+                'type' => 'false',
             ])
             ->addField([
                 'columnName' => 'date_reglement',
@@ -147,7 +147,7 @@ class InvoiceRepository extends Repository implements MetadataInitializer
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'date_facture',
@@ -156,88 +156,88 @@ class InvoiceRepository extends Repository implements MetadataInitializer
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'montant',
                 'fieldName' => 'amount',
-                'type' => 'float'
+                'type' => 'float',
             ])
             ->addField([
                 'columnName' => 'type_reglement',
                 'fieldName' => 'paymentType',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'informations_reglement',
                 'fieldName' => 'paymentInfos',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'societe',
                 'fieldName' => 'company',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nom',
                 'fieldName' => 'lastname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'prenom',
                 'fieldName' => 'firstname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'adresse',
                 'fieldName' => 'address',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'code_postal',
                 'fieldName' => 'zipcode',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'ville',
                 'fieldName' => 'city',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'id_pays',
                 'fieldName' => 'countryId',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'autorisation',
                 'fieldName' => 'authorization',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'transaction',
                 'fieldName' => 'transaction',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'etat',
                 'fieldName' => 'status',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'facturation',
                 'fieldName' => 'invoice',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'forumId',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
@@ -34,33 +34,33 @@ class MeetupRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary' => true,
                 'autoincrement' => false,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date',
                 'fieldName' => 'date',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'title',
                 'fieldName' => 'title',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'location',
                 'fieldName' => 'location',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'description',
                 'fieldName' => 'description',
                 'type' => 'text',
-                'nullable' => true
+                'nullable' => true,
             ])
             ->addField([
                 'columnName' => 'antenne_name',
                 'fieldName' => 'antenneName',
-                'type' => 'string'
+                'type' => 'string',
             ]);
 
         return $metadata;

--- a/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/PlanningRepository.php
@@ -80,39 +80,39 @@ class PlanningRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_session',
                 'fieldName' => 'talkId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'debut',
                 'fieldName' => 'start',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                ],
             ])
             ->addField([
                 'columnName' => 'fin',
                 'fieldName' => 'end',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                ],
             ])
             ->addField([
                 'columnName' => 'keynote',
                 'fieldName' => 'isKeynote',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/RoomRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/RoomRepository.php
@@ -39,17 +39,17 @@ class RoomRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'nom',
                 'fieldName' => 'name',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -190,109 +190,109 @@ SQL
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'civilite',
                 'fieldName' => 'civility',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nom',
                 'fieldName' => 'lastname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'prenom',
                 'fieldName' => 'firstname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'societe',
                 'fieldName' => 'company',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'ville',
                 'fieldName' => 'locality',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'phone_number',
                 'fieldName' => 'phoneNumber',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'biographie',
                 'fieldName' => 'biography',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'twitter',
                 'fieldName' => 'twitter',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'mastodon',
                 'fieldName' => 'mastodon',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'bluesky',
                 'fieldName' => 'bluesky',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'user_github',
                 'fieldName' => 'user',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'photo',
                 'fieldName' => 'photo',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'will_attend_speakers_diner',
                 'fieldName' => 'willAttendSpeakersDiner',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'has_special_diet',
                 'fieldName' => 'hasSpecialDiet',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'special_diet_description',
                 'fieldName' => 'specialDietDescription',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'hotel_nights',
                 'fieldName' => 'hotelNights',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'referent_person',
                 'fieldName' => 'referentPerson',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'referent_person_email',
                 'fieldName' => 'referentPersonEmail',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/SpeakerSuggestionRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerSuggestionRepository.php
@@ -30,40 +30,40 @@ class SpeakerSuggestionRepository extends Repository implements MetadataInitiali
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'event_id',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'suggester_email',
                 'fieldName' => 'suggesterEmail',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'suggester_name',
                 'fieldName' => 'suggesterName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'speaker_name',
                 'fieldName' => 'speakerName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'comment',
                 'fieldName' => 'comment',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'created_at',
                 'fieldName' => 'createdAt',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => false]
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => false],
+                ],
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/SponsorScanRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SponsorScanRepository.php
@@ -50,27 +50,27 @@ class SponsorScanRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'sponsor_ticket_id',
                 'fieldName' => 'sponsorTicketId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'ticket_id',
                 'fieldName' => 'ticketId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'created_on',
                 'fieldName' => 'createdOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'deleted_on',
                 'fieldName' => 'deletedOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
@@ -41,58 +41,58 @@ class SponsorTicketRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'company',
                 'fieldName' => 'company',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'token',
                 'fieldName' => 'token',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'contact_email',
                 'fieldName' => 'contactEmail',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'max_invitations',
                 'fieldName' => 'maxInvitations',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'used_invitations',
                 'fieldName' => 'usedInvitations',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'idForum',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'created_on',
                 'fieldName' => 'createdOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'edited_on',
                 'fieldName' => 'editedOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'creator_id',
                 'fieldName' => 'creatorId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'qr_codes_scanner_available',
                 'fieldName' => 'qrCodesScannerAvailable',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/TalkInvitationRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkInvitationRepository.php
@@ -46,37 +46,37 @@ class TalkInvitationRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'talk_id',
                 'fieldName' => 'talkId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'state',
                 'fieldName' => 'state',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'submitted_on',
                 'fieldName' => 'submittedOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'submitted_by',
                 'fieldName' => 'submittedBy',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'token',
                 'fieldName' => 'token',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -157,7 +157,7 @@ class TalkRepository extends Repository implements MetadataInitializer
             'user' => $user->getId(),
             'excluded_event' => $event->getId(),
             'excluded_user' => $user->getId(),
-            'randomSeed' => $randomSeed
+            'randomSeed' => $randomSeed,
         ]);
 
         return $query->query();
@@ -330,142 +330,142 @@ class TalkRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'forumId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date_soumission',
                 'fieldName' => 'submittedOn',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => false]
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => false],
+                ],
             ])
             ->addField([
                 'columnName' => 'titre',
                 'fieldName' => 'title',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'abstract',
                 'fieldName' => 'abstract',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'staff_notes',
                 'fieldName' => 'staffNotes',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'genre',
                 'fieldName' => 'type',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'skill',
                 'fieldName' => 'skill',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'with_workshop',
                 'fieldName' => 'withWorkshop',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'workshop_abstract',
                 'fieldName' => 'workshopAbstract',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'plannifie',
                 'fieldName' => 'scheduled',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'needs_mentoring',
                 'fieldName' => 'needsMentoring',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'youtube_id',
                 'fieldName' => 'youtubeId',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'video_has_fr_subtitles',
                 'fieldName' => 'videoHasFrSubtitles',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'video_has_en_subtitles',
                 'fieldName' => 'videoHasEnSubtitles',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'slides_url',
                 'fieldName' => 'slidesUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'blog_post_url',
                 'fieldName' => 'blogPostUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'interview_url',
                 'fieldName' => 'interviewUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'joindin',
                 'fieldName' => 'joindinId',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'openfeedback_path',
                 'fieldName' => 'openfeedbackPath',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'language_code',
                 'fieldName' => 'languageCode',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'tweets',
                 'fieldName' => 'tweets',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'transcript',
                 'fieldName' => 'transcript',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'verbatim',
                 'fieldName' => 'verbatim',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'markdown',
                 'fieldName' => 'useMarkdown',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'has_allowed_to_sharing_with_local_offices',
                 'fieldName' => 'hasAllowedToSharingWithLocalOffices',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ]);
 
         return $metadata;

--- a/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
@@ -80,13 +80,13 @@ class TalkToSpeakersRepository extends Repository implements MetadataInitializer
                 'columnName' => 'conferencier_id',
                 'fieldName' => 'speakerId',
                 'primary'       => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'session_id',
                 'fieldName' => 'talkId',
                 'primary'       => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/TicketEventTypeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketEventTypeRepository.php
@@ -78,7 +78,7 @@ class TicketEventTypeRepository extends Repository implements MetadataInitialize
             'date_start' => $ticketEventType->getDateStart()->format('Y-m-d H:i:s'),
             'date_end' => $ticketEventType->getDateEnd()->format('Y-m-d H:i:s'),
             'description' => $ticketEventType->getDescription(),
-            'max_tickets' => $ticketEventType->getMaxTickets()
+            'max_tickets' => $ticketEventType->getMaxTickets(),
         ]);
 
         return $query->execute();
@@ -119,17 +119,17 @@ class TicketEventTypeRepository extends Repository implements MetadataInitialize
             ->addField([
                 'columnName' => 'id_tarif',
                 'fieldName' => 'ticketTypeId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_event',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'price',
                 'fieldName' => 'price',
-                'type' => 'float'
+                'type' => 'float',
             ])
             ->addField([
                 'columnName' => 'date_start',
@@ -144,12 +144,12 @@ class TicketEventTypeRepository extends Repository implements MetadataInitialize
             ->addField([
                 'columnName' => 'description',
                 'fieldName' => 'description',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'max_tickets',
                 'fieldName' => 'maxTickets',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/TicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketRepository.php
@@ -47,9 +47,9 @@ class TicketRepository extends Repository implements MetadataInitializer
                 'member' => $userId,
                 'type' => $userType,
                 'forum' => $eventId,
-                'state' => Ticket::STATUS_PAID
+                'state' => Ticket::STATUS_PAID,
             ])->query($this->getCollection(new HydratorArray()))->first()['total'];
-        } catch (QueryException $exception) {
+        } catch (QueryException) {
             return 0;
         }
     }
@@ -232,7 +232,7 @@ class TicketRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date',
@@ -241,123 +241,123 @@ class TicketRepository extends Repository implements MetadataInitializer
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['format' => 'U'],
-                ]
+                ],
             ])
             ->addField([
                 'columnName' => 'reference',
                 'fieldName' => 'reference',
-                'type' => 'string'
+                'type' => 'string',
             ])
 
             ->addField([
                 'columnName' => 'coupon',
                 'fieldName' => 'voucher',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'type_inscription',
                 'fieldName' => 'ticketTypeId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'montant',
                 'fieldName' => 'amount',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'informations_reglement',
                 'fieldName' => 'paymentInfo',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'civilite',
                 'fieldName' => 'civility',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nom',
                 'fieldName' => 'lastname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'prenom',
                 'fieldName' => 'firstname',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'email',
                 'fieldName' => 'email',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'telephone',
                 'fieldName' => 'phoneNumber',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'citer_societe',
                 'fieldName' => 'companyCitation',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'newsletter_afup',
                 'fieldName' => 'newsletter',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'commentaires',
                 'fieldName' => 'comments',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'etat',
                 'fieldName' => 'status',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'facturation',
                 'fieldName' => 'invoiceStatus',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'forumId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_member',
                 'fieldName' => 'memberId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'member_type',
                 'fieldName' => 'memberType',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'mail_partenaire',
                 'fieldName' => 'optin',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'presence_day1',
                 'fieldName' => 'day1Checkin',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'presence_day2',
                 'fieldName' => 'day2Checkin',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'special_price_token',
                 'fieldName' => 'specialPriceToken',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'nearest_office',
@@ -372,7 +372,7 @@ class TicketRepository extends Repository implements MetadataInitializer
             ->addField([
                 'columnName' => 'transport_distance',
                 'fieldName' => 'transportDistance',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'qr_code',

--- a/sources/AppBundle/Event/Model/Repository/TicketSpecialPriceRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketSpecialPriceRepository.php
@@ -81,22 +81,22 @@ class TicketSpecialPriceRepository extends Repository implements MetadataInitial
             ->addField([
                 'columnName' => 'id',
                 'fieldName' => 'id',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_event',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'token',
                 'fieldName' => 'token',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'price',
                 'fieldName' => 'price',
-                'type' => 'float'
+                'type' => 'float',
             ])
             ->addField([
                 'columnName' => 'date_start',
@@ -111,17 +111,17 @@ class TicketSpecialPriceRepository extends Repository implements MetadataInitial
             ->addField([
                 'columnName' => 'description',
                 'fieldName' => 'description',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'created_on',
                 'fieldName' => 'createdOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'creator_id',
                 'fieldName' => 'creatorId',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/TicketTypeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketTypeRepository.php
@@ -31,52 +31,52 @@ class TicketTypeRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'technical_name',
                 'fieldName' => 'technicalName',
-                'type' => 'string'
+                'type' => 'string',
             ])
 
             ->addField([
                 'columnName' => 'pretty_name',
                 'fieldName' => 'prettyName',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'public',
                 'fieldName' => 'isPublic',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'members_only',
                 'fieldName' => 'isRestrictedToMembers',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'cfp_submitter_only',
                 'fieldName' => 'isRestrictedToCfpSubmitter',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'default_price',
                 'fieldName' => 'defaultPrice',
-                'type' => 'float'
+                'type' => 'float',
             ])
             ->addField([
                 'columnName' => 'active',
                 'fieldName' => 'isActive',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'day',
                 'fieldName' => 'day',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/UserBadgeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/UserBadgeRepository.php
@@ -57,21 +57,21 @@ class UserBadgeRepository extends Repository implements MetadataInitializer
                 'columnName' => 'afup_personne_physique_id',
                 'fieldName' => 'userId',
                 'primary' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'badge_id',
                 'fieldName' => 'badgeId',
                 'primary' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'issued_at',
                 'fieldName' => 'issuedAt',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => false]
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => false],
+                ],
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Repository/VoteRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/VoteRepository.php
@@ -89,32 +89,32 @@ WHERE s.id_forum = :event');
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'session_id',
                 'fieldName' => 'sessionId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'submitted_on',
                 'fieldName' => 'submittedOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'comment',
                 'fieldName' => 'comment',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'user',
                 'fieldName' => 'user',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'vote',
                 'fieldName' => 'vote',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Room.php
+++ b/sources/AppBundle/Event/Model/Room.php
@@ -18,10 +18,8 @@ class Room implements NotifyPropertyInterface
      */
     private $name;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private ?int $eventId = null;
 
     /**

--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -25,41 +25,41 @@ class Speaker implements NotifyPropertyInterface
 
     /**
      * @var int
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
      */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private $eventId;
 
     /**
      * @var int
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
      */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private $user;
 
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     private $civility;
 
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     private $firstname;
 
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     private $lastname;
 
     /**
-     * @Assert\NotBlank()
-     * @Assert\Email()
      * @var string
      */
+    #[Assert\NotBlank]
+    #[Assert\Email]
     private $email;
 
     /**
@@ -73,9 +73,9 @@ class Speaker implements NotifyPropertyInterface
     private $locality;
 
     /**
-     * @Assert\NotBlank()
      * @var string
      */
+    #[Assert\NotBlank]
     private $biography;
 
     /**
@@ -96,9 +96,8 @@ class Speaker implements NotifyPropertyInterface
 
     /**
      * Wrapper for SpeakerType to allow picture upload
-     *
-     * @Assert\File(mimeTypes={"image/jpeg","image/png"})
      */
+    #[Assert\File(mimeTypes: ['image/jpeg', 'image/png'])]
     private ?UploadedFile $photoFile = null;
 
     /**
@@ -403,7 +402,7 @@ class Speaker implements NotifyPropertyInterface
         $twitter = trim($twitter, '@');
         $twitter = preg_replace('!^(https?://(twitter|x).com/)!', '', $twitter);
 
-        return trim($twitter);
+        return trim((string) $twitter);
     }
 
     public function getUrlTwitter(): string
@@ -449,11 +448,11 @@ class Speaker implements NotifyPropertyInterface
     public function getCleanedMastodon(): string
     {
         $mastodon = $this->getMastodon();
-        if (!str_contains($mastodon, '@')) {
+        if (!str_contains((string) $mastodon, '@')) {
             return '';
         }
 
-        [, $username] = explode('@', $mastodon);
+        [, $username] = explode('@', (string) $mastodon);
         return trim($username);
     }
 
@@ -677,9 +676,7 @@ class Speaker implements NotifyPropertyInterface
         return 0 === count($hotelNights);
     }
 
-    /**
-     * @Assert\Callback
-     */
+    #[Assert\Callback]
     public function validate(ExecutionContextInterface $context, $payload): void
     {
         // check if the name is actually a fake name

--- a/sources/AppBundle/Event/Model/SponsorTicket.php
+++ b/sources/AppBundle/Event/Model/SponsorTicket.php
@@ -20,29 +20,29 @@ class SponsorTicket implements NotifyPropertyInterface
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $company;
 
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Length(min=30, max=64)
      */
+    #[Assert\NotBlank]
+    #[Assert\Length(min: 30, max: 64)]
     private $token;
 
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Email()
      */
+    #[Assert\NotBlank]
+    #[Assert\Email]
     private $contactEmail;
 
     /**
      * @var int
-     * @Assert\NotBlank()
-     * @Assert\Range(min=1, max=20)
      */
+    #[Assert\NotBlank]
+    #[Assert\Range(min: 1, max: 20)]
     private $maxInvitations = 0;
 
     /**

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -32,38 +32,28 @@ class Talk implements NotifyPropertyInterface
 
     private ?int $id = null;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private ?int $forumId = null;
 
     private ?\DateTime $submittedOn = null;
 
-    /**
-     * @Assert\NotBlank()
-     */
+    #[Assert\NotBlank]
     private string $title = '';
 
-    /**
-     * @Assert\NotBlank()
-     */
-    private ?string $abstract = '';
+    #[Assert\NotBlank]
+    private string $abstract = '';
 
     private ?string $staffNotes = null;
 
     private bool $scheduled = false;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Choice(choices = {1, 2, 3}, message = "Choose a valid type")
-     */
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: [1, 2, 3], message: 'Choose a valid type')]
     private int $type = self::TYPE_FULL_LONG;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\Choice(choices = {0, 1, 2, 3}, message = "Choose a valid skill requirement")
-     */
+    #[Assert\NotBlank]
+    #[Assert\Choice(choices: [0, 1, 2, 3], message: 'Choose a valid skill requirement')]
     private int $skill = self::SKILL_NA;
 
     private bool $withWorkshop = false;
@@ -98,9 +88,7 @@ class Talk implements NotifyPropertyInterface
 
     private bool $useMarkdown = true;
 
-    /**
-     * @Assert\NotNull()
-     */
+    #[Assert\NotNull]
     private bool $hasAllowedToSharingWithLocalOffices = false;
 
     /**

--- a/sources/AppBundle/Event/Model/TalkInvitation.php
+++ b/sources/AppBundle/Event/Model/TalkInvitation.php
@@ -22,40 +22,38 @@ class TalkInvitation implements NotifyPropertyInterface
 
     /**
      * @var int
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
      */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private $talkId;
 
     /**
      * @var string
-     * @Assert\Email()
-     * @Assert\NotBlank()
      */
+    #[Assert\Email]
+    #[Assert\NotBlank]
     private $email;
 
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     private $token;
 
     private ?\DateTime $submittedOn = null;
 
     /**
      * @var int
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     *
-     * Speaker id who sent the invitation
      *
      */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)] // Speaker id who sent the invitation
     private $submittedBy;
 
     /**
      * @var int
-     * @Assert\Choice(choices = {0, 1}, message = "Invalid state")
      */
+    #[Assert\Choice(choices: [0, 1], message: 'Invalid state')]
     private $state;
 
     /**

--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -28,7 +28,7 @@ class Ticket implements NotifyPropertyInterface
         AFUP_TRANSPORT_MODE_TRAIN => 'Train',
         AFUP_TRANSPORT_MODE_AVION_ECO => 'Avion classe économique',
         AFUP_TRANSPORT_MODE_AVION_BUSINESS => 'Avion classe business',
-        AFUP_TRANSPORT_MODE_COMMUN => 'Transports en commun'
+        AFUP_TRANSPORT_MODE_COMMUN => 'Transports en commun',
     ];
 
     const TRANSPORT_DISTANCES = [

--- a/sources/AppBundle/Event/Model/Vote.php
+++ b/sources/AppBundle/Event/Model/Vote.php
@@ -14,27 +14,18 @@ class Vote implements NotifyPropertyInterface
 
     private int $id;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private int $sessionId = 0;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(0)
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(0)]
     private int $user = 0;
 
     private ?string $comment = null;
 
-    /**
-     * @Assert\NotBlank()
-     * @Assert\GreaterThan(
-     *     value = 0,
-     *     message = "Please set a note !"
-     * )
-     */
+    #[Assert\NotBlank]
+    #[Assert\GreaterThan(value: 0, message: 'Please set a note !')]
     private int $vote = 0;
 
     private ?\DateTime $submittedOn = null;

--- a/sources/AppBundle/Event/Speaker/ExportGenerator.php
+++ b/sources/AppBundle/Event/Speaker/ExportGenerator.php
@@ -12,11 +12,8 @@ use CCMBenchmark\Ting\Query\QueryException;
 
 class ExportGenerator
 {
-    private TalkRepository $talkRepository;
-
-    public function __construct(TalkRepository $talkRepository)
+    public function __construct(private readonly TalkRepository $talkRepository)
     {
-        $this->talkRepository = $talkRepository;
     }
 
     /**

--- a/sources/AppBundle/Event/Speaker/SpeakerPage.php
+++ b/sources/AppBundle/Event/Speaker/SpeakerPage.php
@@ -22,18 +22,11 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SpeakerPage extends AbstractController
 {
-    private TalkRepository $talkRepository;
-    private SpeakerRepository $speakerRepository;
-    private SpeakersExpensesStorage $speakersExpensesStorage;
-
     public function __construct(
-        TalkRepository $talkRepository,
-        SpeakerRepository $speakerRepository,
-        SpeakersExpensesStorage $speakersExpensesStorage
+        private readonly TalkRepository $talkRepository,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly SpeakersExpensesStorage $speakersExpensesStorage,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->speakersExpensesStorage = $speakersExpensesStorage;
     }
 
     public function handleRequest(Request $request, Event $event, Speaker $speaker)
@@ -46,7 +39,7 @@ class SpeakerPage extends AbstractController
         $now = new DateTime('now');
 
         $speakersContactDefaults = [
-            'phone_number' => $speaker->getPhoneNumber()
+            'phone_number' => $speaker->getPhoneNumber(),
         ];
         $speakersContactType = $this->createForm(SpeakersContactType::class, $speakersContactDefaults);
         $speakersContactType->handleRequest($request);

--- a/sources/AppBundle/Event/Sponsorship/SponsorshipLeadMail.php
+++ b/sources/AppBundle/Event/Sponsorship/SponsorshipLeadMail.php
@@ -16,20 +16,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SponsorshipLeadMail
 {
-    private Mailer $mailer;
-
-    private TranslatorInterface $translator;
-
-    private LoggerInterface $logger;
-
     public function __construct(
-        Mailer $mailer,
-        TranslatorInterface $translator,
-        LoggerInterface $logger
+        private readonly Mailer $mailer,
+        private readonly TranslatorInterface $translator,
+        private readonly LoggerInterface $logger,
     ) {
-        $this->mailer = $mailer;
-        $this->translator = $translator;
-        $this->logger = $logger;
     }
 
     public function sendSponsorshipFile(Lead $lead): void

--- a/sources/AppBundle/Event/Talk/ExportGenerator.php
+++ b/sources/AppBundle/Event/Talk/ExportGenerator.php
@@ -12,11 +12,8 @@ use CCMBenchmark\Ting\Query\QueryException;
 
 class ExportGenerator
 {
-    private TalkRepository $talkRepository;
-
-    public function __construct(TalkRepository $talkRepository)
+    public function __construct(private readonly TalkRepository $talkRepository)
     {
-        $this->talkRepository = $talkRepository;
     }
 
     /**
@@ -133,7 +130,7 @@ class ExportGenerator
     {
         try {
             return $talk->getLanguageLabel();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return '';
         }
     }

--- a/sources/AppBundle/Event/Talk/InvitationFormHandler.php
+++ b/sources/AppBundle/Event/Talk/InvitationFormHandler.php
@@ -22,24 +22,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class InvitationFormHandler
 {
-    private TalkInvitationRepository $talkInvitationRepository;
-    private EventDispatcherInterface $eventDispatcher;
-    private TranslatorInterface $translator;
-    private UrlGeneratorInterface $urlGenerator;
-    private Mailer $mailer;
-
     public function __construct(
-        TalkInvitationRepository $talkInvitationRepository,
-        EventDispatcherInterface $eventDispatcher,
-        TranslatorInterface $translator,
-        UrlGeneratorInterface $urlGenerator,
-        Mailer $mailer
+        private readonly TalkInvitationRepository $talkInvitationRepository,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly TranslatorInterface $translator,
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly Mailer $mailer,
     ) {
-        $this->talkInvitationRepository = $talkInvitationRepository;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->translator = $translator;
-        $this->urlGenerator = $urlGenerator;
-        $this->mailer = $mailer;
     }
 
     public function handle(Request $request, Event $event, FormInterface $form, GithubUser $user, Talk $talk): bool

--- a/sources/AppBundle/Event/Talk/TalkFormHandler.php
+++ b/sources/AppBundle/Event/Talk/TalkFormHandler.php
@@ -20,27 +20,14 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class TalkFormHandler
 {
-    private TalkRepository $talkRepository;
-    private SpeakerRepository $speakerRepository;
-    private SlackNotifier $slackNotifier;
-    private EventDispatcherInterface $eventDispatcher;
-    private TalkToSpeakersRepository $talkToSpeakersRepository;
-    private UnitOfWork $unitOfWork;
-
     public function __construct(
-        TalkRepository $talkRepository,
-        SpeakerRepository $speakerRepository,
-        SlackNotifier $slackNotifier,
-        EventDispatcherInterface $eventDispatcher,
-        TalkToSpeakersRepository $talkToSpeakersRepository,
-        UnitOfWork $unitOfWork
+        private readonly TalkRepository $talkRepository,
+        private readonly SpeakerRepository $speakerRepository,
+        private readonly SlackNotifier $slackNotifier,
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly TalkToSpeakersRepository $talkToSpeakersRepository,
+        private readonly UnitOfWork $unitOfWork,
     ) {
-        $this->talkRepository = $talkRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->slackNotifier = $slackNotifier;
-        $this->eventDispatcher = $eventDispatcher;
-        $this->talkToSpeakersRepository = $talkToSpeakersRepository;
-        $this->unitOfWork = $unitOfWork;
     }
 
     public function handle(Request $request, Event $event, FormInterface $form, Speaker $speaker): bool

--- a/sources/AppBundle/Event/Ticket/PurchaseTypeFactory.php
+++ b/sources/AppBundle/Event/Ticket/PurchaseTypeFactory.php
@@ -16,24 +16,12 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class PurchaseTypeFactory
 {
-    private AuthorizationCheckerInterface $securityChecker;
-
-    private FormFactoryInterface $formFactory;
-
-    private InvoiceFactory $invoiceFactory;
-
-    private SpeakerRepository $speakerRepository;
-
     public function __construct(
-        AuthorizationCheckerInterface $securityChecker,
-        FormFactoryInterface $formFactory,
-        InvoiceFactory $invoiceFactory,
-        SpeakerRepository $speakerRepository
+        private readonly AuthorizationCheckerInterface $securityChecker,
+        private readonly FormFactoryInterface $formFactory,
+        private readonly InvoiceFactory $invoiceFactory,
+        private readonly SpeakerRepository $speakerRepository,
     ) {
-        $this->securityChecker = $securityChecker;
-        $this->formFactory = $formFactory;
-        $this->invoiceFactory = $invoiceFactory;
-        $this->speakerRepository = $speakerRepository;
     }
 
     public function getPurchaseForUser(Event $event, User $user = null, $specialPriceToken = null)

--- a/sources/AppBundle/Event/Ticket/QrCodeGenerator.php
+++ b/sources/AppBundle/Event/Ticket/QrCodeGenerator.php
@@ -6,11 +6,8 @@ namespace AppBundle\Event\Ticket;
 
 class QrCodeGenerator
 {
-    private string $salt;
-
-    public function __construct(string $salt)
+    public function __construct(private readonly string $salt)
     {
-        $this->salt = $salt;
     }
 
     public function generate(int $idTicket): string

--- a/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
+++ b/sources/AppBundle/Event/Ticket/RegistrationsExportGenerator.php
@@ -16,23 +16,13 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
 class RegistrationsExportGenerator
 {
-    private OfficeFinder $officeFinder;
-
-    private SeniorityComputer $seniorityComputer;
-
-    private InvoiceRepository $invoiceRepository;
-
-    private TicketRepository $ticketRepository;
-
-    private UserRepository $userRepository;
-
-    public function __construct(OfficeFinder $officeFinder, SeniorityComputer $seniorityComputer, TicketRepository $ticketRepository, InvoiceRepository $invoiceRepository, UserRepository $userRepository)
-    {
-        $this->officeFinder = $officeFinder;
-        $this->seniorityComputer = $seniorityComputer;
-        $this->ticketRepository = $ticketRepository;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->userRepository = $userRepository;
+    public function __construct(
+        private readonly OfficeFinder $officeFinder,
+        private readonly SeniorityComputer $seniorityComputer,
+        private readonly TicketRepository $ticketRepository,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly UserRepository $userRepository,
+    ) {
     }
 
     public function export(Event $event, \SplFileObject $toFile): void
@@ -47,7 +37,7 @@ class RegistrationsExportGenerator
             'type_pass',
             'email',
             'member_since',
-            'office'
+            'office',
         ];
 
         $toFile->fputcsv($columns);
@@ -87,7 +77,7 @@ class RegistrationsExportGenerator
 
             try {
                 $user = $this->userRepository->loadUserByUsername($ticket->getEmail());
-            } catch (UserNotFoundException $exception) {
+            } catch (UserNotFoundException) {
                 $user = null;
             }
 
@@ -134,58 +124,15 @@ class RegistrationsExportGenerator
 
     private function getTypePass($type): string
     {
-        switch ($type) {
-            case AFUP_FORUM_PREMIERE_JOURNEE:
-            case AFUP_FORUM_LATE_BIRD_PREMIERE_JOURNEE:
-            case Ticket::TYPE_AFUP_DAY_EARLY_BIRD:
-            case Ticket::TYPE_AFUP_DAY_CROISIERE:
-            case Ticket::TYPE_AFUP_DAY_LATE:
-            case Ticket::TYPE_AFUP_DAY_CFP_SUBMITTER:
-            case Ticket::TYPE_AFUP_DAY_LIVE_FREE:
-            case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_1:
-            case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_2:
-            case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_3:
-            case Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_4:
-            case Ticket::TYPE_AFUP_DAY_2021_LIVE_1:
-                return 'PASS JOUR 1';
-            case AFUP_FORUM_DEUXIEME_JOURNEE:
-            case AFUP_FORUM_LATE_BIRD_DEUXIEME_JOURNEE:
-            case Ticket::TYPE_AFUP_DAY_2021_LIVE_2:
-                return 'PASS JOUR 2';
-            case AFUP_FORUM_2_JOURNEES:
-            case AFUP_FORUM_2_JOURNEES_AFUP:
-            case AFUP_FORUM_2_JOURNEES_ETUDIANT:
-            case AFUP_FORUM_2_JOURNEES_PREVENTE:
-            case AFUP_FORUM_2_JOURNEES_AFUP_PREVENTE:
-            case AFUP_FORUM_2_JOURNEES_ETUDIANT_PREVENTE:
-            case AFUP_FORUM_2_JOURNEES_COUPON:
-            case AFUP_FORUM_INVITATION:
-            case AFUP_FORUM_EARLY_BIRD:
-            case AFUP_FORUM_EARLY_BIRD_AFUP:
-            case AFUP_FORUM_LATE_BIRD:
-            case AFUP_FORUM_LATE_BIRD_AFUP:
-            case AFUP_FORUM_CFP_SUBMITTER:
-            case AFUP_FORUM_SPECIAL_PRICE:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_1:
-            case Ticket::TYPE_FORUM_PHP_LIVE_FREE:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_2:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_3:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_4:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_5:
-            case Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_6:
-            case Ticket::TYPE_AFUP_DAY_2021_LIVE_3:
-            case Ticket::TYPE_AFUP_DAY_2021_LIVE_4:
-                return 'PASS 2 JOURS';
-            case AFUP_FORUM_ORGANISATION:
-                return 'ORGANISATION';
-            case AFUP_FORUM_PRESSE:
-                return 'PRESSE';
-            case AFUP_FORUM_CONFERENCIER:
-                return 'CONFERENCIER';
-            case AFUP_FORUM_SPONSOR:
-                return 'SPONSOR';
-            default:
-                throw new \RuntimeException(sprintf('Libellé du type %s non trouvé', var_export($type, true)));
-        }
+        return match ($type) {
+            AFUP_FORUM_PREMIERE_JOURNEE, AFUP_FORUM_LATE_BIRD_PREMIERE_JOURNEE, Ticket::TYPE_AFUP_DAY_EARLY_BIRD, Ticket::TYPE_AFUP_DAY_CROISIERE, Ticket::TYPE_AFUP_DAY_LATE, Ticket::TYPE_AFUP_DAY_CFP_SUBMITTER, Ticket::TYPE_AFUP_DAY_LIVE_FREE, Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_1, Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_2, Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_3, Ticket::TYPE_AFUP_DAY_LIVE_SOUTIEN_4, Ticket::TYPE_AFUP_DAY_2021_LIVE_1 => 'PASS JOUR 1',
+            AFUP_FORUM_DEUXIEME_JOURNEE, AFUP_FORUM_LATE_BIRD_DEUXIEME_JOURNEE, Ticket::TYPE_AFUP_DAY_2021_LIVE_2 => 'PASS JOUR 2',
+            AFUP_FORUM_2_JOURNEES, AFUP_FORUM_2_JOURNEES_AFUP, AFUP_FORUM_2_JOURNEES_ETUDIANT, AFUP_FORUM_2_JOURNEES_PREVENTE, AFUP_FORUM_2_JOURNEES_AFUP_PREVENTE, AFUP_FORUM_2_JOURNEES_ETUDIANT_PREVENTE, AFUP_FORUM_2_JOURNEES_COUPON, AFUP_FORUM_INVITATION, AFUP_FORUM_EARLY_BIRD, AFUP_FORUM_EARLY_BIRD_AFUP, AFUP_FORUM_LATE_BIRD, AFUP_FORUM_LATE_BIRD_AFUP, AFUP_FORUM_CFP_SUBMITTER, AFUP_FORUM_SPECIAL_PRICE, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_1, Ticket::TYPE_FORUM_PHP_LIVE_FREE, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_2, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_3, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_4, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_5, Ticket::TYPE_FORUM_PHP_LIVE_SOUTIEN_6, Ticket::TYPE_AFUP_DAY_2021_LIVE_3, Ticket::TYPE_AFUP_DAY_2021_LIVE_4 => 'PASS 2 JOURS',
+            AFUP_FORUM_ORGANISATION => 'ORGANISATION',
+            AFUP_FORUM_PRESSE => 'PRESSE',
+            AFUP_FORUM_CONFERENCIER => 'CONFERENCIER',
+            AFUP_FORUM_SPONSOR => 'SPONSOR',
+            default => throw new \RuntimeException(sprintf('Libellé du type %s non trouvé', var_export($type, true))),
+        };
     }
 }

--- a/sources/AppBundle/Event/Ticket/SponsorTicketHelper.php
+++ b/sources/AppBundle/Event/Ticket/SponsorTicketHelper.php
@@ -14,24 +14,12 @@ use CCMBenchmark\Ting\Exception;
 
 class SponsorTicketHelper
 {
-    private InvoiceFactory $invoiceFactory;
-
-    private InvoiceRepository $invoiceRepository;
-
-    private TicketRepository $ticketRepository;
-
-    private SponsorTicketRepository $sponsorTicketRepository;
-
     public function __construct(
-        InvoiceFactory $invoiceFactory,
-        InvoiceRepository $invoiceRepository,
-        TicketRepository $ticketRepository,
-        SponsorTicketRepository $sponsorTicketRepository
+        private readonly InvoiceFactory $invoiceFactory,
+        private readonly InvoiceRepository $invoiceRepository,
+        private readonly TicketRepository $ticketRepository,
+        private readonly SponsorTicketRepository $sponsorTicketRepository,
     ) {
-        $this->invoiceFactory = $invoiceFactory;
-        $this->invoiceRepository = $invoiceRepository;
-        $this->ticketRepository = $ticketRepository;
-        $this->sponsorTicketRepository = $sponsorTicketRepository;
     }
 
     public function addTicketToSponsor(SponsorTicket $sponsorTicket, Ticket $ticket): void
@@ -49,7 +37,7 @@ class SponsorTicketHelper
             $this->ticketRepository->save($ticket);
             $this->sponsorTicketRepository->save($sponsorTicket);
             $this->invoiceRepository->commit();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->invoiceRepository->rollback();
         }
     }
@@ -66,7 +54,7 @@ class SponsorTicketHelper
             $sponsorTicket->setUsedInvitations($sponsorTicket->getUsedInvitations()-1);
             $this->sponsorTicketRepository->save($sponsorTicket);
             $this->ticketRepository->commit();
-        } catch (Exception $e) {
+        } catch (Exception) {
             $this->ticketRepository->rollback();
         }
     }

--- a/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
+++ b/sources/AppBundle/Event/Ticket/SponsorTokenMail.php
@@ -17,20 +17,12 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class SponsorTokenMail
 {
-    private Mailer $mailer;
-
-    private TranslatorInterface $translator;
-
-    private RouterInterface $router;
-
-    private EventRepository $eventRepository;
-
-    public function __construct(Mailer $mail, TranslatorInterface $translator, RouterInterface $router, EventRepository $eventRepository)
-    {
-        $this->mailer = $mail;
-        $this->translator = $translator;
-        $this->router = $router;
-        $this->eventRepository = $eventRepository;
+    public function __construct(
+        private readonly Mailer $mailer,
+        private readonly TranslatorInterface $translator,
+        private readonly RouterInterface $router,
+        private readonly EventRepository $eventRepository,
+    ) {
     }
 
     /**
@@ -65,7 +57,7 @@ class SponsorTokenMail
                     ['eventSlug' => $event->getPath()],
                     UrlGeneratorInterface::ABSOLUTE_URL
                 ),
-                '%endDate%' => $event->getDateEndSalesSponsorToken()->format('d/m/Y')
+                '%endDate%' => $event->getDateEndSalesSponsorToken()->format('d/m/Y'),
             ]
         );
 

--- a/sources/AppBundle/Event/Ticket/TicketTypeAvailability.php
+++ b/sources/AppBundle/Event/Ticket/TicketTypeAvailability.php
@@ -15,11 +15,8 @@ class TicketTypeAvailability
     const DAY_TWO = 'two';
     const DAY_BOTH = 'both';
 
-    private TicketRepository $ticketRepository;
-
-    public function __construct(TicketRepository $ticketRepository)
+    public function __construct(private readonly TicketRepository $ticketRepository)
     {
-        $this->ticketRepository = $ticketRepository;
     }
 
     public function getStock(TicketEventType $ticketEventType, Event $event)

--- a/sources/AppBundle/Event/Validator/Constraints/AvailableTicketValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/AvailableTicketValidator.php
@@ -14,14 +14,10 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class AvailableTicketValidator extends ConstraintValidator
 {
-    private TicketTypeAvailability $ticketTypeAvailability;
-
-    private EventRepository $eventRepository;
-
-    public function __construct(TicketTypeAvailability $ticketTypeAvailability, EventRepository $eventRepository)
-    {
-        $this->ticketTypeAvailability = $ticketTypeAvailability;
-        $this->eventRepository = $eventRepository;
+    public function __construct(
+        private readonly TicketTypeAvailability $ticketTypeAvailability,
+        private readonly EventRepository $eventRepository,
+    ) {
     }
 
     public function validate($ticket, Constraint $constraint): void

--- a/sources/AppBundle/Event/Validator/Constraints/CorporateMemberValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/CorporateMemberValidator.php
@@ -17,20 +17,11 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class CorporateMemberValidator extends ConstraintValidator
 {
-    private TokenStorageInterface $tokenStorage;
-
-    private CompanyMemberRepository $companyMemberRepository;
-
-    private TicketRepository $ticketRepository;
-
     public function __construct(
-        TokenStorageInterface $tokenStorage,
-        CompanyMemberRepository $companyMemberRepository,
-        TicketRepository $ticketRepository
+        private readonly TokenStorageInterface $tokenStorage,
+        private readonly CompanyMemberRepository $companyMemberRepository,
+        private readonly TicketRepository $ticketRepository,
     ) {
-        $this->tokenStorage = $tokenStorage;
-        $this->companyMemberRepository = $companyMemberRepository;
-        $this->ticketRepository = $ticketRepository;
     }
 
     public function validate($tickets, Constraint $constraint): void

--- a/sources/AppBundle/Event/Validator/Constraints/LoggedInMemberValidator.php
+++ b/sources/AppBundle/Event/Validator/Constraints/LoggedInMemberValidator.php
@@ -14,11 +14,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class LoggedInMemberValidator extends ConstraintValidator
 {
-    private TokenStorageInterface $tokenStorage;
-
-    public function __construct(TokenStorageInterface $tokenStorage)
+    public function __construct(private readonly TokenStorageInterface $tokenStorage)
     {
-        $this->tokenStorage = $tokenStorage;
     }
 
     public function validate($ticket, Constraint $constraint): void

--- a/sources/AppBundle/GeneralMeeting/Attendee.php
+++ b/sources/AppBundle/GeneralMeeting/Attendee.php
@@ -9,29 +9,6 @@ use DateTimeImmutable;
 
 class Attendee
 {
-    /** @var int */
-    private $id;
-    /** @var string */
-    private $email;
-    /** @var string */
-    private $login;
-    /** @var string */
-    private $lastname;
-    /** @var string */
-    private $firstname;
-    /** @var string */
-    private $nearestOffice;
-    /** @var DateTimeImmutable|null */
-    private $consultationDate;
-    /** @var int */
-    private $presence;
-    /** @var int|null */
-    private $powerId;
-    /** @var string|null */
-    private $powerLastname;
-    /** @var string|null */
-    private $powerFirstname;
-
     /**
      * @param int                    $id
      * @param string                 $email
@@ -46,29 +23,18 @@ class Attendee
      * @param string|null            $powerFirstname
      */
     public function __construct(
-        $id,
-        $email,
-        $login,
-        $lastname,
-        $firstname,
-        $nearestOffice,
-        $consultationDate,
-        $presence,
-        $powerId,
-        $powerLastname,
-        $powerFirstname
+        private $id,
+        private $email,
+        private $login,
+        private $lastname,
+        private $firstname,
+        private $nearestOffice,
+        private $consultationDate,
+        private $presence,
+        private $powerId,
+        private $powerLastname,
+        private $powerFirstname,
     ) {
-        $this->id = $id;
-        $this->email = $email;
-        $this->login = $login;
-        $this->lastname = $lastname;
-        $this->firstname = $firstname;
-        $this->nearestOffice = $nearestOffice;
-        $this->consultationDate = $consultationDate;
-        $this->presence = $presence;
-        $this->powerId = $powerId;
-        $this->powerLastname = $powerLastname;
-        $this->powerFirstname = $powerFirstname;
     }
 
     public function getId()

--- a/sources/AppBundle/GeneralMeeting/GeneralMeeting.php
+++ b/sources/AppBundle/GeneralMeeting/GeneralMeeting.php
@@ -4,22 +4,8 @@ declare(strict_types=1);
 
 namespace AppBundle\GeneralMeeting;
 
-use DateTimeInterface;
-
 class GeneralMeeting
 {
-    /** @var int */
-    private $id;
-    /** @var int */
-    private $personnePhysiqueId;
-    private \DateTimeInterface $date;
-    /** @var int */
-    private $presence;
-    /** @var int */
-    private $personneAvecPouvoirId;
-    private ?\DateTimeInterface $consultationDate;
-    private ?\DateTimeInterface $modificationDate;
-
     /**
      * @param int $id
      * @param int $personnePhysiqueId
@@ -27,21 +13,14 @@ class GeneralMeeting
      * @param int $personneAvecPouvoirId
      */
     public function __construct(
-        $id,
-        $personnePhysiqueId,
-        DateTimeInterface $date,
-        $presence,
-        $personneAvecPouvoirId,
-        DateTimeInterface $consultationDate = null,
-        DateTimeInterface $modificationDate = null
+        private $id,
+        private $personnePhysiqueId,
+        private readonly \DateTimeInterface $date,
+        private $presence,
+        private $personneAvecPouvoirId,
+        private readonly ?\DateTimeInterface $consultationDate = null,
+        private readonly ?\DateTimeInterface $modificationDate = null,
     ) {
-        $this->id = $id;
-        $this->personnePhysiqueId = $personnePhysiqueId;
-        $this->date = $date;
-        $this->presence = $presence;
-        $this->personneAvecPouvoirId = $personneAvecPouvoirId;
-        $this->consultationDate = $consultationDate;
-        $this->modificationDate = $modificationDate;
     }
 
     public function getId()

--- a/sources/AppBundle/GeneralMeeting/GeneralMeetingQuestionFormType.php
+++ b/sources/AppBundle/GeneralMeeting/GeneralMeetingQuestionFormType.php
@@ -22,8 +22,8 @@ class GeneralMeetingQuestionFormType extends AbstractType
                 'label' => 'Question',
                 'constraints' => [
                     new NotBlank(),
-                    new Length(['min' => 5, 'max' => 255])
-                ]
+                    new Length(['min' => 5, 'max' => 255]),
+                ],
             ])
             ->add('submit', SubmitType::class);
     }

--- a/sources/AppBundle/GeneralMeeting/GeneralMeetingRepository.php
+++ b/sources/AppBundle/GeneralMeeting/GeneralMeetingRepository.php
@@ -13,11 +13,8 @@ use Doctrine\DBAL\DBALException;
 
 class GeneralMeetingRepository
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**
@@ -32,7 +29,7 @@ ORDER BY apag.date DESC
 SQL
         );
 
-        return array_map(static fn (array $row) => new DateTimeImmutable('@' . $row['date']), $query->fetchAll());
+        return array_map(static fn (array $row): \DateTimeImmutable => new DateTimeImmutable('@' . $row['date']), $query->fetchAll());
     }
 
     /**
@@ -104,7 +101,7 @@ SQL
 
         return is_array($row) ? [
             'date' => new \DateTimeImmutable('@' . $row['date']),
-            'description' => $row['description']
+            'description' => $row['description'],
         ] : null;
     }
 

--- a/sources/AppBundle/Github/GithubClient.php
+++ b/sources/AppBundle/Github/GithubClient.php
@@ -11,11 +11,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class GithubClient
 {
-    private HttpClientInterface $httpClient;
-
-    public function __construct(HttpClientInterface $githubClient)
+    public function __construct(private readonly HttpClientInterface $httpClient)
     {
-        $this->httpClient = $githubClient;
     }
 
     /**

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Edge.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Edge.php
@@ -9,10 +9,7 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
  */
 final class Edge
 {
-    public Node $node;
-
-    public function __construct(Node $node)
+    public function __construct(public Node $node)
     {
-        $this->node = $node;
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Events.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Events.php
@@ -9,14 +9,10 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
  */
 final class Events
 {
-    /** @var list<Edge> */
-    public array $edges;
-
     /**
      * @param list<Edge> $edges
      */
-    public function __construct(array $edges)
+    public function __construct(public array $edges)
     {
-        $this->edges = $edges;
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Group.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Group.php
@@ -9,12 +9,9 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
  */
 final class Group
 {
-    public Events $upcomingEvents;
-    public Events $pastEvents;
-
-    public function __construct(Events $upcomingEvents, Events $pastEvents)
-    {
-        $this->upcomingEvents = $upcomingEvents;
-        $this->pastEvents = $pastEvents;
+    public function __construct(
+        public Events $upcomingEvents,
+        public Events $pastEvents,
+    ) {
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Node.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Node.php
@@ -11,18 +11,12 @@ use DateTime;
  */
 final class Node
 {
-    public string $id;
-    public string $title;
-    public string $description;
-    public DateTime $dateTime;
-    public ?Venue $venue;
-
-    public function __construct(string $id, string $title, string $description, DateTime $dateTime, ?Venue $venue)
-    {
-        $this->id = $id;
-        $this->title = $title;
-        $this->description = $description;
-        $this->dateTime = $dateTime;
-        $this->venue = $venue;
+    public function __construct(
+        public string $id,
+        public string $title,
+        public string $description,
+        public DateTime $dateTime,
+        public ?Venue $venue,
+    ) {
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/QueryGroupsResponse.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/QueryGroupsResponse.php
@@ -9,14 +9,10 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
  */
 final class QueryGroupsResponse
 {
-    /** @var array<string, Group> */
-    public array $data;
-
     /**
      * @param array<string, Group> $data
      */
-    public function __construct(array $data)
+    public function __construct(public array $data)
     {
-        $this->data = $data;
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Venue.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Venue.php
@@ -9,10 +9,7 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
  */
 final class Venue
 {
-    public string $name;
-
-    public function __construct(string $name)
+    public function __construct(public string $name)
     {
-        $this->name = $name;
     }
 }

--- a/sources/AppBundle/Indexation/Meetups/MeetupClient.php
+++ b/sources/AppBundle/Indexation/Meetups/MeetupClient.php
@@ -11,18 +11,15 @@ use CuyZ\Valinor\Mapper\Source\Source;
 use CuyZ\Valinor\MapperBuilder;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class MeetupClient
+final readonly class MeetupClient
 {
     private const QUANTITY_PAST_EVENTS = 2;
     private const QUANTITY_UPCOMING_EVENTS = 10;
 
-    private HttpClientInterface $httpClient;
-    private AntennesCollection $antennesCollection;
-
-    public function __construct(HttpClientInterface $httpClient, AntennesCollection $antennesCollection)
-    {
-        $this->httpClient = $httpClient;
-        $this->antennesCollection = $antennesCollection;
+    public function __construct(
+        private HttpClientInterface $httpClient,
+        private AntennesCollection $antennesCollection,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Indexation/Meetups/Runner.php
+++ b/sources/AppBundle/Indexation/Meetups/Runner.php
@@ -13,16 +13,12 @@ use CCMBenchmark\Ting\Repository\CollectionInterface;
 
 class Runner
 {
-    protected SearchClient $algoliaClient;
-
-    protected MeetupRepository $meetupRepository;
-
     protected Transformer $transformer;
 
-    public function __construct(SearchClient $algoliaClient, MeetupRepository $meetupRepository)
-    {
-        $this->algoliaClient = $algoliaClient;
-        $this->meetupRepository = $meetupRepository;
+    public function __construct(
+        protected SearchClient $algoliaClient,
+        protected MeetupRepository $meetupRepository,
+    ) {
         $this->transformer = new Transformer(new AntennesCollection());
     }
 
@@ -36,7 +32,7 @@ class Runner
 
         $index->clearObjects();
         $index->saveObjects($meetups, [
-            'objectIDKey' => 'meetup_id'
+            'objectIDKey' => 'meetup_id',
         ]);
 
         echo "Indexation des meetups terminée avec succès !\n";

--- a/sources/AppBundle/Indexation/Meetups/Transformer.php
+++ b/sources/AppBundle/Indexation/Meetups/Transformer.php
@@ -12,11 +12,8 @@ class Transformer
 {
     const MEETUP_URL = 'https://www.meetup.com/fr-FR/';
 
-    private AntennesCollection $antennesCollection;
-
-    public function __construct(AntennesCollection $antennesCollection)
+    public function __construct(private readonly AntennesCollection $antennesCollection)
     {
-        $this->antennesCollection = $antennesCollection;
     }
 
     /**

--- a/sources/AppBundle/Indexation/Talks/Runner.php
+++ b/sources/AppBundle/Indexation/Talks/Runner.php
@@ -17,16 +17,12 @@ use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
 
 class Runner
 {
-    protected SearchClient $algoliaClient;
-
-    protected RepositoryFactory $ting;
-
     protected Transformer $transformer;
 
-    public function __construct(SearchClient $algoliaClient, RepositoryFactory $ting)
-    {
-        $this->algoliaClient = $algoliaClient;
-        $this->ting = $ting;
+    public function __construct(
+        protected SearchClient $algoliaClient,
+        protected RepositoryFactory $ting,
+    ) {
         $this->transformer = new Transformer();
     }
 
@@ -46,7 +42,7 @@ class Runner
 
         $index->clearObjects();
         $index->saveObjects($objects, [
-            'objectIDKey' => 'planning_id'
+            'objectIDKey' => 'planning_id',
         ]);
     }
 

--- a/sources/AppBundle/Joindin/JoindinComments.php
+++ b/sources/AppBundle/Joindin/JoindinComments.php
@@ -9,11 +9,8 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class JoindinComments
 {
-    private CacheItemPoolInterface $cache;
-
-    public function __construct(CacheItemPoolInterface $cache)
+    public function __construct(private readonly CacheItemPoolInterface $cache)
     {
-        $this->cache = $cache;
     }
 
     public function getCommentsFromTalk(Talk $talk): array
@@ -24,7 +21,7 @@ class JoindinComments
 
         try {
             return $this->getCommmentsFromId($talk->getJoindinId());
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return [];
         }
     }

--- a/sources/AppBundle/Joindin/JoindinTalk.php
+++ b/sources/AppBundle/Joindin/JoindinTalk.php
@@ -9,11 +9,8 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class JoindinTalk
 {
-    private CacheItemPoolInterface $cache;
-
-    public function __construct(CacheItemPoolInterface $cache)
+    public function __construct(private readonly CacheItemPoolInterface $cache)
     {
-        $this->cache = $cache;
     }
 
 
@@ -25,7 +22,7 @@ class JoindinTalk
 
         try {
             return $this->prepareStubFromJoindinResponse($this->callJoindInApi($talk->getJoindinId()));
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return null;
         }
     }

--- a/sources/AppBundle/Listener/LocaleEventSubscriber.php
+++ b/sources/AppBundle/Listener/LocaleEventSubscriber.php
@@ -11,10 +11,8 @@ use Symfony\Component\HttpKernel\KernelEvents;
 
 class LocaleEventSubscriber implements EventSubscriberInterface
 {
-    private $defaultLocale;
-    public function __construct($defaultLocale)
+    public function __construct(private $defaultLocale)
     {
-        $this->defaultLocale = $defaultLocale;
     }
 
     public function onKernelRequest(RequestEvent $event): void

--- a/sources/AppBundle/Mailchimp/EventEventSubscriber.php
+++ b/sources/AppBundle/Mailchimp/EventEventSubscriber.php
@@ -9,14 +9,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class EventEventSubscriber implements EventSubscriberInterface
 {
-    private Mailchimp $mailchimp;
-
-    private $membersList;
-
-    public function __construct(Mailchimp $mailchimp, $membersList)
-    {
-        $this->mailchimp = $mailchimp;
-        $this->membersList = $membersList;
+    public function __construct(
+        private readonly Mailchimp $mailchimp,
+        private $membersList,
+    ) {
     }
 
     public function onUserDisabled(UserDisabledEvent $userDisabledEvent): void

--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -11,11 +11,8 @@ class Mailchimp
 {
     private const MAX_MEMBERS_PER_PAGE = 50;
 
-    private DrewMailChimp $client;
-
-    public function __construct(DrewMailChimp $client)
+    public function __construct(private readonly DrewMailChimp $client)
     {
-        $this->client = $client;
     }
 
     /**
@@ -28,7 +25,7 @@ class Mailchimp
         return $this->client->put('lists/' . $list . '/members/' . $this->getAddressId($email), [
             'status' => 'pending',
             'email_address' => $email,
-            'language' => 'fr'
+            'language' => 'fr',
         ]);
     }
 
@@ -37,7 +34,7 @@ class Mailchimp
         return $this->client->put('lists/' . $list . '/members/' . $this->getAddressId($email), [
             'status' => 'subscribed',
             'email_address' => $email,
-            'language' => 'fr'
+            'language' => 'fr',
         ]);
     }
 
@@ -92,7 +89,7 @@ class Mailchimp
     {
         return $this->client->put('lists/' . $list . '/members/' . $this->getAddressId($email), [
             'status' => 'unsubscribed',
-            'email_address' => $email
+            'email_address' => $email,
         ]);
     }
 
@@ -126,14 +123,14 @@ class Mailchimp
             'recipients' => [
                 'list_id' => $list,
             ],
-            'settings' => $settings
+            'settings' => $settings,
         ]);
     }
 
     public function scheduleCampaign(string $campaignId, \DateTime $datetime)
     {
         return $this->client->post('campaigns/' . $campaignId . '/actions/schedule', [
-            'schedule_time' => $datetime->format('c')
+            'schedule_time' => $datetime->format('c'),
         ]);
     }
 }

--- a/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
+++ b/sources/AppBundle/Mailchimp/MailchimpMembersAutoListSynchronizer.php
@@ -10,19 +10,13 @@ use Psr\Log\NullLogger;
 
 class MailchimpMembersAutoListSynchronizer
 {
-    private Mailchimp $mailchimp;
-
-    private UserRepository $userRepository;
-
-    private string $listId;
-
     private LoggerInterface $logger;
 
-    public function __construct(Mailchimp $mailchimp, UserRepository $userRepository, string $listId)
-    {
-        $this->mailchimp = $mailchimp;
-        $this->userRepository = $userRepository;
-        $this->listId = $listId;
+    public function __construct(
+        private readonly Mailchimp $mailchimp,
+        private readonly UserRepository $userRepository,
+        private readonly string $listId,
+    ) {
         $this->logger = new NullLogger();
     }
 
@@ -84,7 +78,7 @@ class MailchimpMembersAutoListSynchronizer
         }
 
         if ($errors !== []) {
-            throw new \RuntimeException('Errors during subscribeAddresses : ' . implode($errors, PHP_EOL));
+            throw new \RuntimeException('Errors during subscribeAddresses : ' . implode(PHP_EOL, $errors));
         }
     }
 

--- a/sources/AppBundle/Mailchimp/Runner.php
+++ b/sources/AppBundle/Mailchimp/Runner.php
@@ -9,27 +9,19 @@ use AppBundle\Association\Model\User;
 
 class Runner
 {
-    private Mailchimp $mailchimp;
-
-    private UserRepository $userRepository;
-
-    /**
-     * @var string id of the mailchimp list to use
-     */
-    private $membersListId;
-
     /**
      * Runner constructor.
      * @param $membersListId
+     * @param string $membersListId
      */
     public function __construct(
-        Mailchimp $mailchimp,
-        UserRepository $userRepository,
-        $membersListId
+        private readonly Mailchimp $mailchimp,
+        private readonly UserRepository $userRepository,
+        /**
+         * @var string id of the mailchimp list to use
+         */
+        private $membersListId,
     ) {
-        $this->mailchimp = $mailchimp;
-        $this->userRepository = $userRepository;
-        $this->membersListId = $membersListId;
     }
 
     /**

--- a/sources/AppBundle/Model/CollectionFilter.php
+++ b/sources/AppBundle/Model/CollectionFilter.php
@@ -18,7 +18,7 @@ class CollectionFilter
 
         return array_filter($items, function ($item) use ($method, $value): bool {
             if (method_exists($item, $method) === false) {
-                throw new \RuntimeException(sprintf('Could not find method "%s" on object of type "%s"', $method, get_class($item)));
+                throw new \RuntimeException(sprintf('Could not find method "%s" on object of type "%s"', $method, $item::class));
             }
             return $item->$method() === $value;
         });

--- a/sources/AppBundle/Notifier/SlackNotifier.php
+++ b/sources/AppBundle/Notifier/SlackNotifier.php
@@ -15,17 +15,12 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class SlackNotifier
 {
-    private string $postUrl;
-    private MessageFactory $messageFactory;
-    private Serializer $serializer;
-    private HttpClientInterface $httpClient;
-
-    public function __construct(string $postUrl, MessageFactory $messageFactory, Serializer $serializer, HttpClientInterface $httpClient)
-    {
-        $this->postUrl = $postUrl;
-        $this->messageFactory = $messageFactory;
-        $this->serializer = $serializer;
-        $this->httpClient = $httpClient;
+    public function __construct(
+        private readonly string $postUrl,
+        private readonly MessageFactory $messageFactory,
+        private readonly Serializer $serializer,
+        private readonly HttpClientInterface $httpClient,
+    ) {
     }
 
     public function notifyVote(Vote $vote): void

--- a/sources/AppBundle/Offices/OfficeFinder.php
+++ b/sources/AppBundle/Offices/OfficeFinder.php
@@ -15,15 +15,12 @@ class OfficeFinder
 {
     public const MAX_DISTANCE_TO_OFFICE = 50000;
 
-    private AntennesCollection $antennesCollection;
-
-    private Geocoder $geocoder;
+    private readonly AntennesCollection $antennesCollection;
 
     private array $geocodeCache = [];
 
-    public function __construct(Geocoder $geocoder)
+    public function __construct(private readonly Geocoder $geocoder)
     {
-        $this->geocoder = $geocoder;
         $this->antennesCollection = new AntennesCollection();
     }
 
@@ -69,13 +66,13 @@ class OfficeFinder
             $addressCollection = $this->geocodeAddresses([
                 $user->getZipCode() . ' ' . $user->getCity() . ' ' . $user->getCountry(),
                 $user->getZipCode() . ' ' . $user->getCity(),
-                $user->getCity()
+                $user->getCity(),
             ]);
         } else {
             $addressCollection = $this->geocodeAddresses([
                 $invoice->getZipCode() . ' ' . $invoice->getCity() . ' ' . $invoice->getCountryId(),
                 $invoice->getZipCode() . ' ' . $invoice->getCity(),
-                $invoice->getCity()
+                $invoice->getCity(),
             ]);
         }
 

--- a/sources/AppBundle/Openfeedback/OpenfeedbackJsonGenerator.php
+++ b/sources/AppBundle/Openfeedback/OpenfeedbackJsonGenerator.php
@@ -14,14 +14,10 @@ use AppBundle\Event\Model\Talk;
 
 class OpenfeedbackJsonGenerator
 {
-    private TalkRepository $talkRepository;
-
-    private PhotoStorage $photoStorage;
-
-    public function __construct(TalkRepository $talkRepository, PhotoStorage $photoStorage)
-    {
-        $this->talkRepository = $talkRepository;
-        $this->photoStorage = $photoStorage;
+    public function __construct(
+        private readonly TalkRepository $talkRepository,
+        private readonly PhotoStorage $photoStorage,
+    ) {
     }
 
     public function generate(Event $event): array
@@ -60,7 +56,7 @@ class OpenfeedbackJsonGenerator
                         [
                             'Présentation',
                             'link' => sprintf('https://event.afup.org/%s/speakers/#%d', $event->getPath(), $speaker->getId()),
-                        ]
+                        ],
                     ],
                     'id' => "{$speaker->getId()}",
                 ];

--- a/sources/AppBundle/Payment/Paybox.php
+++ b/sources/AppBundle/Payment/Paybox.php
@@ -26,12 +26,6 @@ class Paybox
     const TYPE_PAIEMENT = 'CARTE';
     const TYPECARTE = 'CB';
 
-    private $domainServer;
-    private $secretKey;
-    private $site;
-    private $rang;
-    private $identifiant;
-
     private $total = 0;
     private $cmd;
     private $porteur;
@@ -40,14 +34,13 @@ class Paybox
     private $urlRetourAnnule;
     private $urlRepondreA;
 
-    public function __construct($domainServer, $secretKey, $site, $rang, $identifiant)
-    {
-        // la configuration des domainServer est visible ici http://www.paybox.com/espace-integrateur-documentation/la-solution-paybox-system/urls-dappels-et-adresses-ip/
-        $this->domainServer = $domainServer;
-        $this->secretKey = $secretKey;
-        $this->site = $site;
-        $this->rang = $rang;
-        $this->identifiant = $identifiant;
+    public function __construct(
+        private $domainServer,
+        private $secretKey,
+        private $site,
+        private $rang,
+        private $identifiant,
+    ) {
     }
 
     public function generate(\DateTimeInterface $now, PayboxBilling $payboxBilling, $quantity = 1): string
@@ -108,7 +101,7 @@ class Paybox
         $htmlForm = '<form method="POST" action="https://' . $this->domainServer . '/cgi/MYchoix_pagepaiement.cgi">' . PHP_EOL;
         foreach ($sanitizedInputs as $inputKey => $inputValue) {
             if (in_array($inputKey, self::SPECIAL_CHARS_INPUTS)) {
-                $inputValue = htmlspecialchars($inputValue);
+                $inputValue = htmlspecialchars((string) $inputValue);
             }
             $htmlForm .= '  <input type="hidden" name="' . $inputKey . '" value="' . $inputValue . '">' . PHP_EOL;
         }
@@ -165,7 +158,7 @@ class Paybox
 
     private function preparePbxBillingValue($value, int $maxLength, $default)
     {
-        $value = $value ? trim($value) : '';
+        $value = $value ? trim((string) $value) : '';
 
         if ($value === '') {
             $value = $default;

--- a/sources/AppBundle/Payment/PayboxBilling.php
+++ b/sources/AppBundle/Payment/PayboxBilling.php
@@ -9,21 +9,14 @@ use League\ISO3166\ISO3166;
 
 class PayboxBilling
 {
-    private $firstName;
-    private $lastName;
-    private $address1;
-    private $zipCode;
-    private $city;
-    private $countryCode;
-
-    public function __construct($firstName, $lastName, $address1, $zipCode, $city, $countryCode)
-    {
-        $this->firstName = $firstName;
-        $this->lastName = $lastName;
-        $this->address1 = $address1;
-        $this->zipCode = $zipCode;
-        $this->city = $city;
-        $this->countryCode = $countryCode;
+    public function __construct(
+        private $firstName,
+        private $lastName,
+        private $address1,
+        private $zipCode,
+        private $city,
+        private $countryCode,
+    ) {
     }
 
     /**
@@ -82,7 +75,7 @@ class PayboxBilling
             $data = (new ISO3166)->alpha2($country);
 
             return $data['numeric'];
-        } catch (\Exception $exception) {
+        } catch (\Exception) {
             return null;
         }
     }

--- a/sources/AppBundle/Payment/PayboxFactory.php
+++ b/sources/AppBundle/Payment/PayboxFactory.php
@@ -11,22 +11,14 @@ use Symfony\Component\Routing\RouterInterface;
 
 class PayboxFactory
 {
-    private RouterInterface $router;
-
-    private $payboxDomainServer;
-    private $payboxSecretKey;
-    private $payboxSite;
-    private $payboxRang;
-    private $payboxIdentifiant;
-
-    public function __construct(RouterInterface $router, $payboxDomainServer, $payboxSecretKey, $payboxSite, $payboxRang, $payboxIdentifiant)
-    {
-        $this->router = $router;
-        $this->payboxDomainServer = $payboxDomainServer;
-        $this->payboxSecretKey = $payboxSecretKey;
-        $this->payboxSite = $payboxSite;
-        $this->payboxRang = $payboxRang;
-        $this->payboxIdentifiant = $payboxIdentifiant;
+    public function __construct(
+        private readonly RouterInterface $router,
+        private $payboxDomainServer,
+        private $payboxSecretKey,
+        private $payboxSite,
+        private $payboxRang,
+        private $payboxIdentifiant,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Payment/PayboxResponse.php
+++ b/sources/AppBundle/Payment/PayboxResponse.php
@@ -15,37 +15,19 @@ class PayboxResponse
     const STATUS_DUPLICATE = '00015';
 
     /**
-     * @var string
+     * @param string $cmd
+     * @param string $status
+     * @param int $total
+     * @param string $authorizationId
+     * @param string $transactionId
      */
-    private $cmd;
-
-    /**
-     * @var string
-     */
-    private $status;
-
-    /**
-     * @var int
-     */
-    private $total;
-
-    /**
-     * @var string
-     */
-    private $authorizationId;
-
-    /**
-     * @var string
-     */
-    private $transactionId;
-
-    public function __construct($cmd, $status, $total, $authorizationId, $transactionId)
-    {
-        $this->cmd = $cmd;
-        $this->status = $status;
-        $this->total = $total;
-        $this->authorizationId = $authorizationId;
-        $this->transactionId = $transactionId;
+    public function __construct(
+        private $cmd,
+        private $status,
+        private $total,
+        private $authorizationId,
+        private $transactionId,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/Payment/PayboxResponseFactory.php
+++ b/sources/AppBundle/Payment/PayboxResponseFactory.php
@@ -13,7 +13,7 @@ class PayboxResponseFactory
         $keys = [
             'cmd',
             'transaction',
-            'status'
+            'status',
         ];
         foreach ($keys as $key) {
             if ($request->query->has($key) === false) {

--- a/sources/AppBundle/Planete/FeedFormData.php
+++ b/sources/AppBundle/Planete/FeedFormData.php
@@ -11,20 +11,20 @@ class FeedFormData
 {
     /**
      * @var string
-     * @Assert\NotBlank()
      */
+    #[Assert\NotBlank]
     public $name;
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Url()
      */
+    #[Assert\NotBlank]
+    #[Assert\Url]
     public $url = 'https://';
     /**
      * @var string
-     * @Assert\NotBlank()
-     * @Assert\Url()
      */
+    #[Assert\NotBlank]
+    #[Assert\Url]
     public $feed = 'https://';
     /**
      * @var int|null
@@ -32,7 +32,7 @@ class FeedFormData
     public $userId;
     /**
      * @var int
-     * @Assert\Choice(choices={0, 1}, strict=true)
      */
+    #[Assert\Choice(choices: [Feed::STATUS_INACTIVE, Feed::STATUS_ACTIVE], strict: true)]
     public $status = Feed::STATUS_ACTIVE;
 }

--- a/sources/AppBundle/Planete/FeedFormType.php
+++ b/sources/AppBundle/Planete/FeedFormType.php
@@ -15,11 +15,8 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class FeedFormType extends AbstractType
 {
-    private UserRepository $userRepository;
-
-    public function __construct(UserRepository $userRepository)
+    public function __construct(private readonly UserRepository $userRepository)
     {
-        $this->userRepository = $userRepository;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/sources/AppBundle/Security/ActionThrottling/ActionThrottling.php
+++ b/sources/AppBundle/Security/ActionThrottling/ActionThrottling.php
@@ -6,11 +6,8 @@ namespace AppBundle\Security\ActionThrottling;
 
 class ActionThrottling
 {
-    private LogRepository $logRepository;
-
-    public function __construct(LogRepository $logRepository)
+    public function __construct(private readonly LogRepository $logRepository)
     {
-        $this->logRepository = $logRepository;
     }
 
     /**

--- a/sources/AppBundle/Security/ActionThrottling/Log.php
+++ b/sources/AppBundle/Security/ActionThrottling/Log.php
@@ -11,7 +11,7 @@ class Log implements NotifyPropertyInterface
 {
     const ACTION_SPONSOR_TOKEN = 'sponsor_token';
     const LIMITATIONS = [
-        self::ACTION_SPONSOR_TOKEN => ['delay' => 'PT1H', 'limit' => 10]
+        self::ACTION_SPONSOR_TOKEN => ['delay' => 'PT1H', 'limit' => 10],
     ];
 
     use NotifyProperty;

--- a/sources/AppBundle/Security/ActionThrottling/LogRepository.php
+++ b/sources/AppBundle/Security/ActionThrottling/LogRepository.php
@@ -39,7 +39,7 @@ class LogRepository extends Repository implements MetadataInitializer
         $createdOn->sub($interval);
 
         $params = [
-            'createdOn' => $createdOn->format('Y-m-d H:i:s')
+            'createdOn' => $createdOn->format('Y-m-d H:i:s'),
         ];
 
         $where = [];
@@ -73,7 +73,7 @@ class LogRepository extends Repository implements MetadataInitializer
         ');
         $query->setParams([
             'action' => $action,
-            'ip' => ip2long($ip)
+            'ip' => ip2long($ip),
         ]);
 
         $query->execute();
@@ -87,7 +87,7 @@ class LogRepository extends Repository implements MetadataInitializer
         ');
         $date = (new \DateTime())->sub($delay);
         $query->setParams([
-            'date' => $date->format('Y-m-d H:i:s')
+            'date' => $date->format('Y-m-d H:i:s'),
         ]);
 
         $query->execute();
@@ -110,27 +110,27 @@ class LogRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'ip',
                 'fieldName' => 'ip',
-                'type' => 'ip'
+                'type' => 'ip',
             ])
             ->addField([
                 'columnName' => 'action',
                 'fieldName' => 'action',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'object_id',
                 'fieldName' => 'objectId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'created_on',
                 'fieldName' => 'createdOn',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
         ;
 

--- a/sources/AppBundle/Security/GithubAuthenticator.php
+++ b/sources/AppBundle/Security/GithubAuthenticator.php
@@ -24,15 +24,11 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 
 class GithubAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
-    private ClientRegistry $clientRegistry;
-    private GithubUserRepository $githubUserRepository;
-    private RouterInterface $router;
-
-    public function __construct(ClientRegistry $clientRegistry, GithubUserRepository $githubUserRepository, RouterInterface $router)
-    {
-        $this->clientRegistry = $clientRegistry;
-        $this->githubUserRepository = $githubUserRepository;
-        $this->router = $router;
+    public function __construct(
+        private readonly ClientRegistry $clientRegistry,
+        private readonly GithubUserRepository $githubUserRepository,
+        private readonly RouterInterface $router,
+    ) {
     }
 
     public function authenticate(Request $request): SelfValidatingPassport
@@ -72,7 +68,7 @@ class GithubAuthenticator extends OAuth2Authenticator implements AuthenticationE
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonResponse
     {
         $data = [
-            'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
+            'message' => strtr($exception->getMessageKey(), $exception->getMessageData()),
         ];
 
         return new JsonResponse($data, Response::HTTP_FORBIDDEN);

--- a/sources/AppBundle/Security/TalkVoter.php
+++ b/sources/AppBundle/Security/TalkVoter.php
@@ -13,11 +13,8 @@ use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 class TalkVoter extends Voter
 {
-    private SpeakerRepository $speakerRepository;
-
-    public function __construct(SpeakerRepository $speakerRepository)
+    public function __construct(private readonly SpeakerRepository $speakerRepository)
     {
-        $this->speakerRepository = $speakerRepository;
     }
 
     /**

--- a/sources/AppBundle/Security/TestGithubAuthenticator.php
+++ b/sources/AppBundle/Security/TestGithubAuthenticator.php
@@ -20,11 +20,8 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 
 class TestGithubAuthenticator extends OAuth2Authenticator implements AuthenticationEntryPointInterface
 {
-    private GithubUserRepository $githubUserRepository;
-
-    public function __construct(GithubUserRepository $githubUserRepository)
+    public function __construct(private readonly GithubUserRepository $githubUserRepository)
     {
-        $this->githubUserRepository = $githubUserRepository;
     }
 
     public function authenticate(Request $request): SelfValidatingPassport
@@ -75,7 +72,7 @@ class TestGithubAuthenticator extends OAuth2Authenticator implements Authenticat
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): JsonResponse
     {
         $data = [
-            'message' => strtr($exception->getMessageKey(), $exception->getMessageData())
+            'message' => strtr($exception->getMessageKey(), $exception->getMessageData()),
         ];
 
         return new JsonResponse($data, Response::HTTP_FORBIDDEN);

--- a/sources/AppBundle/Site/Form/NewsFiltersType.php
+++ b/sources/AppBundle/Site/Form/NewsFiltersType.php
@@ -15,11 +15,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class NewsFiltersType extends AbstractType
 {
-    private ArticleRepository $articleRepository;
-
-    public function __construct(ArticleRepository $articleRepository)
+    public function __construct(private readonly ArticleRepository $articleRepository)
     {
-        $this->articleRepository = $articleRepository;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void

--- a/sources/AppBundle/Site/Form/RubriqueType.php
+++ b/sources/AppBundle/Site/Form/RubriqueType.php
@@ -21,13 +21,10 @@ class RubriqueType extends AbstractType
 {
     const POSITIONS_RUBRIQUES = 9;
 
-    private RubriqueRepository $rubriqueRepository;
-    private UserRepository $userRepository;
-
-    public function __construct(RubriqueRepository $rubriqueRepository, UserRepository $userRepository)
-    {
-        $this->rubriqueRepository = $rubriqueRepository;
-        $this->userRepository = $userRepository;
+    public function __construct(
+        private readonly RubriqueRepository $rubriqueRepository,
+        private readonly UserRepository $userRepository,
+    ) {
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -96,7 +93,7 @@ class RubriqueType extends AbstractType
                         'minHeight' => 37,
                         'maxHeight' => 43,
                     ]),
-                ]
+                ],
             ])
             ->add('raccourci', TextType::class, [
                 'required' => true,

--- a/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
+++ b/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
@@ -84,7 +84,7 @@ class ArticleRepository extends Repository implements MetadataInitializer
             $params,
             [
                 'offset' => ($page - 1) * $itemsPerPage,
-                'limit' => $itemsPerPage
+                'limit' => $itemsPerPage,
             ]
         );
 
@@ -254,60 +254,60 @@ class ArticleRepository extends Repository implements MetadataInitializer
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_site_rubrique',
                 'fieldName' => 'rubricId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'raccourci',
                 'fieldName' => 'path',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'titre',
                 'fieldName' => 'title',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'chapeau',
                 'fieldName' => 'leadParagraph',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'contenu',
                 'fieldName' => 'content',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'type_contenu',
                 'fieldName' => 'contentType',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'theme',
                 'fieldName' => 'theme',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'id_forum',
                 'fieldName' => 'eventId',
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'date',
                 'fieldName' => 'publishedAt',
                 'type' => 'datetime',
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U']
-                ]
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                ],
             ])
             ->addField([
                 'columnName' => 'etat',
                 'fieldName' => 'state',
-                'type' => 'int'
+                'type' => 'int',
             ])
         ;
 

--- a/sources/AppBundle/Site/Model/Rubrique.php
+++ b/sources/AppBundle/Site/Model/Rubrique.php
@@ -18,9 +18,7 @@ class Rubrique implements NotifyPropertyInterface
     const ID_RUBRIQUE_INFORMATIONS_PRATIQUES = 86;
     const ID_RUBRIQUE_NOS_ACTIONS = 88;
 
-    /**
-     * @Assert\Type("integer")
-     */
+    #[Assert\Type('integer')]
     private $id;
 
     private $idPersonnePhysique;

--- a/sources/AppBundle/Slack/LegacyClient.php
+++ b/sources/AppBundle/Slack/LegacyClient.php
@@ -6,11 +6,8 @@ namespace AppBundle\Slack;
 
 class LegacyClient
 {
-    private $token;
-
-    public function __construct($token)
+    public function __construct(private $token)
     {
-        $this->token = $token;
     }
 
     public function invite($email): void

--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -20,14 +20,11 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 
 class MessageFactory
 {
-    private TranslatorInterface $translator;
-
     /**
      * MessageFactory constructor.
      */
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
     public function createMessageForVote(Vote $vote): Message

--- a/sources/AppBundle/Slack/UsersChecker.php
+++ b/sources/AppBundle/Slack/UsersChecker.php
@@ -11,14 +11,11 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 class UsersChecker
 {
     const SUBSCRIPTION_DELAY = '+15 days';
-    private UsersClient $usersClient;
 
-    private UserRepository $userRepository;
-
-    public function __construct(UsersClient $usersClient, UserRepository $userRepository)
-    {
-        $this->usersClient = $usersClient;
-        $this->userRepository = $userRepository;
+    public function __construct(
+        private readonly UsersClient $usersClient,
+        private readonly UserRepository $userRepository,
+    ) {
     }
 
     /**
@@ -69,7 +66,7 @@ class UsersChecker
                             $result[] = $userInfo;
                         }
                     }
-                } catch (UserNotFoundException $e) {
+                } catch (UserNotFoundException) {
                     //User Not found ! A supprimer de slack !
                     $result[] = $userInfo;
                 }

--- a/sources/AppBundle/Slack/UsersClient.php
+++ b/sources/AppBundle/Slack/UsersClient.php
@@ -11,22 +11,13 @@ class UsersClient
     const USER_LIST_API = '/users.list';
 
     /**
-     * @var string
-     */
-    private $token;
-    /**
-     * @var string
-     */
-    private $apiBaseUrl;
-
-    /**
      * @param string $token Token des API Slack
      * @param string $apiBaseUrl URL de base des API Slack
      */
-    public function __construct($token, $apiBaseUrl)
-    {
-        $this->token = $token;
-        $this->apiBaseUrl = $apiBaseUrl;
+    public function __construct(
+        private $token,
+        private $apiBaseUrl,
+    ) {
     }
 
     /**

--- a/sources/AppBundle/SocialNetwork/Bluesky/BlueskyPolyfill.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/BlueskyPolyfill.php
@@ -16,13 +16,10 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  *
  * @see https://github.com/symfony/bluesky-notifier/blob/7.2/BlueskyTransport.php
  */
-final class BlueskyPolyfill
+final readonly class BlueskyPolyfill
 {
-    private HttpClientInterface $httpClient;
-
-    public function __construct(HttpClientInterface $httpClient)
+    public function __construct(private HttpClientInterface $httpClient)
     {
-        $this->httpClient = $httpClient;
     }
 
     public function parseFacets(string $input): array
@@ -38,7 +35,7 @@ final class BlueskyPolyfill
             try {
                 $response = $this->httpClient->request('GET', '/xrpc/com.atproto.identity.resolveHandle', [
                     'query' => [
-                        'handle' => ltrim($match['match'], '@'),
+                        'handle' => ltrim((string) $match['match'], '@'),
                     ],
                 ]);
 
@@ -47,7 +44,7 @@ final class BlueskyPolyfill
                 }
 
                 $did = $response->toArray()['did'] ?? null;
-            } catch (ExceptionInterface $e) {
+            } catch (ExceptionInterface) {
                 continue;
             }
 

--- a/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/BlueskyTransport.php
@@ -16,16 +16,13 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class BlueskyTransport implements Transport
 {
-    private HttpClientInterface $httpClient;
-    private string $apiIdentifier;
-    private string $apiAppPassword;
     private ?Session $session = null;
 
-    public function __construct(HttpClientInterface $httpClient, string $apiIdentifier, string $apiAppPassword)
-    {
-        $this->httpClient = $httpClient;
-        $this->apiIdentifier = $apiIdentifier;
-        $this->apiAppPassword = $apiAppPassword;
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $apiIdentifier,
+        private readonly string $apiAppPassword,
+    ) {
     }
 
     public function socialNetwork(): SocialNetwork
@@ -106,7 +103,7 @@ final class BlueskyTransport implements Transport
         if ($embedData->imageUrl !== null) {
             try {
                 $thumbnail = $this->buildThumbnail($embedData->imageUrl);
-            } catch (Exception $e) {
+            } catch (Exception) {
                 // Si une erreur survient, on ne bloque pas la création du post.
                 // Il sera juste envoyé sans image.
                 return $embed;

--- a/sources/AppBundle/SocialNetwork/Bluesky/Session.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/Session.php
@@ -9,12 +9,9 @@ namespace AppBundle\SocialNetwork\Bluesky;
  */
 final class Session
 {
-    public string $did;
-    public string $accessJwt;
-
-    public function __construct(string $did, string $accessJwt)
-    {
-        $this->did = $did;
-        $this->accessJwt = $accessJwt;
+    public function __construct(
+        public string $did,
+        public string $accessJwt,
+    ) {
     }
 }

--- a/sources/AppBundle/SocialNetwork/Embed.php
+++ b/sources/AppBundle/SocialNetwork/Embed.php
@@ -9,16 +9,11 @@ namespace AppBundle\SocialNetwork;
  */
 final class Embed
 {
-    public string $url;
-    public string $title;
-    public string $abstract;
-    public ?string $imageUrl;
-
-    public function __construct(string $url, string $title, string $abstract, ?string $imageUrl)
-    {
-        $this->url = $url;
-        $this->title = $title;
-        $this->abstract = $abstract;
-        $this->imageUrl = $imageUrl;
+    public function __construct(
+        public string $url,
+        public string $title,
+        public string $abstract,
+        public ?string $imageUrl,
+    ) {
     }
 }

--- a/sources/AppBundle/SocialNetwork/Status.php
+++ b/sources/AppBundle/SocialNetwork/Status.php
@@ -9,12 +9,9 @@ namespace AppBundle\SocialNetwork;
  */
 final class Status
 {
-    public string $text;
-    public ?Embed $embed;
-
-    public function __construct(string $text, ?Embed $embed = null)
-    {
-        $this->text = $text;
-        $this->embed = $embed;
+    public function __construct(
+        public string $text,
+        public ?Embed $embed = null,
+    ) {
     }
 }

--- a/sources/AppBundle/SocialNetwork/StatusId.php
+++ b/sources/AppBundle/SocialNetwork/StatusId.php
@@ -9,10 +9,7 @@ namespace AppBundle\SocialNetwork;
  */
 final class StatusId
 {
-    public string $value;
-
-    public function __construct(string $value)
+    public function __construct(public string $value)
     {
-        $this->value = $value;
     }
 }

--- a/sources/AppBundle/SpeakerInfos/Form/HotelReservationType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/HotelReservationType.php
@@ -20,11 +20,8 @@ class HotelReservationType extends AbstractType
 {
     const NIGHT_NONE = 'none';
 
-    private TranslatorInterface $translator;
-
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(private readonly TranslatorInterface $translator)
     {
-        $this->translator = $translator;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -73,8 +70,8 @@ class HotelReservationType extends AbstractType
                                     ->addViolation()
                                 ;
                             }
-                        }])
-                    ]
+                        }]),
+                    ],
                 ]
             )
             ->add('submit', SubmitType::class, ['label' => 'Enregistrer'])
@@ -85,7 +82,7 @@ class HotelReservationType extends AbstractType
     {
         $resolver->setDefaults([
             'event' => null,
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
     }
 }

--- a/sources/AppBundle/SpeakerInfos/Form/SpeakersContactType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/SpeakersContactType.php
@@ -30,7 +30,7 @@ class SpeakersContactType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
     }
 }

--- a/sources/AppBundle/SpeakerInfos/Form/SpeakersDinerType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/SpeakersDinerType.php
@@ -55,7 +55,7 @@ class SpeakersDinerType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
     }
 }

--- a/sources/AppBundle/SpeakerInfos/Form/SpeakersExpensesType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/SpeakersExpensesType.php
@@ -32,13 +32,13 @@ class SpeakersExpensesType extends AbstractType
                                 'maxSize' => '2M',
                                 'mimeTypes' => [
                                     'application/pdf',
-                                    'application/x-pdf'
+                                    'application/x-pdf',
                                 ],
-                            ])
-                        ])
+                            ]),
+                        ]),
                     ],
                     'attr' => [
-                        'accept' => '.pdf'
+                        'accept' => '.pdf',
                     ],
                 ]
             )
@@ -49,7 +49,7 @@ class SpeakersExpensesType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'csrf_protection' => false
+            'csrf_protection' => false,
         ]);
     }
 }

--- a/sources/AppBundle/SpeakerInfos/SpeakersExpensesStorage.php
+++ b/sources/AppBundle/SpeakerInfos/SpeakersExpensesStorage.php
@@ -18,9 +18,10 @@ final class SpeakersExpensesStorage
 {
     private Filesystem $filesystem;
 
-    public function __construct(private readonly string $basePath,
+    public function __construct(
+        private readonly string $basePath,
                                 private readonly EventRepository $eventRepository,
-                                private readonly LoggerInterface $logger
+                                private readonly LoggerInterface $logger,
     ) {
         $this->filesystem = new Filesystem();
     }
@@ -62,7 +63,7 @@ final class SpeakersExpensesStorage
             $basename = str_replace(sprintf('%d_', $speaker->getId()), '', $file->getBasename());
             $files[] = [
                 'basename' => $basename,
-                'path' => $directory . '/' . $file->getBasename()
+                'path' => $directory . '/' . $file->getBasename(),
             ];
         }
         return $files;

--- a/sources/AppBundle/Subscriber/SitemapXmlSubscriber.php
+++ b/sources/AppBundle/Subscriber/SitemapXmlSubscriber.php
@@ -28,14 +28,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SitemapXmlSubscriber implements EventSubscriberInterface
 {
-    private UrlGeneratorInterface $urlGenerator;
-    private RepositoryFactory $ting;
-
-    public function __construct(UrlGeneratorInterface $urlGenerator,
-                                RepositoryFactory $ting)
-    {
-        $this->urlGenerator = $urlGenerator;
-        $this->ting = $ting;
+    public function __construct(
+        private readonly UrlGeneratorInterface $urlGenerator,
+        private readonly RepositoryFactory $ting,
+    ) {
     }
 
     public static function getSubscribedEvents(): array
@@ -79,7 +75,7 @@ class SitemapXmlSubscriber implements EventSubscriberInterface
                 $video = new GoogleVideo(
                     sprintf('https://img.youtube.com/vi/%s/0.jpg', $talk->getYoutubeId()),
                     $talk->getTitle(),
-                    strip_tags(html_entity_decode($talk->getDescription())),
+                    strip_tags(html_entity_decode((string) $talk->getDescription())),
                     ['player_location' => $talk->getYoutubeUrl()]
                 );
                 $decoratedUrl = new GoogleVideoUrlDecorator($url);
@@ -202,7 +198,7 @@ class SitemapXmlSubscriber implements EventSubscriberInterface
 
         $leafs = $branche->feuillesEnfants($id);
         foreach ($leafs as $leaf) {
-            if (!$leaf['lien'] || !str_starts_with($leaf['lien'], 'http')) {
+            if (!$leaf['lien'] || !str_starts_with((string) $leaf['lien'], 'http')) {
                 continue;
             }
 

--- a/sources/AppBundle/TechLetter/DataExtractor.php
+++ b/sources/AppBundle/TechLetter/DataExtractor.php
@@ -16,7 +16,7 @@ class DataExtractor
      */
     public function extractDataForTechLetter($url): array
     {
-        $urlInfo = parse_url($url);
+        $urlInfo = parse_url((string) $url);
 
         $urlCrawler = new UrlCrawler();
         $html = $urlCrawler->crawlUrl($url);
@@ -29,11 +29,11 @@ class DataExtractor
          * @todo fix it
          */
         $data = [
-            'title' => substr($parser->getTitle(), 0, 250),
-            'name' => substr($parser->getTitle(), 0, 250),
+            'title' => substr((string) $parser->getTitle(), 0, 250),
+            'name' => substr((string) $parser->getTitle(), 0, 250),
             'excerpt' => $parser->getMeta('description'),
             'description' => $parser->getMeta('description'),
-            'host' => $urlInfo['host']
+            'host' => $urlInfo['host'],
         ];
 
         $richSchema = $parser->getRichSchema();

--- a/sources/AppBundle/TechLetter/HtmlParser.php
+++ b/sources/AppBundle/TechLetter/HtmlParser.php
@@ -7,14 +7,14 @@ namespace AppBundle\TechLetter;
 
 class HtmlParser
 {
-    private \DOMDocument $dom;
+    private readonly \DOMDocument $dom;
 
     /**
      * @var \DOMNodeList&iterable<\DOMElement>
      */
-    private \DOMNodeList $meta;
+    private readonly \DOMNodeList $meta;
 
-    private \DOMXPath $xpath;
+    private readonly \DOMXPath $xpath;
 
     const OPEN_GRAPH_PREFIX = 'og';
     const TWITTER_PREFIX = 'twitter';
@@ -109,7 +109,7 @@ class HtmlParser
 
         $data = [];
         foreach ($jsonScripts as $script) {
-            $data[] = json_decode($script->nodeValue, true);
+            $data[] = json_decode((string) $script->nodeValue, true);
         }
         return $data;
     }

--- a/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
+++ b/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
@@ -11,19 +11,13 @@ use Psr\Log\NullLogger;
 
 class MailchimpSynchronizer
 {
-    private Mailchimp $mailchimp;
-
-    private TechletterSubscriptionsRepository $subscriptionsRepository;
-
-    private string $listId;
-
     private LoggerInterface $logger;
 
-    public function __construct(Mailchimp $mailchimp, TechletterSubscriptionsRepository $subscriptionsRepository, string $listId)
-    {
-        $this->mailchimp = $mailchimp;
-        $this->subscriptionsRepository = $subscriptionsRepository;
-        $this->listId = $listId;
+    public function __construct(
+        private readonly Mailchimp $mailchimp,
+        private readonly TechletterSubscriptionsRepository $subscriptionsRepository,
+        private readonly string $listId,
+    ) {
         $this->logger = new NullLogger();
     }
 

--- a/sources/AppBundle/TechLetter/Model/Article.php
+++ b/sources/AppBundle/TechLetter/Model/Article.php
@@ -7,24 +7,16 @@ namespace AppBundle\TechLetter\Model;
 class Article implements \JsonSerializable
 {
     private const DEFAULT_LANGUAGE = 'en';
+    private readonly string $language;
 
-    private string $url;
-    private string $title;
-    private string $host;
-
-    /** @var numeric-string */
-    private string $readingTime;
-
-    private string $excerpt;
-    private string $language;
-
-    public function __construct(string $url, string $title, string $host, string $readingTime, string $excerpt, ?string $language = self::DEFAULT_LANGUAGE)
-    {
-        $this->url = $url;
-        $this->title = $title;
-        $this->host = $host;
-        $this->readingTime = $readingTime;
-        $this->excerpt = $excerpt;
+    public function __construct(
+        private readonly string $url,
+        private readonly string $title,
+        private readonly string $host,
+        private readonly string $readingTime,
+        private readonly string $excerpt,
+        ?string $language = self::DEFAULT_LANGUAGE,
+    ) {
         $this->language = $language ?? self::DEFAULT_LANGUAGE;
     }
 

--- a/sources/AppBundle/TechLetter/Model/News.php
+++ b/sources/AppBundle/TechLetter/Model/News.php
@@ -6,15 +6,11 @@ namespace AppBundle\TechLetter\Model;
 
 class News implements \JsonSerializable
 {
-    private string $url;
-    private string $title;
-    private \DateTimeImmutable $date;
-
-    public function __construct(string $url, string $title, \DateTimeImmutable $date)
-    {
-        $this->url = $url;
-        $this->title = $title;
-        $this->date = $date;
+    public function __construct(
+        private readonly string $url,
+        private readonly string $title,
+        private readonly \DateTimeImmutable $date,
+    ) {
     }
 
     public function getUrl(): string
@@ -37,7 +33,7 @@ class News implements \JsonSerializable
         return [
             'url' => $this->url,
             'title' => $this->title,
-            'date' => $this->date->format('Y-m-d')
+            'date' => $this->date->format('Y-m-d'),
         ];
     }
 }

--- a/sources/AppBundle/TechLetter/Model/Project.php
+++ b/sources/AppBundle/TechLetter/Model/Project.php
@@ -6,15 +6,11 @@ namespace AppBundle\TechLetter\Model;
 
 class Project implements \JsonSerializable
 {
-    private string $url;
-    private string $name;
-    private string $description;
-
-    public function __construct(string $url, string $name, string $description)
-    {
-        $this->url = $url;
-        $this->name = $name;
-        $this->description = $description;
+    public function __construct(
+        private readonly string $url,
+        private readonly string $name,
+        private readonly string $description,
+    ) {
     }
 
     public function getUrl(): string
@@ -37,7 +33,7 @@ class Project implements \JsonSerializable
         return [
             'url' => $this->url,
             'name' => $this->name,
-            'description' => $this->description
+            'description' => $this->description,
         ];
     }
 }

--- a/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
+++ b/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
@@ -58,28 +58,28 @@ SQL;
                 'fieldName' => 'id',
                 'primary'       => true,
                 'autoincrement' => true,
-                'type' => 'int'
+                'type' => 'int',
             ])
             ->addField([
                 'columnName' => 'sending_date',
                 'fieldName' => 'sendingDate',
-                'type' => 'datetime'
+                'type' => 'datetime',
             ])
             ->addField([
                 'columnName' => 'techletter',
                 'fieldName' => 'techletter',
-                'type' => 'string'
+                'type' => 'string',
             ])
             ->addField([
                 'columnName' => 'sent_to_mailchimp',
                 'fieldName' => 'sentToMailchimp',
                 'type' => 'bool',
-                'serializer' => Boolean::class
+                'serializer' => Boolean::class,
             ])
             ->addField([
                 'columnName' => 'archive_url',
                 'fieldName' => 'archiveUrl',
-                'type' => 'string'
+                'type' => 'string',
             ])
         ;
 

--- a/sources/AppBundle/TechLetter/Model/TechLetter.php
+++ b/sources/AppBundle/TechLetter/Model/TechLetter.php
@@ -6,25 +6,16 @@ namespace AppBundle\TechLetter\Model;
 
 class TechLetter implements \JsonSerializable
 {
-    private ?News $firstNews;
-    private ?News $secondNews;
-
-    /** @var array<Article> */
-    private array $articles;
-
-    /** @var array<Project> */
-    private array $projects;
-
     /**
      * @param array<Article> $articles
      * @param array<Project> $projects
      */
-    public function __construct(?News $firstNews = null, ?News $secondNews = null, array $articles = [], array $projects = [])
-    {
-        $this->firstNews = $firstNews;
-        $this->secondNews = $secondNews;
-        $this->articles = $articles;
-        $this->projects = $projects;
+    public function __construct(
+        private readonly ?News $firstNews = null,
+        private readonly ?News $secondNews = null,
+        private readonly array $articles = [],
+        private readonly array $projects = [],
+    ) {
     }
 
     public function getFirstNews(): ?News
@@ -58,8 +49,8 @@ class TechLetter implements \JsonSerializable
         return [
             'firstNews' => $this->firstNews instanceof News ? $this->firstNews->jsonSerialize() : null,
             'secondNews' => $this->secondNews instanceof News ? $this->secondNews->jsonSerialize() : null,
-            'articles' => array_map(fn (Article $article) => $article->jsonSerialize(), $this->articles),
-            'projects' => array_map(fn (Project $project) => $project->jsonSerialize(), $this->projects)
+            'articles' => array_map(fn (Article $article): array => $article->jsonSerialize(), $this->articles),
+            'projects' => array_map(fn (Project $project): array => $project->jsonSerialize(), $this->projects),
         ];
     }
 }

--- a/sources/AppBundle/Twig/AssetsExtension.php
+++ b/sources/AppBundle/Twig/AssetsExtension.php
@@ -13,7 +13,7 @@ class AssetsExtension extends AbstractExtension
 {
     public function __construct(
         #[Autowire('%kernel.project_dir%')]
-        private string $kernelProjectDir,
+        private readonly string $kernelProjectDir,
     ) {
     }
 
@@ -24,7 +24,7 @@ class AssetsExtension extends AbstractExtension
                 $path = $this->kernelProjectDir . '/../htdocs/' . $url;
 
                 return substr(md5_file($path), 0, 8);
-            }, ['is_safe' => ['html']])
+            }, ['is_safe' => ['html']]),
         ];
     }
 

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -14,12 +14,12 @@ use Twig\TwigFunction;
 class TwigExtension extends AbstractExtension implements GlobalsInterface
 {
     public function __construct(
-        private Parsedown $parsedown,
-        private Parsedown $emailParsedown,
+        private readonly Parsedown $parsedown,
+        private readonly Parsedown $emailParsedown,
         #[Autowire('%google_analytics_enabled%')]
-        private string $googleAnalyticsEnabled,
+        private readonly string $googleAnalyticsEnabled,
         #[Autowire('%google_analytics_id%')]
-        private string $googleAnalyticsId,
+        private readonly string $googleAnalyticsId,
     ) {
     }
 
@@ -35,7 +35,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                     return $response;
                 }
                 return '';
-            }, ['is_safe' => ['html']])
+            }, ['is_safe' => ['html']]),
         ];
     }
 

--- a/sources/AppBundle/Twig/ViewRenderer.php
+++ b/sources/AppBundle/Twig/ViewRenderer.php
@@ -12,15 +12,11 @@ use Twig\Environment;
 
 class ViewRenderer
 {
-    private Security $security;
-    private RequestStack $requestStack;
-    private Environment $twig;
-
-    public function __construct(Security $security, RequestStack $requestStack, Environment $twig)
-    {
-        $this->security = $security;
-        $this->requestStack = $requestStack;
-        $this->twig = $twig;
+    public function __construct(
+        private readonly Security $security,
+        private readonly RequestStack $requestStack,
+        private readonly Environment $twig,
+    ) {
     }
 
 
@@ -44,7 +40,7 @@ class ViewRenderer
                 'header' => $page->header($requestUri, $this->security->getUser()),
                 'sidebar' => $page->getRightColumn(),
                 'social' => $page->social(),
-                'footer' => $page->footer()
+                'footer' => $page->footer(),
             ];
         }
 

--- a/sources/AppBundle/Validator/Constraints/UniqueEntityValidator.php
+++ b/sources/AppBundle/Validator/Constraints/UniqueEntityValidator.php
@@ -11,11 +11,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 class UniqueEntityValidator extends ConstraintValidator
 {
-    private RepositoryFactory $repositoryFactory;
-
-    public function __construct(RepositoryFactory $repositoryFactory)
+    public function __construct(private readonly RepositoryFactory $repositoryFactory)
     {
-        $this->repositoryFactory = $repositoryFactory;
     }
 
     /**
@@ -28,7 +25,7 @@ class UniqueEntityValidator extends ConstraintValidator
         }
         $repository = $this->repositoryFactory->get($constraint->repository);
 
-        $fields = (array) $constraint->fields;
+        $fields = $constraint->fields;
         $criteria = [];
         foreach ($fields as $field) {
             $propertyName    = 'get' . $field;

--- a/sources/AppBundle/VideoNotifier/Engine.php
+++ b/sources/AppBundle/VideoNotifier/Engine.php
@@ -14,41 +14,25 @@ use Exception;
 use Psr\Clock\ClockInterface;
 use Psr\Log\LoggerInterface;
 
-final class Engine
+final readonly class Engine
 {
     private const VALID_TALK_TYPES = [
         Talk::TYPE_FULL_LONG,
         Talk::TYPE_FULL_SHORT,
     ];
 
-    /** @var iterable<Transport> */
-    private iterable $transports;
-    private PlanningRepository $planningRepository;
-    private TalkRepository $talkRepository;
-    private SpeakerRepository $speakerRepository;
-    private HistoryRepository $historyRepository;
-    private LoggerInterface $logger;
-    private ClockInterface $clock;
-
     /**
      * @param iterable<Transport> $transports
      */
     public function __construct(
-        iterable $transports,
-        PlanningRepository $planningRepository,
-        TalkRepository $talkRepository,
-        SpeakerRepository $speakerRepository,
-        HistoryRepository $historyRepository,
-        LoggerInterface $logger,
-        ClockInterface $clock
+        private iterable $transports,
+        private PlanningRepository $planningRepository,
+        private TalkRepository $talkRepository,
+        private SpeakerRepository $speakerRepository,
+        private HistoryRepository $historyRepository,
+        private LoggerInterface $logger,
+        private ClockInterface $clock,
     ) {
-        $this->transports = $transports;
-        $this->planningRepository = $planningRepository;
-        $this->talkRepository = $talkRepository;
-        $this->speakerRepository = $speakerRepository;
-        $this->historyRepository = $historyRepository;
-        $this->logger = $logger;
-        $this->clock = $clock;
     }
 
     public function run(): ?HistoryEntry

--- a/sources/AppBundle/VideoNotifier/HistoryEntry.php
+++ b/sources/AppBundle/VideoNotifier/HistoryEntry.php
@@ -6,13 +6,11 @@ namespace AppBundle\VideoNotifier;
 
 class HistoryEntry
 {
-    private int $talkId;
     private ?string $statusIdBluesky = null;
     private ?string $statusIdMastodon = null;
 
-    public function __construct(int $talkId)
+    public function __construct(private readonly int $talkId)
     {
-        $this->talkId = $talkId;
     }
 
     public function setStatusIdBluesky(?string $statusIdBluesky): void

--- a/sources/AppBundle/VideoNotifier/HistoryRepository.php
+++ b/sources/AppBundle/VideoNotifier/HistoryRepository.php
@@ -7,13 +7,10 @@ namespace AppBundle\VideoNotifier;
 use AppBundle\Event\Model\Talk;
 use Doctrine\DBAL\Connection;
 
-final class HistoryRepository
+final readonly class HistoryRepository
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     public function insert(HistoryEntry $entry): void

--- a/sources/AppBundle/VideoNotifier/StatusGenerator.php
+++ b/sources/AppBundle/VideoNotifier/StatusGenerator.php
@@ -10,13 +10,10 @@ use AppBundle\SocialNetwork\Embed;
 use AppBundle\SocialNetwork\SocialNetwork;
 use AppBundle\SocialNetwork\Status;
 
-final class StatusGenerator
+final readonly class StatusGenerator
 {
-    private SocialNetwork $socialNetwork;
-
-    public function __construct(SocialNetwork $socialNetwork)
+    public function __construct(private SocialNetwork $socialNetwork)
     {
-        $this->socialNetwork = $socialNetwork;
     }
 
     /**
@@ -34,7 +31,7 @@ final class StatusGenerator
         $mentionsText = $this->buildMentionsText($speakers);
 
         // Nettoyage des espaces dans le titre
-        $title = trim(preg_replace('/\s+/', ' ', $talk->getTitle()));
+        $title = trim((string) preg_replace('/\s+/', ' ', $talk->getTitle()));
 
         $text = sprintf(
             "« %s », la conférence de %s à revoir sur le site de l'AFUP",

--- a/sources/PlanetePHP/CrawlingResult.php
+++ b/sources/PlanetePHP/CrawlingResult.php
@@ -4,22 +4,15 @@ declare(strict_types=1);
 
 namespace PlanetePHP;
 
-/**
- * @readonly
- */
-final class CrawlingResult
+final readonly class CrawlingResult
 {
-    public int $saved;
-    public int $tooOld;
-    public array $failedFeedsIds;
-
     /**
      * @param array<int> $failedFeedsIds
      */
-    public function __construct(int $saved, int $tooOld, array $failedFeedsIds)
-    {
-        $this->saved = $saved;
-        $this->tooOld = $tooOld;
-        $this->failedFeedsIds = $failedFeedsIds;
+    public function __construct(
+        public int $saved,
+        public int $tooOld,
+        public array $failedFeedsIds,
+    ) {
     }
 }

--- a/sources/PlanetePHP/DisplayableFeedArticle.php
+++ b/sources/PlanetePHP/DisplayableFeedArticle.php
@@ -6,21 +6,6 @@ namespace PlanetePHP;
 
 class DisplayableFeedArticle
 {
-    /** @var string */
-    private $title;
-    /** @var string */
-    private $url;
-    /** @var string */
-    private $update;
-    /** @var string */
-    private $author;
-    /** @var string */
-    private $content;
-    /** @var string */
-    private $feedName;
-    /** @var string */
-    private $feedUrl;
-
     /**
      * @param string $title
      * @param string $url
@@ -31,21 +16,14 @@ class DisplayableFeedArticle
      * @param string $feedUrl
      */
     public function __construct(
-        $title,
-        $url,
-        $update,
-        $author,
-        $content,
-        $feedName,
-        $feedUrl
+        private $title,
+        private $url,
+        private $update,
+        private $author,
+        private $content,
+        private $feedName,
+        private $feedUrl,
     ) {
-        $this->title = $title;
-        $this->url = $url;
-        $this->update = $update;
-        $this->author = $author;
-        $this->content = $content;
-        $this->feedName = $feedName;
-        $this->feedUrl = $feedUrl;
     }
 
     public function getTitle()

--- a/sources/PlanetePHP/Feed.php
+++ b/sources/PlanetePHP/Feed.php
@@ -8,18 +8,6 @@ class Feed
 {
     const STATUS_ACTIVE = 1;
     const STATUS_INACTIVE = 0;
-    /** @var int */
-    private $id;
-    /** @var string */
-    private $name;
-    /** @var string */
-    private $url;
-    /** @var string */
-    private $feed;
-    /** @var int */
-    private $status;
-    /** @var int */
-    private $userId;
 
     /**
      * @param int    $id
@@ -29,14 +17,14 @@ class Feed
      * @param int    $status
      * @param int    $userId
      */
-    public function __construct($id, $name, $url, $feed, $status, $userId)
-    {
-        $this->id = $id;
-        $this->name = $name;
-        $this->url = $url;
-        $this->feed = $feed;
-        $this->status = $status;
-        $this->userId = $userId;
+    public function __construct(
+        private $id,
+        private $name,
+        private $url,
+        private $feed,
+        private $status,
+        private $userId,
+    ) {
     }
 
     public function getId()

--- a/sources/PlanetePHP/FeedArticle.php
+++ b/sources/PlanetePHP/FeedArticle.php
@@ -6,27 +6,6 @@ namespace PlanetePHP;
 
 class FeedArticle
 {
-    /** @var int */
-    private $id;
-    /** @var int */
-    private $feedId;
-    /** @var string */
-    private $key;
-    /** @var string */
-    private $title;
-    /** @var string */
-    private $url;
-    /** @var int */
-    private $update;
-    /** @var string */
-    private $author;
-    /** @var string */
-    private $summary;
-    /** @var string */
-    private $content;
-    /** @var int */
-    private $status;
-
     /**
      * @param int    $id
      * @param int    $feedId
@@ -40,27 +19,17 @@ class FeedArticle
      * @param int    $status
      */
     public function __construct(
-        $id,
-        $feedId,
-        $key,
-        $title,
-        $url,
-        $update,
-        $author,
-        $summary,
-        $content,
-        $status
+        private $id,
+        private $feedId,
+        private $key,
+        private $title,
+        private $url,
+        private $update,
+        private $author,
+        private $summary,
+        private $content,
+        private $status,
     ) {
-        $this->id = $id;
-        $this->feedId = $feedId;
-        $this->key = $key;
-        $this->title = $title;
-        $this->url = $url;
-        $this->update = $update;
-        $this->author = $author;
-        $this->summary = $summary;
-        $this->content = $content;
-        $this->status = $status;
     }
 
     public function getId()

--- a/sources/PlanetePHP/FeedArticleRepository.php
+++ b/sources/PlanetePHP/FeedArticleRepository.php
@@ -13,12 +13,10 @@ class FeedArticleRepository
     const RELEVANT = 1;
     const IRRELEVANT = 0;
     const PERTINENCE_LIST = 'php|afup|pear|pecl|symfony|copix|jelix|wampserver|simpletest|simplexml|zend|pmo|drupal|ovidentia|mvc|magento|chrome|spip|PDO|mock|cake|hiphop|CMS|Framework|typo3|photon|pattern';
-    private Connection $connection;
-    private string $pertinenceRegex;
+    private readonly string $pertinenceRegex;
 
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
         $this->pertinenceRegex = '/' . self::PERTINENCE_LIST . '/i';
     }
 
@@ -97,7 +95,7 @@ class FeedArticleRepository
 
     public function isRelevant($content): int
     {
-        $content = strip_tags($content);
+        $content = strip_tags((string) $content);
         $relevant = self::IRRELEVANT;
         if (preg_match($this->pertinenceRegex, $content)) {
             $relevant = self::RELEVANT;

--- a/sources/PlanetePHP/FeedCrawler.php
+++ b/sources/PlanetePHP/FeedCrawler.php
@@ -11,27 +11,15 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpClient\Exception\ClientException;
 use Symfony\Component\HttpClient\Exception\ServerException;
 
-final class FeedCrawler
+final readonly class FeedCrawler
 {
-    private ClockInterface $clock;
-    private SymfonyFeedClient $httpClient;
-    private FeedRepository $feedRepository;
-    private FeedArticleRepository $feedArticleRepository;
-    private LoggerInterface $logger;
-
     public function __construct(
-        ClockInterface $clock,
-        SymfonyFeedClient $httpClient,
-        FeedRepository $feedRepository,
-        FeedArticleRepository $feedArticleRepository,
-        LoggerInterface $logger
+        private ClockInterface $clock,
+        private SymfonyFeedClient $httpClient,
+        private FeedRepository $feedRepository,
+        private FeedArticleRepository $feedArticleRepository,
+        private LoggerInterface $logger,
     ) {
-        $this->clock = $clock;
-        $this->httpClient = $httpClient;
-        $this->feedRepository = $feedRepository;
-        $this->feedArticleRepository = $feedArticleRepository;
-        $this->logger = $logger;
-
         Reader::setHttpClient($this->httpClient);
     }
 

--- a/sources/PlanetePHP/FeedRepository.php
+++ b/sources/PlanetePHP/FeedRepository.php
@@ -9,11 +9,8 @@ use Doctrine\DBAL\Connection;
 
 class FeedRepository
 {
-    private Connection $connection;
-
-    public function __construct(Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
-        $this->connection = $connection;
     }
 
     /**

--- a/sources/PlanetePHP/SymfonyFeedClient.php
+++ b/sources/PlanetePHP/SymfonyFeedClient.php
@@ -9,13 +9,10 @@ use Laminas\Feed\Reader\Http\Response;
 use Laminas\Feed\Reader\Http\ResponseInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-final class SymfonyFeedClient implements ClientInterface
+final readonly class SymfonyFeedClient implements ClientInterface
 {
-    private HttpClientInterface $httpClient;
-
-    public function __construct(HttpClientInterface $httpClient)
+    public function __construct(private HttpClientInterface $httpClient)
     {
-        $this->httpClient = $httpClient;
     }
 
     public function get($uri): ResponseInterface

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -21,7 +21,7 @@ class FeatureContext implements Context
 
     private array $pdfPages = [];
 
-    private DatabaseManager $databaseManager;
+    private readonly DatabaseManager $databaseManager;
 
     public function __construct()
     {
@@ -404,7 +404,7 @@ class FeatureContext implements Context
     {
         $pageContent = $this->pdfPages[$page] ?? null;
 
-        if (!str_contains($pageContent, $expectedContent)) {
+        if (!str_contains((string) $pageContent, $expectedContent)) {
             throw new ExpectationException(
                 sprintf('The content "%s" was not found in the content "%s"', $expectedContent, $pageContent),
                 $this->minkContext->getSession()->getDriver()

--- a/tests/support/DatabaseManager.php
+++ b/tests/support/DatabaseManager.php
@@ -13,18 +13,16 @@ use Symfony\Component\Process\Process;
 /**
  * Helper pour les tests pour recréer une base de données avec un dump.
  */
-final class DatabaseManager
+final readonly class DatabaseManager
 {
     private const DB_NAME = 'web';
 
     private PDO $database;
     private Mysqldump $dumper;
     private string $dbDumpKey;
-    private bool $shouldRunSeeds;
 
-    public function __construct(bool $shouldRunSeeds)
+    public function __construct(private bool $shouldRunSeeds)
     {
-        $this->shouldRunSeeds = $shouldRunSeeds;
         $this->database = new PDO('mysql:host=dbtest;dbname=' . self::DB_NAME, 'root', 'root');
         $this->dumper = new Mysqldump('mysql:host=dbtest;dbname=' . self::DB_NAME, 'root', 'root');
         $this->dbDumpKey = $this->computeDbDumpKey();

--- a/tests/support/MockClock.php
+++ b/tests/support/MockClock.php
@@ -7,13 +7,10 @@ namespace Afup\Tests\Support;
 use DateTimeImmutable;
 use Psr\Clock\ClockInterface;
 
-final class MockClock implements ClockInterface
+final readonly class MockClock implements ClockInterface
 {
-    private \DateTimeImmutable $now;
-
-    public function __construct(DateTimeImmutable $now)
+    public function __construct(private \DateTimeImmutable $now)
     {
-        $this->now = $now;
     }
 
     public function now(): DateTimeImmutable

--- a/tests/unit/Afup/Association/CotisationsTest.php
+++ b/tests/unit/Afup/Association/CotisationsTest.php
@@ -52,11 +52,11 @@ final class CotisationsTest extends TestCase
         return [
             'Personne Morale' => [
                 'FCOTIS-2023-202',
-                ['type' => UserRepository::USER_TYPE_COMPANY, 'id' => '202']
+                ['type' => UserRepository::USER_TYPE_COMPANY, 'id' => '202'],
             ],
             'Personne physique' => [
                 'C2023-211120232237-0-5-PAUL-431',
-                ['type' => UserRepository::USER_TYPE_PHYSICAL, 'id' => '5']
+                ['type' => UserRepository::USER_TYPE_PHYSICAL, 'id' => '5'],
             ],
         ];
     }

--- a/tests/unit/AppBundle/Compta/Importer/AutoQualifierTest.php
+++ b/tests/unit/AppBundle/Compta/Importer/AutoQualifierTest.php
@@ -98,7 +98,7 @@ final class AutoQualifierTest extends TestCase
         int $expectedCategorie,
         int $expectedAttachment,
         ?float $expectedHT,
-        ?string $expectedHTKey
+        ?string $expectedHTKey,
     ): void {
         $operation = new Operation('2022-02-22', $operationDescription, '100', $operationType, '1234');
         $qualifier = new AutoQualifier($this->fakeBD());

--- a/tests/unit/AppBundle/Indexation/Talks/TransformerTest.php
+++ b/tests/unit/AppBundle/Indexation/Talks/TransformerTest.php
@@ -87,7 +87,7 @@ final class TransformerTest extends TestCase
                         'first_name' => 'Dimitri',
                         'last_name' => 'Fontaine',
                         'label' => 'Dimitri FONTAINE',
-                    ]
+                    ],
                 ],
                 'has_video' => true,
                 'video_url' => 'https://www.youtube.com/watch?v=hzn0ODTMNDk',
@@ -103,7 +103,7 @@ final class TransformerTest extends TestCase
                 'language' => [
                     'code' => 'fr',
                     'label' => 'Français',
-                ]
+                ],
             ],
             $result,
         );

--- a/tests/unit/AppBundle/Payment/PayboxTest.php
+++ b/tests/unit/AppBundle/Payment/PayboxTest.php
@@ -22,7 +22,7 @@ final class PayboxTest extends TestCase
         \DateTimeImmutable $currentDate,
         \Closure $callback,
         PayboxBilling $billing,
-        string $expected
+        string $expected,
     ): void {
         $paybox = new Paybox($domainServer, $secretKey, $site, $rang, $identifiant);
 

--- a/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
+++ b/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
@@ -31,7 +31,7 @@ class StatusGeneratorTest extends TestCase
         SocialNetwork $socialNetwork,
         Talk $talk,
         array $speakers,
-        string $expectedExceptionMessage
+        string $expectedExceptionMessage,
     ): void {
         self::expectException(\LengthException::class);
         self::expectExceptionMessage($expectedExceptionMessage);
@@ -69,7 +69,7 @@ class StatusGeneratorTest extends TestCase
         SocialNetwork $socialNetwork,
         Talk $talk,
         array $speakers,
-        Status $expectedStatus
+        Status $expectedStatus,
     ): void {
         $generator = new StatusGenerator($socialNetwork);
 


### PR DESCRIPTION
Suite à la mise à jour en PHP 8.2, on peut maintenant utiliser les constructor properties promotion.

J'ai installé `kubawerlos/php-cs-fixer-custom-fixers` pour utiliser la custom règle : `MultilinePromotedPropertiesFixer` qui format les properties promotion sur plusieurs lignes.
Ensuite, j'ai appliqué `rector` et `php-cs-fixer`.