### PR TITLE
Fix synchonizer Mailchimp

### DIFF
--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -75,7 +75,7 @@ class Mailchimp
             ]);
 
             foreach ($response['members'] as $member) {
-                $addresses[] = $member->email_address;
+                $addresses[] = $member['email_address'];
             }
         }
 

--- a/sources/AppBundle/Mailchimp/Mailchimp.php
+++ b/sources/AppBundle/Mailchimp/Mailchimp.php
@@ -18,7 +18,7 @@ class Mailchimp
     /**
      * Subscribe an address to a list
      */
-    public function subscribeAddress(string $list, string $email)
+    public function subscribeAddress(string $list, string $email): bool|array
     {
         // Le status pending permet d'être en double opt-in, que Mailchimp envoie
         // un mail de confirmation pour valider l'inscription à la newsletter
@@ -29,7 +29,7 @@ class Mailchimp
         ]);
     }
 
-    public function subscribeAddressWithoutConfirmation(string $list, string $email)
+    public function subscribeAddressWithoutConfirmation(string $list, string $email): bool|array
     {
         return $this->client->put('lists/' . $list . '/members/' . $this->getAddressId($email), [
             'status' => 'subscribed',
@@ -85,7 +85,7 @@ class Mailchimp
     /**
      * Unsubscribe an address from a list
      */
-    public function unSubscribeAddress(string $list, string $email)
+    public function unSubscribeAddress(string $list, string $email): bool|array
     {
         return $this->client->put('lists/' . $list . '/members/' . $this->getAddressId($email), [
             'status' => 'unsubscribed',
@@ -93,7 +93,7 @@ class Mailchimp
         ]);
     }
 
-    public function archiveAddress(string $list, string $email)
+    public function archiveAddress(string $list, string $email): bool|array
     {
         return $this->client->delete('lists/' . $list . '/members/' . $this->getAddressId($email));
     }
@@ -108,7 +108,7 @@ class Mailchimp
     }
 
 
-    public function createTemplate(string $title, string $html)
+    public function createTemplate(string $title, string $html): bool|array
     {
         return $this->client->post('templates', [
             'name' => $title,
@@ -127,7 +127,7 @@ class Mailchimp
         ]);
     }
 
-    public function scheduleCampaign(string $campaignId, \DateTime $datetime)
+    public function scheduleCampaign(string $campaignId, \DateTime $datetime): bool|array
     {
         return $this->client->post('campaigns/' . $campaignId . '/actions/schedule', [
             'schedule_time' => $datetime->format('c'),

--- a/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
+++ b/sources/AppBundle/TechLetter/MailchimpSynchronizer.php
@@ -23,11 +23,11 @@ class MailchimpSynchronizer
 
     public function synchronize(): void
     {
-        $subscribdedEmailsOnMailchimp = $this->getSubscribedEmailsOnMailchimp();
-        $subscribdedEmailsOnWebsite = $this->getSubscribedEmailsOnWebsite();
+        $subscribedEmailsOnMailchimp = $this->getSubscribedEmailsOnMailchimp();
+        $subscribedEmailsOnWebsite = $this->getSubscribedEmailsOnWebsite();
 
-        $this->unsubscribeAddresses(array_diff($subscribdedEmailsOnMailchimp, $subscribdedEmailsOnWebsite));
-        $this->subscribeAddresses(array_diff($subscribdedEmailsOnWebsite, $subscribdedEmailsOnMailchimp));
+        $this->unsubscribeAddresses(array_diff($subscribedEmailsOnMailchimp, $subscribedEmailsOnWebsite));
+        $this->subscribeAddresses(array_diff($subscribedEmailsOnWebsite, $subscribedEmailsOnMailchimp));
     }
 
     public function setLogger(LoggerInterface $logger): self


### PR DESCRIPTION
Suite aux erreurs en prod lié à la tâche de synchronisation des emails avec Mailchimp : 
>  2025-05-11T23:00:06.236Z (bas) CMDOUT (PHP Warning:  Attempt to read property "email_address" on array in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Mailchimp/Mailchimp.php on line 78)

On corrige le synchronizer Mailchimp + ajout de typehint.