### PR TITLE
Stockage de l'évènement sélectionné en session

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -190,9 +190,9 @@ parameters:
                 forum_vote_github:
                     nom: 'Votes visiteurs'
                     niveau: 'ROLE_FORUM'
-                    url: '/admin/vote/'
+                    url: '/admin/event/votes/'
                     extra_routes:
-                        - admin_vote
+                        - admin_event_votes
                 forum_conferenciers:
                     nom: 'Speakers'
                     niveau: 'ROLE_FORUM'

--- a/app/config/routing/admin.yml
+++ b/app/config/routing/admin.yml
@@ -2,10 +2,6 @@ admin_home:
   path: /
   defaults: {_controller: AppBundle\Controller\Admin\HomeAction}
 
-admin_vote:
-  path: /vote/
-  defaults: {_controller: AppBundle\Controller\Admin\VoteController::admin}
-
 admin_relances:
   path: /association/relances/{page}
   defaults: {_controller: AppBundle\Controller\Admin\Membership\ReminderLogAction}

--- a/app/config/routing/admin_event.yml
+++ b/app/config/routing/admin_event.yml
@@ -101,3 +101,7 @@ admin_event_restore:
   defaults: { _controller: AppBundle\Controller\Admin\Event\RestoreAction }
   requirements:
     id: \d+
+
+admin_event_votes:
+  path: /votes
+  defaults: {_controller: AppBundle\Controller\Admin\Event\VotesListeAction}

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -62,7 +62,6 @@ security:
         - { path: ^/admin/members/companies, roles: ROLE_ADMIN }
         - { path: ^/admin/event/speakers-management, roles: ROLE_FORUM }
         - { path: ^/admin/event, roles: ROLE_ADMIN }
-        - { path: ^/admin/vote, roles: ROLE_ADMIN }
         - { path: ^/admin/members/general_meeting, roles: ROLE_ADMIN }
         - { path: ^/admin/members/general_meeting_vote, roles: ROLE_ADMIN }
         - { path: ^/admin/site, roles: ROLE_ADMIN }

--- a/htdocs/pages/administration/forum_facturation.php
+++ b/htdocs/pages/administration/forum_facturation.php
@@ -43,6 +43,8 @@ if ($action == 'lister') {
         $list_filtre = $_GET['filtre'];
     }
 
+    chargerForumId();
+
     if (!isset($_GET['id_forum']) || intval($_GET['id_forum']) == 0) {
         $_GET['id_forum'] = $forum->obtenirDernier();
     }

--- a/htdocs/pages/administration/forum_inscriptions.php
+++ b/htdocs/pages/administration/forum_inscriptions.php
@@ -85,6 +85,8 @@ if ($action == 'lister') {
         $list_filtre = $_GET['filtre'];
     }
 
+    chargerForumId();
+
     if (!isset($_GET['id_forum']) || intval($_GET['id_forum']) == 0) {
         $_GET['id_forum'] = $forum->obtenirDernier();
     }

