### PR TITLE
utilisation de la variable d'environnement AFUP_GLOBAL_MENU_EVENT_LABEL

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -74,3 +74,5 @@ MAILER_BCC=""
 QR_CODE_SALT=""
 # https://symfony.com/doc/current/reference/configuration/framework.html#ide
 IDE_USED="phpstorm"
+
+AFUP_GLOBAL_MENU_EVENT_LABEL="Forum PHP"

--- a/app/config/config.php
+++ b/app/config/config.php
@@ -24,6 +24,8 @@ foreach ($lines as $line) {
     $value = trim($value);
     if (is_numeric($value)) {
         $value = (int) $value;
+    } else {
+        $value = trim($value, '"');
     }
 
     $container->setParameter($name, $value);

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -349,6 +349,7 @@ twig:
     strict_variables: "%kernel.debug%"
     globals:
       photo_storage: '@AppBundle\CFP\PhotoStorage'
+      global_menu_event_label: '%afup_global_menu_event_label%'
     form_themes: ['form_theme.html.twig']
     exception_controller: null
     default_path: "%kernel.project_dir%/../templates"

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -31,7 +31,7 @@
         <a class="evitement" href="#contenu">Aller au contenu</a>
         <div id="afup-global-menu">
             <a href="https://afup.org" class="lien-entete lien-entete__active" tabindex="-1">AFUP</a>
-            <a href="https://event.afup.org" class="lien-entete" tabindex="-1">Forum PHP 2025</a>
+            <a href="https://event.afup.org" class="lien-entete" tabindex="-1">{{ global_menu_event_label }}</a>
             <a href="https://barometre.afup.org" class="lien-entete" tabindex="-1">Baromètre</a>
             <a href="https://www.planete-php.fr" class="lien-entete" tabindex="-1">Planète PHP</a>
             <a href="https://pufa.afup.org" class="lien-entete" tabindex="-1">PUFA</a>


### PR DESCRIPTION
Cela permet d'éviter de hardcoder cette valeur et utiliser la valeur déjà présente dans l'addon de config sur clever cloud et de centraliser la configuration.