### PR TITLE
Correction pour la date d'ouverture du CFP

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -314,6 +314,7 @@ SQL;
                 'columnName' => 'date_debut_appel_conferencier',
                 'fieldName' => 'dateStartCallForPapers',
                 'type' => 'datetime',
+                'serializer' => DateTimeWithTimeZoneSerializer::class,
                 'serializer_options' => [
                     'unserialize' => ['unSerializeUseFormat' => true, 'format' => 'U'],
                     'serialize' => ['serializeUseFormat' => true, 'format' => 'U'],


### PR DESCRIPTION
On applique la correction de la timezone #1775 sur le nouveau champ de date d'ouverture du CFP.