### PR TITLE
Correction d'une erreur de type du synchronizer mailchimp

### DIFF
--- a/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
+++ b/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
@@ -39,6 +39,7 @@ class MailchimpSynchronizer
 
     private function unsubscribeAddresses(array $emails): void
     {
+        $emails = array_filter($emails);
         foreach ($emails as $email) {
             $this->logger->info('Unsubscribe {address} to techletter', ['address' => $email]);
             try {
@@ -51,6 +52,7 @@ class MailchimpSynchronizer
 
     private function subscribeAddresses(array $emails): void
     {
+        $emails = array_filter($emails);
         foreach ($emails as $email) {
             $this->logger->info('Subscribe {address} to techletter', ['address' => $email]);
             try {


### PR DESCRIPTION
L'éxécution de la synchronisation avec Mailchimp plante tout les jours avec cette erreur : 
```
2025-05-09T23:00:09.202Z (bas) CMDOUT (01:00:09 INFO      [app] Unsubscribe  to techletter ["address" => null])
2025-05-09T23:00:09.204Z console.CRITICAL: Error thrown while running command "--env=prod sync-techletter -vv". Message: "AppBundle\Mailchimp\Mailchimp::unSubscribeAddress(): Argument #2 ($email) must be of type string, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php on line 45" {"exception":"[object] (TypeError(code: 0): AppBundle\\Mailchimp\\Mailchimp::unSubscribeAddress(): Argument #2 ($email) must be of type string, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php on line 45 at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Mailchimp/Mailchimp.php:88)","command":"--env=prod sync-techletter -vv","message":"AppBundle\\Mailchimp\\Mailchimp::unSubscribeAddress(): Argument #2 ($email) must be of type string, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php on line 45"} []
2025-05-09T23:00:09.206Z (bas) CMDOUT (01:00:09 CRITICAL  [console] Error thrown while running command "--env=prod sync-techletter -vv". Message: "AppBundle\Mailchimp\Mailchimp::unSubscribeAddress(): Argument #2 ($email) must be of type string, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php on line 45" ["exception" => TypeError { …},"command" => "--env=prod sync-techletter -vv","message" => "AppBundle\Mailchimp\Mailchimp::unSubscribeAddress(): Argument #2 ($email) must be of type string, null given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php on line 45"])
2025-05-09T23:00:09.212Z (bas) CMDOUT (  AppBundle\Mailchimp\Mailchimp::unSubscribeAddress(): Argument #2 ($email) m  )
2025-05-09T23:00:09.212Z (bas) CMDOUT ( AppBundle\Mailchimp\Mailchimp->unSubscribeAddress() at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php:45)
2025-05-09T23:00:09.212Z (bas) CMDOUT ( AppBundle\TechLetter\MailchimpSynchronizer->unsubscribeAddresses() at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/TechLetter/MailchimpSynchronizer.php:29)
```


On sécurise la désinscription des emails avec un `array_filter()` pour ne plus avoir d'email à `null`
