### PR TITLE
correction de la gestion des dates dans l'admin des événements

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -7,6 +7,7 @@ namespace AppBundle\Event\Model\Repository;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\GithubUser;
 use AppBundle\Event\Model\Ticket;
+use AppBundle\Ting\DateTimeWithTImeZoneSerializer;
 use CCMBenchmark\Ting\Driver\Mysqli\Serializer\Boolean;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 use CCMBenchmark\Ting\Repository\HydratorArray;
@@ -292,8 +293,9 @@ SQL;
                 'columnName' => 'date_fin_appel_projet',
                 'fieldName' => 'dateEndCallForProjects',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -301,8 +303,9 @@ SQL;
                 'columnName' => 'date_fin_appel_conferencier',
                 'fieldName' => 'dateEndCallForPapers',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -315,8 +318,9 @@ SQL;
                 'columnName' => 'date_fin_prevente',
                 'fieldName' => 'dateEndPreSales',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -324,8 +328,9 @@ SQL;
                 'columnName' => 'date_fin_vente',
                 'fieldName' => 'dateEndSales',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -333,8 +338,9 @@ SQL;
                 'columnName' => 'date_fin_vente_token_sponsor',
                 'fieldName' => 'dateEndSalesSponsorToken',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -342,8 +348,9 @@ SQL;
                 'columnName' => 'date_fin_saisie_repas_speakers',
                 'fieldName' => 'dateEndSpeakersDinerInfosCollection',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -351,8 +358,9 @@ SQL;
                 'columnName' => 'date_annonce_planning',
                 'fieldName' => 'datePlanningAnnouncement',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -360,8 +368,9 @@ SQL;
                 'columnName' => 'date_fin_saisie_nuites_hotel',
                 'fieldName' => 'dateEndHotelInfosCollection',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -7,7 +7,7 @@ namespace AppBundle\Event\Model\Repository;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\GithubUser;
 use AppBundle\Event\Model\Ticket;
-use AppBundle\Ting\DateTimeWithTImeZoneSerializer;
+use AppBundle\Ting\DateTimeWithTimeZoneSerializer;
 use CCMBenchmark\Ting\Driver\Mysqli\Serializer\Boolean;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
 use CCMBenchmark\Ting\Repository\HydratorArray;
@@ -293,7 +293,7 @@ SQL;
                 'columnName' => 'date_fin_appel_projet',
                 'fieldName' => 'dateEndCallForProjects',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -303,7 +303,7 @@ SQL;
                 'columnName' => 'date_fin_appel_conferencier',
                 'fieldName' => 'dateEndCallForPapers',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -318,7 +318,7 @@ SQL;
                 'columnName' => 'date_fin_prevente',
                 'fieldName' => 'dateEndPreSales',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -328,7 +328,7 @@ SQL;
                 'columnName' => 'date_fin_vente',
                 'fieldName' => 'dateEndSales',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -338,7 +338,7 @@ SQL;
                 'columnName' => 'date_fin_vente_token_sponsor',
                 'fieldName' => 'dateEndSalesSponsorToken',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -348,7 +348,7 @@ SQL;
                 'columnName' => 'date_fin_saisie_repas_speakers',
                 'fieldName' => 'dateEndSpeakersDinerInfosCollection',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -358,7 +358,7 @@ SQL;
                 'columnName' => 'date_annonce_planning',
                 'fieldName' => 'datePlanningAnnouncement',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
@@ -368,7 +368,7 @@ SQL;
                 'columnName' => 'date_fin_saisie_nuites_hotel',
                 'fieldName' => 'dateEndHotelInfosCollection',
                 'type' => 'datetime',
-                'serializer' => DateTimeWithTImeZoneSerializer::class,
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -295,7 +295,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -305,7 +305,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -320,7 +320,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -330,7 +330,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -340,7 +340,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -350,7 +350,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -360,7 +360,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])
@@ -370,7 +370,7 @@ SQL;
                 'type' => 'datetime',
                 'serializer' => DateTimeWithTImeZoneSerializer::class,
                 'serializer_options' => [
-                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U', 'timezone' => 'Europe/Paris',],
+                    'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],
                 ]
             ])

--- a/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace AppBundle\Ting;
 
 use CCMBenchmark\Ting\Serializer\DateTime;

--- a/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
@@ -13,8 +13,12 @@ class DateTimeWithTImeZoneSerializer extends DateTime
         $value = parent::unserialize($serialized, $options);
 
         if ($value instanceof \DateTime && isset($options['timezone'])) {
-            $value->setTimezone(new \DateTimeZone($options['timezone']));
+            $timeZone = $options['timezone'];
+        } else {
+            $timeZone = date_default_timezone_get();
         }
+
+        $value->setTimezone(new \DateTimeZone($timeZone));
 
         return $value;
     }

--- a/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTImeZoneSerializer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AppBundle\Ting;
+
+use CCMBenchmark\Ting\Serializer\DateTime;
+
+class DateTimeWithTImeZoneSerializer extends DateTime
+{
+    public function unserialize($serialized, array $options = [])
+    {
+        $value = parent::unserialize($serialized, $options);
+
+        if ($value instanceof \DateTime && isset($options['timezone'])) {
+            $value->setTimezone(new \DateTimeZone($options['timezone']));
+        }
+
+        return $value;
+    }
+}

--- a/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
@@ -6,7 +6,7 @@ namespace AppBundle\Ting;
 
 use CCMBenchmark\Ting\Serializer\DateTime;
 
-class DateTimeWithTImeZoneSerializer extends DateTime
+class DateTimeWithTimeZoneSerializer extends DateTime
 {
     public function unserialize($serialized, array $options = [])
     {

--- a/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
@@ -18,7 +18,7 @@ class DateTimeWithTimeZoneSerializer extends DateTime
             $timeZone = date_default_timezone_get();
         }
 
-        if ($timeZone) {
+        if ($value && $timeZone) {
             $value->setTimezone(new \DateTimeZone($timeZone));
         }
 

--- a/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
+++ b/sources/AppBundle/Ting/DateTimeWithTimeZoneSerializer.php
@@ -18,7 +18,9 @@ class DateTimeWithTimeZoneSerializer extends DateTime
             $timeZone = date_default_timezone_get();
         }
 
-        $value->setTimezone(new \DateTimeZone($timeZone));
+        if ($timeZone) {
+            $value->setTimezone(new \DateTimeZone($timeZone));
+        }
 
         return $value;
     }


### PR DESCRIPTION
Depuis qu'on est passé par les objets ting pour gérer les events dans l'admin nous avons un souci sur la gestion des heures.

Lors de la récupération de l'heure, celle-ci est décalée de 2 heures, et lors de l'enregistrement on enregistre cette version décalée, à chaque enregistre on a le décalage qui s'applique.

Cela car on stocke la date/heure en timestamp sur certains champs (c'est historique et à long terme l'idée est de changer cela mais on ne va pas changer cela à court terme), que le timestamp est converti en datetime par Ting et cela dans gérer le fuseau horaire.

Afin de corriger cela on crée un nouveau type de serialiser qu'on applique aux champs en timestamp qui va avoir une option pour setter la timezone, ainsi la date enregistrée est bien la date affichée.