### PR TITLE
Réorg du menu

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -57,23 +57,6 @@ parameters:
                     extra_routes:
                         - admin_members_badges_index
                         - admin_members_badges_new
-                assemblee_generale:
-                    nom: 'Assemblée générale'
-                    niveau: 'ROLE_ADMIN'
-                    url: '/admin/members/general_meeting'
-                    extra_routes:
-                        - admin_members_general_meeting
-                        - admin_members_general_meeting_prepare
-                        - admin_members_general_meeting_edit
-                        - admin_members_general_meeting_reports
-                assemblee_generale_votes:
-                    nom: 'Assemblée générale - votes'
-                    niveau: 'ROLE_ADMIN'
-                    url: '/admin/members/general_meeting_vote'
-                    extra_routes:
-                        - admin_members_general_vote_list
-                        - admin_members_general_question_add
-                        - admin_members_general_question_edit
         veille:
             nom: "Veille"
             niveau: "ROLE_VEILLE"
@@ -117,23 +100,13 @@ parameters:
                 site_articles:
                     nom: 'Articles'
                     niveau: 'ROLE_SITE'
-        antenne:
-            nom: 'Antennes AFUP'
-            niveau: 'ROLE_ANTENNE'
-            elements:
-                rendez_vous:
-                    nom: 'Rendez-vous'
-                    niveau: 'ROLE_ANTENNE'
-                antenne:
-                    nom: 'Liste des antennes'
-                    niveau: 'ROLE_ANTENNE'
         forum:
             nom: 'Évènements'
             niveau: 'ROLE_FORUM'
             icon: "globe"
             elements:
                 forum_gestion:
-                    nom: 'Gestion évènements'
+                    nom: 'Liste'
                     niveau: 'ROLE_ADMIN'
                     url: '/admin/event/list'
                     extra_routes:
@@ -251,6 +224,28 @@ parameters:
                 compta_recherche:
                     nom: 'Recherche comptable'
                     niveau: 'ROLE_ADMIN'
+        assemblee_generale:
+            nom: 'Assemblée générale'
+            niveau: 'ROLE_ADMIN'
+            icon: 'comments'
+            elements:
+                assemblee_generale_infos:
+                    nom: 'Informations'
+                    niveau: 'ROLE_ADMIN'
+                    url: '/admin/members/general_meeting'
+                    extra_routes:
+                        - admin_members_general_meeting
+                        - admin_members_general_meeting_prepare
+                        - admin_members_general_meeting_edit
+                        - admin_members_general_meeting_reports
+                assemblee_generale_votes:
+                    nom: 'Votes'
+                    niveau: 'ROLE_ADMIN'
+                    url: '/admin/members/general_meeting_vote'
+                    extra_routes:
+                        - admin_members_general_vote_list
+                        - admin_members_general_question_add
+                        - admin_members_general_question_edit
         planete:
             nom: 'Planète PHP FR'
             niveau: 'ROLE_ADMIN'

--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -10,13 +10,13 @@
                 position: fixed;
                 z-index: 1;
                 background-color: #1b1c1d;
-                width: 240px;
+                width: 210px;
                 height: 100%;
                 -webkit-box-flex: 0;
             }
 
             .article {
-                margin-left: 240px;
+                margin-left: 210px;
                 flex: 1 1 auto;
                 min-width: 0;
             }

--- a/templates/admin/menu.html.twig
+++ b/templates/admin/menu.html.twig
@@ -13,8 +13,9 @@
                         {% if element.niveau is not defined or is_granted(element.niveau) %}
                             <a href="{% if element.url is defined %}{{ element.url }}{% else %}/pages/administration/index.php?page={{ clef2 }}{% endif %}"
                                class="item {% if clef2 == current_element_key %}active{% endif %}"
-                               {% if element.nouvelle_fenetre is defined and element.nouvelle_fenetre == true %}target="_blank"{% endif %}>{{ element.nom }}{% if element.nouvelle_fenetre is defined and element.nouvelle_fenetre == true %}
-                                    <i class="glyphicon glyphicon-new-window"></i>{% endif %}</a>
+                                id="afup-main-menu-item--{{ clef2 }}">
+                                {{ element.nom }}
+                            </a>
                         {% endif %}
 
                     {% endfor %}

--- a/tests/behat/features/Admin/Events/GestionEvenements.feature
+++ b/tests/behat/features/Admin/Events/GestionEvenements.feature
@@ -11,7 +11,7 @@ Feature: Administration - Évènements - Gestions Évènements
   @clearAllSponsorFiles
   Scenario: On crée un nouvel évènement vide
     Given I am logged in as admin and on the Administration
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     When I follow "Ajouter"
     Then I should see "Ajouter un évènement"
@@ -22,7 +22,7 @@ Feature: Administration - Évènements - Gestions Évènements
 
   Scenario: On affiche un évènement
     Given I am logged in as admin and on the Administration
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     And I follow the button of tooltip "Modifier le forum forum"
     Then the "event[title]" field should contain "forum"
@@ -39,7 +39,7 @@ Feature: Administration - Évènements - Gestions Évènements
 
   Scenario: On crée un nouvel évènement
     Given I am logged in as admin and on the Administration
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     When I follow "Ajouter"
 
@@ -81,7 +81,7 @@ Feature: Administration - Évènements - Gestions Évènements
 
   Scenario: Suppression d'un évènement vide
     Given I am logged in as admin and on the Administration
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     When I follow "Ajouter"
     Then I fill in "event[title]" with "SUPP"
