### PR TITLE
Correction du message utilisé comme sous-texte pour le forward vers les antennes

### DIFF
--- a/sources/AppBundle/Event/Form/TalkType.php
+++ b/sources/AppBundle/Event/Form/TalkType.php
@@ -79,7 +79,7 @@ class TalkType extends AbstractType
                 'expanded' => true,
                 'multiple' => false,
                 'label' => 'Autoriser l’AFUP à transmettre ma proposition de conférence à ses antennes locales ?',
-                'help' => 'cfp_propose_workshop',
+                'help' => 'cfp_authorize_forward',
             ]);
     }
 


### PR DESCRIPTION
Actuellement la page du CFP indique le label concernant les ateliers comme texte d'aide pour le forward du profil vers les antennes, cette pr corrige ce point.

Version [en prod actuellement](https://afup.org/event/forumphp2025/cfp/propose):
<img width="922" alt="image" src="https://github.com/user-attachments/assets/9a841c96-3bee-46dc-8bdb-00cd9fe04936" />