--- a/htdocs/pages/administration/forum_planning.php
+++ b/htdocs/pages/administration/forum_planning.php
@@ -32,6 +32,7 @@ if ($action == 'lister') {
     $list_associatif = false;
     $list_filtre = false;
 
+    chargerForumId();
 
     if (!isset($_GET['id_forum']) || intval($_GET['id_forum']) == 0) {
         $_GET['id_forum'] = $forum->obtenirDernier();

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -53,6 +53,8 @@ if ($action == 'lister') {
         $list_type = $_GET['type'];
     }
 
+    chargerForumId();
+
     if (!isset($_GET['id_forum']) || intval($_GET['id_forum']) == 0) {
         $_GET['id_forum'] = $forum->obtenirDernier();
     }

--- a/sources/Afup/fonctions.php
+++ b/sources/Afup/fonctions.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use AppBundle\Association\Form\HTML_QuickForm;
+use AppBundle\Controller\Admin\Event\AdminActionWithEventSelector;
 
 /**
  * Affiche un message puis redirige le visiteur vers une URL spécifiée
@@ -108,4 +109,9 @@ function obtenirTitre($pages, $page)
         }
     }
     return null;
+}
+
+function chargerForumId(): void
+{
+    $_GET['id_forum'] = $_GET['id_forum'] ?? $_SESSION['_sf2_attributes'][AdminActionWithEventSelector::SESSION_KEY] ?? 0;
 }

--- a/sources/AppBundle/Controller/Admin/Event/AdminActionWithEventSelector.php
+++ b/sources/AppBundle/Controller/Admin/Event/AdminActionWithEventSelector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Event;
+
+/**
+ * Cette interface permet d'identifier les controllers ayant un sélecteur d'évènement.
+ * Elle sert à faire une redirection si l'id de l'évènement n'est pas présent dans l'url.
+ *
+ * @see RedirectEventFromSessionListener
+ */
+interface AdminActionWithEventSelector
+{
+    public const SESSION_KEY = 'event_selector_current_id';
+}

--- a/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
@@ -8,7 +8,7 @@ use Afup\Site\Forum\Facturation;
 use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Email\Emails;
 use AppBundle\Email\Mailer\MailUser;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Invoice;
 use AppBundle\Event\Model\Repository\InvoiceRepository;
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
-class PendingBankwiresAction extends AbstractController
+class PendingBankwiresAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
@@ -34,6 +34,7 @@ class PendingBankwiresAction extends AbstractController
         private readonly Emails $emails,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -62,7 +63,7 @@ class PendingBankwiresAction extends AbstractController
             'event' => $event,
             'title' => 'Virements en attente',
             'token' => $this->csrfTokenManager->getToken('admin_event_bankwires'),
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 

--- a/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
@@ -6,7 +6,7 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Association\Form\TicketEventType;
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\TicketEventTypeRepository;
 use AppBundle\Event\Model\Repository\TicketTypeRepository;
 use AppBundle\Event\Model\TicketEventType as ModelTicketEventType;
@@ -24,6 +24,7 @@ class PricesAddAction extends AbstractController
         private readonly TicketTypeRepository $ticketTypeRepository,
         private readonly TicketEventTypeRepository $ticketEventTypeRepository,
         private readonly ValidatorInterface $validator,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -74,7 +75,7 @@ class PricesAddAction extends AbstractController
             'event' => $event,
             'title' => 'Tarifications - Ajouter',
             'button_text' => 'Ajouter',
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
@@ -6,7 +6,7 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Association\Form\TicketEventType;
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\TicketEventTypeRepository;
 use AppBundle\Event\Model\Repository\TicketTypeRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -18,6 +18,7 @@ class PricesEditAction extends AbstractController
         private readonly EventActionHelper $eventActionHelper,
         private readonly TicketTypeRepository $ticketTypeRepository,
         private readonly TicketEventTypeRepository $ticketEventTypeRepository,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -56,7 +57,7 @@ class PricesEditAction extends AbstractController
             'event' => $event,
             'title' => 'Tarifications - Modifier',
             'button_text' => 'Modifier',
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/RedirectEventFromSessionListener.php
+++ b/sources/AppBundle/Controller/Admin/Event/RedirectEventFromSessionListener.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Event;
+
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[AsEventListener]
+final readonly class RedirectEventFromSessionListener
+{
+    public function __construct(
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function __invoke(ControllerEvent $event): void
+    {
+        $controller = $event->getController();
+
+        // Gestion des controllers avec plusieurs actions, dans ce cas le controller
+        // est retourné sous ce format : [$controllerInstance, 'methodName']
+        if (is_array($controller)) {
+            $controller = $controller[0];
+        }
+
+        if (!$controller instanceof AdminActionWithEventSelector) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        // Si on arrive sur une route en GET et qui a un sélecteur d'évènement,
+        // alors on vérifie si un id d'évènement est présent dans la session et absent dans l'url.
+        // Si c'est le cas, on redirige vers la même page, mais avec l'id en plus dans l'url.
+        if (
+            $request->isMethod('GET')
+            && !$request->query->has('id')
+            && $request->getSession()->has(AdminActionWithEventSelector::SESSION_KEY)
+        ) {
+            $url = $this->urlGenerator->generate(
+                $request->attributes->get('_route'),
+                array_merge(
+                    $request->attributes->get('_route_params'),
+                    ['id' => $request->getSession()->get(AdminActionWithEventSelector::SESSION_KEY)]
+                ),
+            );
+
+            $event->setController(fn () => new RedirectResponse($url));
+        }
+    }
+}

--- a/sources/AppBundle/Controller/Admin/Event/RoomAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RoomAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\RoomType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\RoomRepository;
 use AppBundle\Event\Model\Room;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
@@ -16,12 +16,13 @@ use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class RoomAction extends AbstractController
+class RoomAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
         private readonly FormFactoryInterface $formFactory,
         private readonly RoomRepository $roomRepository,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -73,7 +74,7 @@ class RoomAction extends AbstractController
             'addForm' => $addForm === null ? null : $addForm->createView(),
             'editForms' => $editForms === null ? null : array_map(static fn (Form $form) => $form->createView(), $editForms),
             'title' => 'Gestion des salles',
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
 use AppBundle\SpeakerInfos\SpeakersExpensesStorage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SpeakersExpensesAction extends AbstractController
+class SpeakersExpensesAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
         private readonly SpeakerRepository $speakerRepository,
         private readonly SpeakersExpensesStorage $speakersExpensesStorage,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -39,7 +40,7 @@ class SpeakersExpensesAction extends AbstractController
         return $this->render('admin/event/speakers_expenses.html.twig', [
             'event' => $event,
             'speakers' => $speakers,
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
 use AppBundle\SpeakerInfos\SpeakersExpensesStorage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SpeakersManagementAction extends AbstractController
+class SpeakersManagementAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
         private readonly SpeakerRepository $speakerRepository,
         private readonly SpeakersExpensesStorage $speakersExpensesStorage,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -39,7 +40,7 @@ class SpeakersManagementAction extends AbstractController
         return $this->render('admin/event/speakers_management.html.twig', [
             'event' => $event,
             'speakers' => $speakers,
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
@@ -6,7 +6,7 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Association\Model\User;
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Form\TicketSpecialPriceType;
 use AppBundle\Event\Model\Repository\TicketSpecialPriceRepository;
 use AppBundle\Event\Model\TicketSpecialPrice;
@@ -15,11 +15,12 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SpecialPriceAction extends AbstractController
+class SpecialPriceAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
         private readonly TicketSpecialPriceRepository $ticketSpecialPriceRepository,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -61,7 +62,7 @@ class SpecialPriceAction extends AbstractController
             'event' => $event,
             'title' => 'Gestion des prix custom',
             'form' => $form === null ? null : $form->createView(),
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
@@ -6,8 +6,8 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Association\Model\User;
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\SponsorTokenType;
+use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\SponsorTicketRepository;
 use AppBundle\Event\Model\SponsorTicket;
 use AppBundle\Event\Ticket\SponsorTokenMail;
@@ -16,12 +16,13 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class SponsorTicketAction extends AbstractController
+class SponsorTicketAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
         private readonly EventActionHelper $eventActionHelper,
         private readonly SponsorTicketRepository $sponsorTicketRepository,
         private readonly SponsorTokenMail $sponsorTokenMail,
+        private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
@@ -68,7 +69,7 @@ class SponsorTicketAction extends AbstractController
             'title' => 'Gestion des inscriptions sponsors',
             'form' => $form === null ? null : $form->createView(),
             'edit' => $edit,
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
+            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/VotesListeAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/VotesListeAction.php
@@ -6,31 +6,31 @@ namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Event\Form\Support\EventSelectFactory;
-use AppBundle\Event\Model\Repository\TicketEventTypeRepository;
+use AppBundle\Event\Model\Repository\VoteRepository;
+use CCMBenchmark\TingBundle\Repository\RepositoryFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class PricesAction extends AbstractController implements AdminActionWithEventSelector
+final class VotesListeAction extends AbstractController implements AdminActionWithEventSelector
 {
     public function __construct(
+        private readonly RepositoryFactory $repositoryFactory,
         private readonly EventActionHelper $eventActionHelper,
-        private readonly TicketEventTypeRepository $ticketEventTypeRepository,
         private readonly EventSelectFactory $eventSelectFactory,
     ) {
     }
 
     public function __invoke(Request $request): Response
     {
-        $id = $request->query->get('id');
-        $event = $this->eventActionHelper->getEventById($id);
-        $ticketEventTypes = $this->ticketEventTypeRepository->getTicketsByEvent($event);
+        $eventId = $request->query->get('id');
+        $event = $this->eventActionHelper->getEventById($eventId);
 
-        return $this->render('admin/event/prices.html.twig', [
-            'ticket_event_types' => $ticketEventTypes,
-            'has_prices_defined_with_vat' => $event->hasPricesDefinedWithVat(),
+        $votes = $event === null ? []:$this->repositoryFactory->get(VoteRepository::class)->getVotesByEvent($event->getId());
+
+        return $this->render('admin/vote/liste.html.twig', [
+            'votes' => $votes,
             'event' => $event,
-            'title' => 'Liste des prix',
             'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
         ]);
     }

--- a/sources/AppBundle/Controller/Admin/VoteController.php
+++ b/sources/AppBundle/Controller/Admin/VoteController.php
@@ -6,7 +6,6 @@ namespace AppBundle\Controller\Admin;
 
 use AppBundle\Association\Model\User;
 use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\EventSelectType;
 use AppBundle\Event\Form\VoteType;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Repository\VoteRepository;
@@ -163,21 +162,6 @@ class VoteController extends AbstractController
         }
 
         return new JsonResponse(['errors' => []]);
-    }
-
-    public function admin(Request $request): Response
-    {
-        $eventId = $request->query->get('id');
-        $event = $this->eventActionHelper->getEventById($eventId);
-
-        $votes = $event === null ? []:$this->repositoryFactory->get(VoteRepository::class)->getVotesByEvent($event->getId());
-
-        return $this->render('admin/vote/liste.html.twig', [
-            'votes' => $votes,
-            'title' => 'Votes',
-            'event' => $event,
-            'event_select_form' => $this->createForm(EventSelectType::class, $event)->createView(),
-        ]);
     }
 
     /**

--- a/sources/AppBundle/Event/Form/Support/EventSelectFactory.php
+++ b/sources/AppBundle/Event/Form/Support/EventSelectFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Event\Form\Support;
+
+use AppBundle\Controller\Admin\Event\AdminActionWithEventSelector;
+use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Repository\EventRepository;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+final readonly class EventSelectFactory
+{
+    public function __construct(
+        private FormFactoryInterface $formFactory,
+        private SessionInterface $session,
+        private EventRepository $eventRepository,
+    ) {
+    }
+
+    public function create(Event $event, Request $request): FormInterface
+    {
+        // L'id dans l'url est prioritaire sur celui de la session
+        $selectedEventId = $request->query->get('id') ?? $this->session->get(AdminActionWithEventSelector::SESSION_KEY);
+
+        if ($request->query->has('id')) {
+            $this->session->set(AdminActionWithEventSelector::SESSION_KEY, $selectedEventId);
+        }
+
+        $selectedEvent = null;
+        if ($selectedEventId) {
+            $selectedEvent = $this->eventRepository->get($selectedEventId);
+        }
+
+        return $this->formFactory->create(EventSelectType::class, $event, [
+            'data' => $selectedEvent,
+        ]);
+    }
+}

--- a/templates/admin/speaker/list.html.twig
+++ b/templates/admin/speaker/list.html.twig
@@ -3,27 +3,9 @@
 {% block content %}
 <h2>Speakers</h2>
 
-<div class="ui violet segment">
-    <form method="GET" name="forum">
-        <div class="ui form">
-            <div class="inline fields">
-                <div class="field">
-                    <label>Évènement</label>
-                    <select name="eventId" onchange="this.form.submit(); return false;">
-                        {% for event in events %}
-                            <option value="{{ event.id }}"{% if eventId == event.id %} selected{% endif %}>{{ event.title }}</option>
-                        {% endfor %}
-                    </select>
-                </div>
-            </div>
-        </div>
-    </form>
-</div>
+{% include 'admin/event/change_event.html.twig' with {form: event_select_form} only %}
 
 <div class="ui menu">
-{% if eventId == null %}
-    <div class="item">Changez d'évènement dans le menu ci dessus</div>
-    {% else %}
     <a href="{{ path('admin_speaker_add' ,{eventId: eventId}) }}" class="item">
         <div data-tooltip="Ajouter un conférencier" data-position="bottom left">
             <i class="icon plus square"></i>
@@ -37,14 +19,13 @@
         <i class="icon file"></i>
         Exporter les speakers
     </a>
-    {% endif %}
 </div>
 
 <div class="ui segment">
     <form method="GET" name="filtre">
         <input type="hidden" name="sort" value="{{ sort }}"/>
         <input type="hidden" name="direction" value="{{ direction }}"/>
-        <input type="hidden" name="eventId" value="{{ eventId }}"/>
+        <input type="hidden" name="id" value="{{ eventId }}"/>
 
         <div class="ui form">
             <div class="inline fields">
@@ -68,7 +49,7 @@
         </div>
     </div>
 
-    {% if speakers %}
+    {% if speakers.count > 0 %}
         <table class="ui table striped compact celled">
             <thead>
             <tr>
@@ -131,7 +112,7 @@
         <div class="ui placeholder segment">
             <div class="ui icon header">
                 <i class="meh outline icon"></i>
-                Aucun speaker. {% if eventId == null %}Essayez de changez d'évènement.{% endif %}
+                Aucun speaker.
             </div>
         </div>
     {% endif %}

--- a/tests/behat/features/Admin/Events/VoteVisiteur.feature
+++ b/tests/behat/features/Admin/Events/VoteVisiteur.feature
@@ -4,7 +4,7 @@ Feature: Administration - Évènements - Vote Visiteur
 
   Scenario: Un membre ne peut pas accéder aux votes visiteurs
     Given I am logged-in with the user "paul" and the password "paul"
-    And I am on "/admin/vote/"
+    And I am on "/admin/event/votes/"
     Then the response status code should be 403
 
   Scenario: Accès aux votes des visiteurs


### PR DESCRIPTION
Stockage de la sélection d'un évènement en session, avec redirection si l'id est présent en session mais manquant dans l'url.

Le système est à moitié géré dans les anciennes pages : le sélecteur n'écrit pas dans la session mais va juste y lire un éventuel id.

Clôture de #1782 et #1716