### PR TITLE
Mise à jour du hash du commit à ignorer suite au merge

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # Passage du linter à PER-CS2.0
-c384b8ec71b75b98eb14f015a8ebd93ad5f4d9af
+1fb5dbe9c851d10103a7c671811283b13bd9d4af


### PR DESCRIPTION
Suite au merge de la PR #1796 le hash du commit a changé malgré le fait d'avoir rebase la branche sur master au moment du merge 🤷