### PR TITLE
Correction des tests Flaky lié au Datetime sur la newsletter

### DIFF
--- a/sources/AppBundle/TechLetter/Model/TechLetterFactory.php
+++ b/sources/AppBundle/TechLetter/Model/TechLetterFactory.php
@@ -27,11 +27,11 @@ class TechLetterFactory
         $firstNews = $secondNews = null;
 
         if (isset($array['firstNews']) && $array['firstNews'] !== null) {
-            $firstNews = new News($array['firstNews']['url'], $array['firstNews']['title'], \DateTimeImmutable::createFromFormat('Y-m-d', (string) $array['firstNews']['date']));
+            $firstNews = new News($array['firstNews']['url'], $array['firstNews']['title'], \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $array['firstNews']['date']));
         }
 
         if (isset($array['secondNews']) && $array['secondNews'] !== null) {
-            $secondNews = new News($array['secondNews']['url'], $array['secondNews']['title'], \DateTimeImmutable::createFromFormat('Y-m-d', (string) $array['secondNews']['date']));
+            $secondNews = new News($array['secondNews']['url'], $array['secondNews']['title'], \DateTimeImmutable::createFromFormat('!Y-m-d', (string) $array['secondNews']['date']));
         }
 
         return new TechLetter(

--- a/tests/unit/AppBundle/TechLetter/Model/TechLetterFactoryTest.php
+++ b/tests/unit/AppBundle/TechLetter/Model/TechLetterFactoryTest.php
@@ -72,7 +72,7 @@ class TechLetterFactoryTest extends TestCase
                 new News(
                     'https://afup.org/news/1222-forum-php-2024-exceptionnel',
                     'Un Forum PHP 2024 exceptionnel !',
-                    DateTimeImmutable::createFromFormat('Y-m-d', '2024-10-21'),
+                    DateTimeImmutable::createFromFormat('!Y-m-d', '2024-10-21'),
                 ),
                 null,
                 [],
@@ -87,7 +87,7 @@ class TechLetterFactoryTest extends TestCase
                 new News(
                     'https://afup.org/news/1231-enquete2025-barometre-des-salaires-PHP-ouverte',
                     'L’enquête 2025 du baromètre des salaires en PHP est ouverte',
-                    DateTimeImmutable::createFromFormat('Y-m-d', '2025-03-17'),
+                    DateTimeImmutable::createFromFormat('!Y-m-d', '2025-03-17'),
                 ),
                 [],
                 [],
@@ -100,12 +100,12 @@ class TechLetterFactoryTest extends TestCase
                 new News(
                     'https://afup.org/news/1222-forum-php-2024-exceptionnel',
                     'Un Forum PHP 2024 exceptionnel !',
-                    DateTimeImmutable::createFromFormat('Y-m-d', '2024-10-21'),
+                    DateTimeImmutable::createFromFormat('!Y-m-d', '2024-10-21'),
                 ),
                 new News(
                     'https://afup.org/news/1231-enquete2025-barometre-des-salaires-PHP-ouverte',
                     'L’enquête 2025 du baromètre des salaires en PHP est ouverte',
-                    DateTimeImmutable::createFromFormat('Y-m-d', '2025-03-17'),
+                    DateTimeImmutable::createFromFormat('!Y-m-d', '2025-03-17'),
                 ),
                 [
                     new Article('https://example.com/fr', 'Example en français', 'example.com', '2', 'Lorem ipsum', 'fr'),


### PR DESCRIPTION
On a des erreurs flaky lié au datetime pour la sérialisation de la newsletter.
Par exemple : https://github.com/afup/web/pull/1771/checks#step:7:70

On ne se sert que des dates (pas des heures, minutes, secondes) donc on les mets à 0 tout le temps.