### PR TITLE
Correction de l'emplacement du controller des votes

### DIFF
--- a/app/config/routing/event.yml
+++ b/app/config/routing/event.yml
@@ -14,17 +14,17 @@ event:
 
 vote_index:
   path: /{eventSlug}/vote
-  defaults: { _controller: AppBundle\Controller\Admin\VoteController::index, all: false, page: 1 }
+  defaults: { _controller: AppBundle\Controller\Event\VoteController::index, all: false, page: 1 }
 
 vote_index_paginated:
   path: /{eventSlug}/vote/{page}
-  defaults: { _controller: AppBundle\Controller\Admin\VoteController::index, all: false }
+  defaults: { _controller: AppBundle\Controller\Event\VoteController::index, all: false }
   requirements:
     page: '\d+'
 
 vote_all:
   path: /{eventSlug}/vote-all
-  defaults: { _controller: AppBundle\Controller\Admin\VoteController::index, all: true, page: 1 }
+  defaults: { _controller: AppBundle\Controller\Event\VoteController::index, all: true, page: 1 }
 
 speaker-suggestion:
   path: /{eventSlug}/speaker-suggestion
@@ -32,7 +32,7 @@ speaker-suggestion:
 
 vote_all_paginated:
   path: /{eventSlug}/vote-all/{page}
-  defaults: { _controller: AppBundle\Controller\Admin\VoteController::index, all: true }
+  defaults: { _controller: AppBundle\Controller\Event\VoteController::index, all: true }
   requirements:
     page: '\d+'
 

--- a/sources/AppBundle/Controller/Event/VoteController.php
+++ b/sources/AppBundle/Controller/Event/VoteController.php
@@ -2,10 +2,9 @@
 
 declare(strict_types=1);
 
-namespace AppBundle\Controller\Admin;
+namespace AppBundle\Controller\Event;
 
 use AppBundle\Association\Model\User;
-use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Event\Form\VoteType;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Repository\VoteRepository;


### PR DESCRIPTION
Il avait été déplacé par erreur dans le namespace de l'admin.

Les votes sur le CFP en cours sont bloqués à cause de ça.