@@ -92,7 +92,7 @@ Feature: Administration - Évènements - Gestions Évènements
     And I fill in "event[dateEnd]" with "1970-01-01"
     And I press "Soumettre"
     Then I should see "Évènement ajouté"
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     And I should see "Liste des évènements"
     When I follow the button of tooltip "Supprimer le forum SUPP"
     And I should see "Événement supprimé"

--- a/tests/behat/features/Admin/Events/Inscriptions.feature
+++ b/tests/behat/features/Admin/Events/Inscriptions.feature
@@ -30,7 +30,7 @@ Feature: Administration - Évènements - Inscriptions
   Scenario: Export CSV: Badges
     Given I am logged in as admin and on the Administration
     # Création d'un évènement
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     When I follow "Ajouter"
     Then I fill in "event[title]" with "AFUP export badges"
@@ -50,7 +50,7 @@ Feature: Administration - Évènements - Inscriptions
   Scenario: Export CSV: Inscrits aux 4 derniers évènements
     Given I am logged in as admin and on the Administration
     # Création d'un évènement
-    And I follow "Gestion évènements"
+    And I follow "afup-main-menu-item--forum_gestion"
     Then the ".content h2" element should contain "Liste des évènements"
     When I follow "Ajouter"
     Then I fill in "event[title]" with "AFUP export derniers"

--- a/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeeting.feature
+++ b/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeeting.feature
@@ -13,7 +13,7 @@ Feature: Administration - Partie Assemblée Générale
   @reloadDbWithTestData
   Scenario: Créer une assemblée générale
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale"
+    And I follow "afup-main-menu-item--assemblee_generale_infos"
     Then the ".content h2" element should contain "Assemblée générale"
     When I follow "Préparer une assemblée générale"
     Then I should see "Préparer une assemblée générale"
@@ -27,7 +27,7 @@ Feature: Administration - Partie Assemblée Générale
 
   Scenario: Modifier une assemblée générale
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale"
+    And I follow "afup-main-menu-item--assemblee_generale_infos"
     Then the ".content h2" element should contain "Assemblée générale"
     When I follow "Modifier la description"
     Then I should see "Modifier l'assemblée générale"

--- a/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingQuestions.feature
+++ b/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingQuestions.feature
@@ -8,13 +8,13 @@ Feature: Administration - Partie Assemblée Générale Questions
   @reloadDbWithTestData
   Scenario: Accès à la liste des questions
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     Then the ".content h2" element should contain "Assemblée générale - votes"
     And I should see "Vote Oui Non Abstention Actions"
 
   Scenario: Ajouter une question
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     When I follow "Ajouter"
     Then the ".content h2" element should contain "Assemblée générale - questions"
     And I fill in "general_meeting_question_form[label]" with "Une super question"
@@ -23,7 +23,7 @@ Feature: Administration - Partie Assemblée Générale Questions
 
   Scenario: Modifier une question
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     When I follow "question-1-edit"
     Then the ".content h2" element should contain "Modifier la question"
     And I fill in "general_meeting_question_form[label]" with "Une super question modifié"
@@ -33,7 +33,7 @@ Feature: Administration - Partie Assemblée Générale Questions
 
   Scenario: Supprimer une question
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     When I follow "question-1-delete"
     Then the ".content h2" element should contain "Assemblée générale - votes"
     Then I should see "La question a été supprimée"

--- a/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingReports.feature
+++ b/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingReports.feature
@@ -8,7 +8,7 @@ Feature: Administration - Partie Assemblée Générale CR
   @reloadDbWithTestData
   Scenario: Accède à la liste des CR
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale"
+    And I follow "afup-main-menu-item--assemblee_generale_infos"
     Then the ".content h2" element should contain "Assemblée générale"
     When I follow "Liste des comptes rendus"
 
@@ -25,5 +25,3 @@ Feature: Administration - Partie Assemblée Générale CR
     # Suppression
     And I follow the button of tooltip "Supprimer le CR test_file1"
     Then the ".content .message" element should contain "Le compte rendu a correctement été supprimé."
-
-

--- a/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingVotes.feature
+++ b/tests/behat/features/Admin/Members/GeneralMeeting/GeneralMeetingVotes.feature
@@ -3,13 +3,13 @@ Feature: Administration - Partie Assemblée Générale Votes
   @reloadDbWithTestData
   Scenario: Accès à la liste des votes
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     Then the ".content h2" element should contain "Assemblée générale - votes"
     And I should see "Vote Oui Non Abstention Actions"
 
   Scenario: Ouvrir et fermer un vote
     Given I am logged in as admin and on the Administration
-    And I follow "Assemblée générale - votes"
+    And I follow "afup-main-menu-item--assemblee_generale_votes"
     When I follow "question-1-open"
     Then the ".content h2" element should contain "Assemblée générale - votes"
     And I should see "Le vote a été ouvert"


### PR DESCRIPTION
Petite réorg du menu pour en réduire encore la largeur (ça aide sur le laptop d'Amélie).

- Les menus AG ne sont utilisés qu'une fois par an
- La partie "Antennes AFUP" pointe sur d'anciennes pages inexistantes
- Aucune page n'utilise l'option `nouvelle_fenetre`
- Le menu "Gestion évènements" peut également être renommé en "Liste" grâce à l'ajout d'un id sur chaque menu (qui peut être ciblé en Behat).

| Avant                                                                                     | Après                                                                                     | 
| ---                                                                                       | ---                                                                                       | 
| ![image](https://github.com/user-attachments/assets/e1a77864-e53e-4f10-9fe6-beebdaa12144) | ![image](https://github.com/user-attachments/assets/c6ab4ad0-3b88-4bc7-88d9-ae50ac8fca6b) | 
