### PR TITLE
Optimisations pour la google search console video

### DIFF
--- a/sources/AppBundle/Controller/Website/TalksController.php
+++ b/sources/AppBundle/Controller/Website/TalksController.php
@@ -18,6 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class TalksController extends AbstractController
 {
@@ -47,14 +48,18 @@ class TalksController extends AbstractController
     public function list(Request $request): Response
     {
         $title = 'Historique des conférences de l\'AFUP';
+        $canonical = $this->generateUrl('talks_list', referenceType: UrlGeneratorInterface::ABSOLUTE_URL);
         if (isset($request->get('fR')['speakers.label'][0])) {
             $title = 'Les vidéos de ' . $request->get('fR')['speakers.label'][0];
+            $canonical = $this->generateUrl('talks_list', ['fR' => $request->get('fR')['speakers.label'][0]], UrlGeneratorInterface::ABSOLUTE_URL);
         } elseif (isset($request->get('fr')['event.title'][0])) {
             $title = $request->get('fR')['event.title'][0] . ' les vidéos';
+            $canonical = $this->generateUrl('talks_list', ['fR' => $request->get('fR')['event.title'][0]], UrlGeneratorInterface::ABSOLUTE_URL);
         }
 
         return $this->view->render('site/talks/list.html.twig', [
             'title' => $title,
+            'canonical' => $canonical,
             'antennes' => (new AntennesCollection())->getAllSortedByLabels(),
             'algolia_app_id' => $this->algoliaAppId,
             'algolia_api_key' => $this->algoliaFrontendApikey,

--- a/templates/site/talks/list.html.twig
+++ b/templates/site/talks/list.html.twig
@@ -2,6 +2,10 @@
 
 {% block title %}{{ title }}{% endblock %}
 
+{% block canonical %}
+    <link rel="canonical" href="{{ canonical }}" />
+{% endblock %}
+
 {% block stylesheets %}
     {{ parent() }}
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/instantsearch.js/1/instantsearch.min.css">
@@ -22,9 +26,9 @@
     <meta name="algolia_appid" content="{{ algolia_app_id }}" />
     <meta name="algolia_apikey" content="{{ algolia_api_key }}" />
 
-    <meta property="og:title" content="AFUP - Vidéos des conférences" />
+    <meta property="og:title" content="{{ title }}" />
     <meta property="og:type" content="article" />
-    <meta property="og:url" content="{{ url('talks_list') }}" />
+    <meta property="og:url" content="{{ canonical }}" />
     <meta property="og:image" content="{{ app.request.schemeAndHttpHost }}/images/talks/thumbnail.jpg" />
     <meta property="og:description" content="Retrouvez l'ensemble des vidéos des conférences de l'AFUP" />
     <meta property="og:site_name" content="AFUP" />


### PR DESCRIPTION
Toujours dans l'idée d'optimiser le référencement du site.

On corrige la balise canonical des pages de liste des vidéos d'un speaker et d'un événement.