### PR TITLE
Mise à jour de PHPUnit en version 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -141,7 +141,7 @@
     "friendsofphp/php-cs-fixer": "^3.75",
     "ifsnop/mysqldump-php": "^2.12",
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.24",
-    "phpunit/phpunit": "^9.6",
+    "phpunit/phpunit": "11.*",
     "rector/rector": "^2.0",
     "smalot/pdfparser": "^0.19.0",
     "symfony/debug-bundle": "^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20ceaab6b092e17f72a22421e2867377",
+    "content-hash": "a01defde076edeceda22a9754e3c682e",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -10452,16 +10452,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
                 "shasum": ""
             },
             "require": {
@@ -10500,7 +10500,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
             },
             "funding": [
                 {
@@ -10508,7 +10508,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-04-29T12:36:36+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -10746,35 +10746,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.32",
+            "version": "11.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
+                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
-                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
+                "reference": "14d63fbcca18457e49c6f8bebaa91a87e8e188d7",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-text-template": "^2.0.4",
-                "sebastian/code-unit-reverse-lookup": "^2.0.3",
-                "sebastian/complexity": "^2.0.3",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/lines-of-code": "^1.0.4",
-                "sebastian/version": "^3.0.2",
+                "nikic/php-parser": "^5.4.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.6"
+                "phpunit/phpunit": "^11.5.2"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -10783,7 +10783,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.2.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -10812,7 +10812,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.9"
             },
             "funding": [
                 {
@@ -10820,32 +10820,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:23:01+00:00"
+            "time": "2025-02-25T13:26:39+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -10872,7 +10872,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
             },
             "funding": [
                 {
@@ -10880,28 +10881,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-02T12:48:52+00:00"
+            "time": "2024-08-27T05:02:59+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "3.1.1",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -10909,7 +10910,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -10935,7 +10936,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -10943,32 +10945,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:58:55+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "2.0.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -10994,7 +10996,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -11002,32 +11005,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T05:33:50+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "5.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11053,7 +11056,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -11061,54 +11065,52 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:16:10+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.22",
+            "version": "11.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+                "reference": "e6bdea63ecb7a8287d2cdab25bdde3126e0cfe6f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6bdea63ecb7a8287d2cdab25bdde3126e0cfe6f",
+                "reference": "e6bdea63ecb7a8287d2cdab25bdde3126e0cfe6f",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.5.0 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.32",
-                "phpunit/php-file-iterator": "^3.0.6",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.4",
-                "phpunit/php-timer": "^5.0.3",
-                "sebastian/cli-parser": "^1.0.2",
-                "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.6",
-                "sebastian/environment": "^5.1.5",
-                "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
-                "sebastian/object-enumerator": "^4.0.4",
-                "sebastian/resource-operations": "^3.0.4",
-                "sebastian/type": "^3.2.1",
-                "sebastian/version": "^3.0.2"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.9",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.1",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/exporter": "^6.3.0",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/type": "^5.1.2",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -11116,7 +11118,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.6-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -11148,7 +11150,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.20"
             },
             "funding": [
                 {
@@ -11160,11 +11162,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T13:48:26+00:00"
+            "time": "2025-05-11T06:39:52+00:00"
         },
         {
             "name": "react/cache",
@@ -11753,28 +11763,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.2",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
-                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -11797,7 +11807,8 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -11805,32 +11816,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:27:43+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.8",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -11853,7 +11864,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
             },
             "funding": [
                 {
@@ -11861,32 +11873,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:08:54+00:00"
+            "time": "2025-03-19T07:56:08+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -11908,7 +11920,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -11916,34 +11929,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:30:19+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "24b8fbc2c8e201bb1308e7b05148d6ab393b6959"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/24b8fbc2c8e201bb1308e7b05148d6ab393b6959",
+                "reference": "24b8fbc2c8e201bb1308e7b05148d6ab393b6959",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.3-dev"
                 }
             },
             "autoload": {
@@ -11982,7 +12000,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.1"
             },
             "funding": [
                 {
@@ -11990,33 +12009,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-03-07T06:57:01+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "2.0.3",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
-                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -12039,7 +12058,8 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -12047,33 +12067,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:19:30+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.6",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
-                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3",
+                "phpunit/phpunit": "^11.0",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -12105,7 +12125,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -12113,27 +12134,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:30:58+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.5",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
+                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -12141,7 +12162,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -12160,7 +12181,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -12168,7 +12189,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.0"
             },
             "funding": [
                 {
@@ -12176,34 +12198,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:03:51+00:00"
+            "time": "2024-07-03T04:54:44+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.6",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
+                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
-                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/3473f61172093b2da7de1fb5782e1f24cc036dc3",
+                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -12245,7 +12267,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.0"
             },
             "funding": [
                 {
@@ -12253,38 +12276,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:33:00+00:00"
+            "time": "2024-12-05T09:17:50+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -12303,13 +12323,14 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
@@ -12317,33 +12338,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.4",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
-                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=7.3"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -12366,7 +12387,8 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -12374,34 +12396,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:20:34+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -12423,7 +12445,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -12431,32 +12454,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:12:34+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "2.0.4",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -12478,7 +12501,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -12486,32 +12510,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:14:26+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "694d156164372abbd149a4b85ccda2e4670c0e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/694d156164372abbd149a4b85ccda2e4670c0e16",
+                "reference": "694d156164372abbd149a4b85ccda2e4670c0e16",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -12541,7 +12565,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.2"
             },
             "funding": [
                 {
@@ -12549,86 +12574,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-03-14T16:00:52+00:00"
+            "time": "2024-07-03T05:10:34+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.1",
+            "version": "5.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+                "reference": "a8a7e30534b0eb0c77cd9d07e82de1a114389f5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/a8a7e30534b0eb0c77cd9d07e82de1a114389f5e",
+                "reference": "a8a7e30534b0eb0c77cd9d07e82de1a114389f5e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.5"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.2-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -12651,7 +12622,8 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.2"
             },
             "funding": [
                 {
@@ -12659,29 +12631,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:13:03+00:00"
+            "time": "2025-03-18T13:35:50+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "3.0.2",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.3"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -12704,7 +12676,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -12712,7 +12685,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:39:44+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "smalot/pdfparser",
@@ -12767,6 +12740,58 @@
                 "source": "https://github.com/smalot/pdfparser/tree/v0.19.0"
             },
             "time": "2021-04-13T08:27:56+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/rector.php
+++ b/rector.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Php80\Rector\Class_\ClassPropertyAssignToConstructorPromotionRector;
 use Rector\Set\ValueObject\LevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Symfony\Set\SymfonySetList;
 use Rector\Symfony\Set\TwigSetList;
 
@@ -31,6 +31,9 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_CODE_QUALITY,
         SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION,
         TwigSetList::TWIG_UNDERSCORE_TO_NAMESPACE,
-        LevelSetList::UP_TO_PHP_82
+        LevelSetList::UP_TO_PHP_82,
+        PHPUnitSetList::PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_110,
     ])
 ;

--- a/tests/support/IntegrationTestCase.php
+++ b/tests/support/IntegrationTestCase.php
@@ -22,4 +22,26 @@ abstract class IntegrationTestCase extends KernelTestCase
         $databaseManager = new DatabaseManager(false);
         $databaseManager->reloadDatabase();
     }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->restoreExceptionHandler();
+    }
+
+    protected function restoreExceptionHandler(): void
+    {
+        while (true) {
+            $previousHandler = set_exception_handler(static fn () => null);
+
+            restore_exception_handler();
+
+            if ($previousHandler === null) {
+                break;
+            }
+
+            restore_exception_handler();
+        }
+    }
 }

--- a/tests/unit/Afup/Association/CotisationsTest.php
+++ b/tests/unit/Afup/Association/CotisationsTest.php
@@ -7,35 +7,34 @@ namespace Afup\Site\Tests\Association;
 use Afup\Site\Association\Cotisations;
 use Afup\Site\Utils\Base_De_Donnees;
 use AppBundle\Association\Model\Repository\UserRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class CotisationsTest extends TestCase
 {
-    public function generateCotisationProvider(): array
+    public static function generateCotisationProvider(): array
     {
         return [
             'La cotisation précédente a expiré il y a plus d\'un an, la nouvelle cotisation doit expirer dans un an' => [
-                'date_fin' => (new \DateTime('18 months ago')),
+                'dateFin' => (new \DateTime('18 months ago')),
                 'expected' => new \DateTime('+1 year'),
             ],
             'La cotisation précédente a expiré hier, la nouvelle cotisation doit expirer dans un an' => [
-                'date_fin' => (new \DateTime('yesterday')),
+                'dateFin' => (new \DateTime('yesterday')),
                 'expected' => new \DateTime('+1 year'),
             ],
             'La cotisation précédente a expiré aujourd\'hui, la nouvelle cotisation doit expirer dans un an' => [
-                'date_fin' => (new \DateTime()),
+                'dateFin' => (new \DateTime()),
                 'expected' => new \DateTime('+1 year'),
             ],
             'La cotisation précédente expire dans 1 mois, la nouvelle cotisation doit expirer dans 13 mois' => [
-                'date_fin' => (new \DateTimeImmutable('+1 month'))->setTime(14, 0),
+                'dateFin' => (new \DateTimeImmutable('+1 month'))->setTime(14, 0),
                 'expected' => (new \DateTimeImmutable('+1 month'))->setTime(14, 0)->add(new \DateInterval('P1Y')),
             ],
         ];
     }
 
-    /**
-     * @dataProvider generateCotisationProvider
-     */
+    #[DataProvider('generateCotisationProvider')]
     public function testFinProchaineCotisation(\DateTimeInterface $dateFin, \DateTimeInterface $expected): void
     {
         $bdd = new Base_De_Donnees('', '', '', '');
@@ -47,7 +46,7 @@ final class CotisationsTest extends TestCase
         self::assertEquals($expected->format('Y-m-d'), $actual->format('Y-m-d'));
     }
 
-    public function accountCmdProvider(): array
+    public static function accountCmdProvider(): array
     {
         return [
             'Personne Morale' => [
@@ -61,9 +60,7 @@ final class CotisationsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider accountCmdProvider
-     */
+    #[DataProvider('accountCmdProvider')]
     public function testGetAccountFromCmd(string $cmd, array $expected): void
     {
         $bdd = new Base_De_Donnees('', '', '', '');

--- a/tests/unit/Afup/Utils/UtilsTest.php
+++ b/tests/unit/Afup/Utils/UtilsTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace Afup\Site\Tests\Utils;
 
 use Afup\Site\Utils\Utils;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class UtilsTest extends TestCase
 {
-    public function dataProvider(): array
+    public static function dataProvider(): array
     {
         return [
             [
@@ -35,9 +36,7 @@ final class UtilsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testCryptFromText($decrypted, string $encrypted): void
     {
         self::assertEquals($encrypted, Utils::cryptFromText($decrypted));

--- a/tests/unit/AppBundle/Association/MembershipFeeReferenceGeneratorTest.php
+++ b/tests/unit/AppBundle/Association/MembershipFeeReferenceGeneratorTest.php
@@ -5,14 +5,13 @@ declare(strict_types=1);
 namespace AppBundle\Tests\Association;
 
 use AppBundle\Association\MembershipFeeReferenceGenerator;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class MembershipFeeReferenceGeneratorTest extends TestCase
 {
-    /**
-     * @dataProvider generateDateProvider
-     */
-    public function testGenerate(string $case, \DateTimeImmutable $currentDate, int $typePersonne, int $idPersonne, string $nom, string $expected): void
+    #[DataProvider('generateDateProvider')]
+    public function testGenerate(\DateTimeImmutable $currentDate, int $typePersonne, int $idPersonne, string $nom, string $expected): void
     {
         $generator = new MembershipFeeReferenceGenerator();
 
@@ -21,22 +20,20 @@ final class MembershipFeeReferenceGeneratorTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function generateDateProvider(): array
+    public static function generateDateProvider(): array
     {
         return [
-            [
-                'case' => 'Cas général',
-                'current_date' => new \DateTimeImmutable('2018-03-02 20:20:19'),
-                'type_personne' => 0,
-                'id_personne' => 1234,
+            'Cas général' => [
+                'currentDate' => new \DateTimeImmutable('2018-03-02 20:20:19'),
+                'typePersonne' => 0,
+                'idPersonne' => 1234,
                 'nom' => 'DUPONT',
                 'expected' => "C2018-020320182020-0-1234-DUPON-875",
             ],
-            [
-                'case' => 'Accent en cinquième position',
-                'current_date' => new \DateTimeImmutable('2018-03-02 20:20:19'),
-                'type_personne' => 0,
-                'id_personne' => 1234,
+            'Accent en cinquième position' => [
+                'currentDate' => new \DateTimeImmutable('2018-03-02 20:20:19'),
+                'typePersonne' => 0,
+                'idPersonne' => 1234,
                 'nom' => 'Jirsé',
                 'expected' => "C2018-020320182020-0-1234-JIRSE-A91",
             ],

--- a/tests/unit/AppBundle/Association/Model/CompanyMemberTest.php
+++ b/tests/unit/AppBundle/Association/Model/CompanyMemberTest.php
@@ -5,17 +5,18 @@ declare(strict_types=1);
 namespace AppBundle\Tests\Association\Model;
 
 use AppBundle\Association\Model\CompanyMember;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CompanyMemberTest extends TestCase
 {
-    /** @dataProvider companies */
+    #[DataProvider('companies')]
     public function testMembershipFee(CompanyMember $companyMember, float $expectedAmount): void
     {
         self::assertEquals($expectedAmount, $companyMember->getMembershipFee());
     }
 
-    public function companies(): array
+    public static function companies(): array
     {
         return [
             'null' => [(new CompanyMember()), AFUP_COTISATION_PERSONNE_MORALE],

--- a/tests/unit/AppBundle/Compta/Importer/AutoQualifierTest.php
+++ b/tests/unit/AppBundle/Compta/Importer/AutoQualifierTest.php
@@ -9,6 +9,7 @@ use AppBundle\Compta\Importer\Operation;
 use AppBundle\Model\ComptaCategorie;
 use AppBundle\Model\ComptaEvenement;
 use AppBundle\Model\ComptaModeReglement;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class AutoQualifierTest extends TestCase
@@ -29,7 +30,7 @@ final class AutoQualifierTest extends TestCase
         self::assertEquals('DESCRIPTION', $actual['description']);
     }
 
-    public function idModeReglementData(): array
+    public static function idModeReglementData(): array
     {
         return [
             'Défaut' => ['XXX blablabla', AutoQualifier::DEFAULT_REGLEMENT],
@@ -42,9 +43,7 @@ final class AutoQualifierTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider idModeReglementData
-     */
+    #[DataProvider('idModeReglementData')]
     public function testIdModeReglement($description, $idModeReglement): void
     {
         $operation = new Operation('2022-02-22', $description, '123', Operation::CREDIT, '1234');
@@ -55,7 +54,7 @@ final class AutoQualifierTest extends TestCase
     }
 
 
-    public function qualifierData(): array
+    public static function qualifierData(): array
     {
         return [
             'sprd.net' => ['VIR SEPA sprd.net AG blablabla', Operation::CREDIT,
@@ -87,9 +86,7 @@ final class AutoQualifierTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider qualifierData
-     */
+    #[DataProvider('qualifierData')]
     public function testQualifier(
         string $operationDescription,
         string $operationType,

--- a/tests/unit/AppBundle/Event/Form/Support/EventHelperTest.php
+++ b/tests/unit/AppBundle/Event/Form/Support/EventHelperTest.php
@@ -7,14 +7,12 @@ namespace AppBundle\Tests\Event\Form\Support;
 use AppBundle\Event\Form\Support\EventHelper;
 use AppBundle\Event\Model\Event;
 use AppBundle\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EventHelperTest extends TestCase
 {
-    /**
-     * @dataProvider groupByYearDataProvider
-     * @param Event|string $event
-     */
-    public function testGroupByYear($event, string $expectedYear): void
+    #[DataProvider('groupByYearDataProvider')]
+    public function testGroupByYear(Event|string $event, string $expectedYear): void
     {
         $helper = new EventHelper();
 
@@ -23,32 +21,32 @@ class EventHelperTest extends TestCase
         self::assertEquals($expectedYear, $actualYear);
     }
 
-    public function groupByYearDataProvider(): \Generator
+    public static function groupByYearDataProvider(): \Generator
     {
         yield 'with event as string' => [
             'event' => 'Forum PHP 2014',
-            'year' => '2014',
+            'expectedYear' => '2014',
         ];
 
         yield 'with start date' => [
             'event' => (new Event())->setDateStart(new \DateTime('1999-12-13')),
-            'year' => '1999',
+            'expectedYear' => '1999',
         ];
 
         yield 'with date in title' => [
             'event' => (new Event())->setTitle('AFUP Day 2025 Lyon'),
-            'year' => '2025',
+            'expectedYear' => '2025',
         ];
 
         yield 'without date in title' => [
             'event' => (new Event())
                 ->setTitle('PHP Tour'),
-            'year' => 'Année inconnue',
+            'expectedYear' => 'Année inconnue',
         ];
 
         yield 'without date' => [
             'event' => (new Event()),
-            'year' => 'Année inconnue',
+            'expectedYear' => 'Année inconnue',
         ];
     }
 
@@ -64,7 +62,7 @@ class EventHelperTest extends TestCase
 
         $helper = new EventHelper();
 
-        $r = $helper->sortEventsByStartDate($this->faker()->shuffle($events));
+        $r = $helper->sortEventsByStartDate(self::faker()->shuffle($events));
 
         self::assertCount(5, $r);
         self::assertEquals('2024-05-03', $r[0]->getDateStart()->format('Y-m-d'));

--- a/tests/unit/AppBundle/Event/Model/EventTest.php
+++ b/tests/unit/AppBundle/Event/Model/EventTest.php
@@ -20,7 +20,7 @@ final class EventTest extends TestCase
         self::assertEquals($expected, $event->isCfpOpen());
     }
 
-    public function dates(): \Generator
+    public static function dates(): \Generator
     {
         yield 'all null' => [null, null, false];
         yield 'null start date' => [null, new DateTime('+1 day'), true];

--- a/tests/unit/AppBundle/Event/Model/SpeakerTest.php
+++ b/tests/unit/AppBundle/Event/Model/SpeakerTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AppBundle\Tests\Event\Model;
 
 use AppBundle\Event\Model\Speaker;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class SpeakerTest extends TestCase
 {
-    /**
-     * @dataProvider mastodonDataProvider
-     */
+    #[DataProvider('mastodonDataProvider')]
     public function testMastodon(string $mastodon, string $expectedUsername, string $expectedUrl): void
     {
         $speaker = new Speaker();
@@ -21,7 +20,7 @@ final class SpeakerTest extends TestCase
         self::assertEquals($expectedUrl, $speaker->getUrlMastodon());
     }
 
-    public function mastodonDataProvider(): array
+    public static function mastodonDataProvider(): array
     {
         return [
             ['', '', ''],
@@ -32,9 +31,7 @@ final class SpeakerTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider twitterDataProvider
-     */
+    #[DataProvider('twitterDataProvider')]
     public function testTwitter(string $twitter, string $expectedUsername, string $expectedUrl): void
     {
         $speaker = new Speaker();
@@ -44,7 +41,7 @@ final class SpeakerTest extends TestCase
         self::assertEquals($expectedUrl, $speaker->getUrlTwitter());
     }
 
-    public function twitterDataProvider(): array
+    public static function twitterDataProvider(): array
     {
         return [
             ['', '', ''],

--- a/tests/unit/AppBundle/Indexation/Meetups/MeetupClientTest.php
+++ b/tests/unit/AppBundle/Indexation/Meetups/MeetupClientTest.php
@@ -6,6 +6,7 @@ namespace AppBundle\Tests\Indexation\Meetups;
 
 use AppBundle\Antennes\AntennesCollection;
 use AppBundle\Indexation\Meetups\MeetupClient;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -14,9 +15,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
 
 final class MeetupClientTest extends TestCase
 {
-    /**
-     * @dataProvider failureDataProvider
-     */
+    #[DataProvider('failureDataProvider')]
     public function testFailure(MockResponse $response, string $expectedExceptionMessage): void
     {
         $httpClient = $this->makeGuzzleMockClient($response);
@@ -29,16 +28,16 @@ final class MeetupClientTest extends TestCase
         $meetupClient->getEvents();
     }
 
-    public function failureDataProvider(): \Generator
+    public static function failureDataProvider(): \Generator
     {
         yield [
             'response' => new MockResponse('', ['http_code' => 500]),
-            'exception' => 'HTTP 500 returned for "http://fakemeetup/gql".',
+            'expectedExceptionMessage' => 'HTTP 500 returned for "http://fakemeetup/gql".',
         ];
 
         yield [
             'response' => new MockResponse('invalid json'),
-            'exception' => 'Syntax error for "http://fakemeetup/gql".',
+            'expectedExceptionMessage' => 'Syntax error for "http://fakemeetup/gql".',
         ];
     }
 

--- a/tests/unit/AppBundle/Payment/PayboxTest.php
+++ b/tests/unit/AppBundle/Payment/PayboxTest.php
@@ -6,13 +6,12 @@ namespace AppBundle\Tests\Payment;
 
 use AppBundle\Payment\Paybox;
 use AppBundle\Payment\PayboxBilling;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class PayboxTest extends TestCase
 {
-    /**
-     * @dataProvider generateDateProvider
-     */
+    #[DataProvider('generateDateProvider')]
     public function testGenerate(
         string $domainServer,
         string $secretKey,
@@ -33,7 +32,7 @@ final class PayboxTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function generateDateProvider(): array
+    public static function generateDateProvider(): array
     {
         $casGeneral = <<<EOF
 <form method="POST" action="https://preprod-tpeweb.paybox.com/cgi/MYchoix_pagepaiement.cgi">
@@ -119,42 +118,42 @@ EOF;
 
         return [
             'Cas général' => [
-                'domain_server' => $preprodDomainServer,
-                'secret_key' => $preprodTestSecretKey,
+                'domainServer' => $preprodDomainServer,
+                'secretKey' => $preprodTestSecretKey,
                 'site' => $testSite,
                 'rang' => $testRang,
                 'identifiant' => $testIdentifiant,
-                'current_date' => new \DateTimeImmutable('2018-03-02 20:20:19'),
+                'currentDate' => new \DateTimeImmutable('2018-03-02 20:20:19'),
                 'callback' => function (Paybox $paybox): void {
                     $paybox->setTotal(2500);
                     $paybox->setCmd('TEST Paybox');
                     $paybox->setPorteur('test@paybox.com');
                 },
-                'paybox_billing' => $billingEmpty,
+                'billing' => $billingEmpty,
                 'expected' => $casGeneral,
             ],
             'Avec un billing' => [
-                'domain_server' => $preprodDomainServer,
-                'secret_key' => $preprodTestSecretKey,
+                'domainServer' => $preprodDomainServer,
+                'secretKey' => $preprodTestSecretKey,
                 'site' => $testSite,
                 'rang' => $testRang,
                 'identifiant' => $testIdentifiant,
-                'current_date' => new \DateTimeImmutable('2018-03-02 20:20:19'),
+                'currentDate' => new \DateTimeImmutable('2018-03-02 20:20:19'),
                 'callback' => function (Paybox $paybox): void {
                     $paybox->setTotal(2500);
                     $paybox->setCmd('TEST Paybox');
                     $paybox->setPorteur('test@paybox.com');
                 },
-                'paybox_billing' => $billing,
+                'billing' => $billing,
                 'expected' => $avecBilling,
             ],
             'URL de retour' => [
-                'domain_server' => $preprodDomainServer,
-                'secret_key' => $preprodTestSecretKey,
+                'domainServer' => $preprodDomainServer,
+                'secretKey' => $preprodTestSecretKey,
                 'site' => $testSite,
                 'rang' => $testRang,
                 'identifiant' => $testIdentifiant,
-                'current_date' => new \DateTimeImmutable('2018-03-02 20:20:19'),
+                'currentDate' => new \DateTimeImmutable('2018-03-02 20:20:19'),
                 'callback' => function (Paybox $paybox): void {
                     $paybox->setTotal(2500);
                     $paybox->setCmd('TEST Paybox');
@@ -165,7 +164,7 @@ EOF;
                     $paybox->setUrlRetourEffectue('http://test4.com');
                     $paybox->setUrlRepondreA('http://reponseA');
                 },
-                'paybox_billing' => $billingEmpty,
+                'billing' => $billingEmpty,
                 'expected' => $urlRetour,
             ],
         ];

--- a/tests/unit/AppBundle/SocialNetwork/SocialNetworkTest.php
+++ b/tests/unit/AppBundle/SocialNetwork/SocialNetworkTest.php
@@ -8,13 +8,12 @@ use AppBundle\Event\Model\Speaker;
 use AppBundle\SocialNetwork\SocialNetwork;
 use AppBundle\SocialNetwork\StatusId;
 use AppBundle\VideoNotifier\HistoryEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SocialNetworkTest extends TestCase
 {
-    /**
-     * @dataProvider speakerHandleDataProvider
-     */
+    #[DataProvider('speakerHandleDataProvider')]
     public function testGetSpeakerHandle(SocialNetwork $socialNetwork, Speaker $speaker, string $expectedHandle): void
     {
         $actualHandle = $socialNetwork->getSpeakerHandle($speaker);
@@ -22,7 +21,7 @@ class SocialNetworkTest extends TestCase
         self::assertEquals($expectedHandle, $actualHandle);
     }
 
-    public function speakerHandleDataProvider(): \Generator
+    public static function speakerHandleDataProvider(): \Generator
     {
         yield 'bluesky without @ prefix' => [
             SocialNetwork::Bluesky,

--- a/tests/unit/AppBundle/Subtitles/ParserTest.php
+++ b/tests/unit/AppBundle/Subtitles/ParserTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AppBundle\Tests\Subtitles;
 
 use AppBundle\Subtitles\Parser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 final class ParserTest extends TestCase
 {
-    /**
-     * @dataProvider parseDataProvider
-     */
+    #[DataProvider('parseDataProvider')]
     public function testPars(string $content, array $expectedResult): void
     {
         $parser = new Parser();
@@ -21,7 +20,7 @@ final class ParserTest extends TestCase
         self::assertEquals($expectedResult, $actualResult);
     }
 
-    public function parseDataProvider(): array
+    public static function parseDataProvider(): array
     {
         $content = <<<EOF
 1
@@ -69,7 +68,7 @@ on reçoit Stéphane Hulard Il baigne dans le web et son écosystème Il est con
         return [
             'Test simple' => [
                 'content' => $content,
-                'expected' => $expected,
+                'expectedResult' => $expected,
             ],
         ];
     }

--- a/tests/unit/AppBundle/TechLetter/Model/TechLetterFactoryTest.php
+++ b/tests/unit/AppBundle/TechLetter/Model/TechLetterFactoryTest.php
@@ -32,26 +32,26 @@ class TechLetterFactoryTest extends TestCase
         self::assertEquals($expectedTechLetter, $actualTechLetter);
     }
 
-    public function jsonDatProvider(): Generator
+    public static function jsonDatProvider(): Generator
     {
         yield 'null' => [
-            'json' => null,
-            'letter' => new TechLetter(),
+            'jsonFilePath' => null,
+            'expectedTechLetter' => new TechLetter(),
         ];
 
         yield 'empty' => [
-            'json' => __DIR__ . '/fixtures/empty.json',
-            'letter' => new TechLetter(),
+            'jsonFilePath' => __DIR__ . '/fixtures/empty.json',
+            'expectedTechLetter' => new TechLetter(),
         ];
 
         yield 'keys-present-but-empty-values' => [
-            'json' => __DIR__ . '/fixtures/keys-present-but-empty-values.json',
-            'letter' => new TechLetter(),
+            'jsonFilePath' => __DIR__ . '/fixtures/keys-present-but-empty-values.json',
+            'expectedTechLetter' => new TechLetter(),
         ];
 
         yield 'with-only-projects' => [
-            'json' => __DIR__ . '/fixtures/with-only-projects.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/with-only-projects.json',
+            'expectedTechLetter' => new TechLetter(
                 null,
                 null,
                 [],
@@ -63,8 +63,8 @@ class TechLetterFactoryTest extends TestCase
         ];
 
         yield 'with-only-articles' => [
-            'json' => __DIR__ . '/fixtures/with-only-articles.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/with-only-articles.json',
+            'expectedTechLetter' => new TechLetter(
                 null,
                 null,
                 [
@@ -76,8 +76,8 @@ class TechLetterFactoryTest extends TestCase
         ];
 
         yield 'language-null' => [
-            'json' => __DIR__ . '/fixtures/language-null.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/language-null.json',
+            'expectedTechLetter' => new TechLetter(
                 null,
                 null,
                 [
@@ -88,8 +88,8 @@ class TechLetterFactoryTest extends TestCase
         ];
 
         yield 'with-only-first-news' => [
-            'json' => __DIR__ . '/fixtures/with-only-first-news.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/with-only-first-news.json',
+            'expectedTechLetter' => new TechLetter(
                 new News(
                     'https://afup.org/news/1222-forum-php-2024-exceptionnel',
                     'Un Forum PHP 2024 exceptionnel !',
@@ -102,8 +102,8 @@ class TechLetterFactoryTest extends TestCase
         ];
 
         yield 'with-only-second-news' => [
-            'json' => __DIR__ . '/fixtures/with-only-second-news.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/with-only-second-news.json',
+            'expectedTechLetter' => new TechLetter(
                 null,
                 new News(
                     'https://afup.org/news/1231-enquete2025-barometre-des-salaires-PHP-ouverte',
@@ -116,8 +116,8 @@ class TechLetterFactoryTest extends TestCase
         ];
 
         yield 'full' => [
-            'json' => __DIR__ . '/fixtures/full.json',
-            'letter' => new TechLetter(
+            'jsonFilePath' => __DIR__ . '/fixtures/full.json',
+            'expectedTechLetter' => new TechLetter(
                 new News(
                     'https://afup.org/news/1222-forum-php-2024-exceptionnel',
                     'Un Forum PHP 2024 exceptionnel !',

--- a/tests/unit/AppBundle/TestCase.php
+++ b/tests/unit/AppBundle/TestCase.php
@@ -9,14 +9,10 @@ use Faker\Generator;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    private ?Generator $faker = null;
+    private static ?Generator $faker = null;
 
-    protected function faker(): Generator
+    protected static function faker(): Generator
     {
-        if ($this->faker === null) {
-            $this->faker = Factory::create();
-        }
-
-        return $this->faker;
+        return self::$faker ??= Factory::create();
     }
 }

--- a/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
+++ b/tests/unit/AppBundle/VideoNotifier/StatusGeneratorTest.php
@@ -11,6 +11,7 @@ use AppBundle\SocialNetwork\SocialNetwork;
 use AppBundle\SocialNetwork\Status;
 use AppBundle\Tests\TestCase;
 use AppBundle\VideoNotifier\StatusGenerator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class StatusGeneratorTest extends TestCase
 {
@@ -24,9 +25,7 @@ class StatusGeneratorTest extends TestCase
         $generator->generate(new Talk(), []);
     }
 
-    /**
-     * @dataProvider textTooLongDataProvider
-     */
+    #[DataProvider('textTooLongDataProvider')]
     public function testTextTooLong(
         SocialNetwork $socialNetwork,
         Talk $talk,
@@ -41,30 +40,28 @@ class StatusGeneratorTest extends TestCase
         $generator->generate($talk, $speakers);
     }
 
-    public function textTooLongDataProvider(): \Generator
+    public static function textTooLongDataProvider(): \Generator
     {
         yield [
             SocialNetwork::Bluesky,
-            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Bluesky->statusMaxLength() * 2)),
+            (new Talk())->setTitle(self::faker()->realText(SocialNetwork::Bluesky->statusMaxLength() * 2)),
             [
-                (new Speaker())->setBluesky($this->faker()->domainName()),
+                (new Speaker())->setBluesky(self::faker()->domainName()),
             ],
             'Statut généré pour bluesky trop long',
         ];
 
         yield [
             SocialNetwork::Mastodon,
-            (new Talk())->setTitle($this->faker()->realText(SocialNetwork::Mastodon->statusMaxLength() * 2)),
+            (new Talk())->setTitle(self::faker()->realText(SocialNetwork::Mastodon->statusMaxLength() * 2)),
             [
-                (new Speaker())->setMastodon($this->faker()->domainName()),
+                (new Speaker())->setMastodon(self::faker()->domainName()),
             ],
             'Statut généré pour mastodon trop long',
         ];
     }
 
-    /**
-     * @dataProvider validStatusDataProvider
-     */
+    #[DataProvider('validStatusDataProvider')]
     public function testGenerateValidStatus(
         SocialNetwork $socialNetwork,
         Talk $talk,
@@ -78,7 +75,7 @@ class StatusGeneratorTest extends TestCase
         self::assertEquals($expectedStatus, $actualStatus);
     }
 
-    public function validStatusDataProvider(): \Generator
+    public static function validStatusDataProvider(): \Generator
     {
         yield 'mastodon full case' => [
             SocialNetwork::Mastodon,


### PR DESCRIPTION
- les data providers doivent être statiques
- les clefs des tableaux doivent correspondre aux arguments des tests
- les annotations sont remplacées par des attributs

On ne peut pas encore passer à la v12 car il faut être en PHP 8.3