### PR TITLE
Correction de la callback paybox

### DIFF
--- a/sources/AppBundle/Controller/Website/MemberShipController.php
+++ b/sources/AppBundle/Controller/Website/MemberShipController.php
@@ -357,7 +357,7 @@ class MemberShipController extends AbstractController
             }
 
             $cotisations->validerReglementEnLigne($payboxResponse->getCmd(), round($payboxResponse->getTotal() / 100, 2), $payboxResponse->getAuthorizationId(), $payboxResponse->getTransactionId());
-            $cotisations->notifierReglementEnLigneAuTresorier($payboxResponse->getCmd(), (string) round($payboxResponse->getTotal() / 100, 2), $payboxResponse->getAuthorizationId(), $payboxResponse->getTransactionId(), $userRepository);
+            $cotisations->notifierReglementEnLigneAuTresorier($payboxResponse->getCmd(), round($payboxResponse->getTotal() / 100, 2), $payboxResponse->getAuthorizationId(), $payboxResponse->getTransactionId(), $userRepository);
             $logs::log("Ajout de la cotisation " . $payboxResponse->getCmd() . " via Paybox.");
         }
         return new Response();


### PR DESCRIPTION
Il y a parfois des erreurs au retour de la callback de paybox.

On gère maintenant comme il faut les 2 cas : 
- Facture
- Cotisation

Et pour ces chaque cas : 
- personne physique
- personne morale

Au pire (du pire), on envoi un `N.C.` quand on n'arrive pas à récupérer les infos (nom, prénom, email) pour ne pas générer une erreur 500 pour le trésorier.