### PR TITLE
Correction du blocage de l'ouverture du CFP

### DIFF
--- a/templates/event/cfp/propose.html.twig
+++ b/templates/event/cfp/propose.html.twig
@@ -9,7 +9,7 @@
         {% endif %}
 
         <div class="mlm">
-            {% if "now"|date < event.dateStartCallForPapers %}
+            {% if event.isCfpOpen %}
                 <div class="flash flash-error">
                     {{ "Le CFP n'est pas encore ouvert. Il ouvrira le %date%."|trans({'%date%': event.dateStartCallForPapers|localizeddate}) }}
                 </div>

--- a/templates/event/cfp/propose.html.twig
+++ b/templates/event/cfp/propose.html.twig
@@ -9,7 +9,7 @@
         {% endif %}
 
         <div class="mlm">
-            {% if event.isCfpOpen %}
+            {% if not event.isCfpOpen %}
                 <div class="flash flash-error">
                     {{ "Le CFP n'est pas encore ouvert. Il ouvrira le %date%."|trans({'%date%': event.dateStartCallForPapers|localizeddate}) }}
                 </div>


### PR DESCRIPTION
Correction du test d'ouverture du CFP.

On comparait :
```
"May 9, 2025 08:59"
```
à
```
DateTime @1749444842 {#752 ▼
  date: 2025-06-09 04:54:02.0 +00:00
}
```

Forcément ça marchait beaucoup moins bien ;-)

On s'appuie maintenant sur `event.isCfpOpen()` (qui est testé unitairement) pour afficher le message de non ouverture.
Dans le cas de la fin du CFP, il y a une redirection faite depuis le controller donc on n'arrivera pas ici.

