### PR TITLE
Ajout du model du template generic des repositories

### DIFF
--- a/sources/AppBundle/Association/Model/Repository/CompanyMemberInvitationRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/CompanyMemberInvitationRepository.php
@@ -13,6 +13,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<CompanyMemberInvitation>
+ */
 class CompanyMemberInvitationRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingQuestionRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingQuestionRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<GeneralMeetingQuestion>
+ */
 class GeneralMeetingQuestionRepository extends Repository implements MetadataInitializer
 {
     public function loadNextOpenedQuestion(\DateTimeInterface $generalMeetingDate)

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingResponseRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingResponseRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<GeneralMeetingResponse>
+ */
 class GeneralMeetingResponseRepository extends Repository implements MetadataInitializer
 {
     public function getByUser(User $user)

--- a/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/GeneralMeetingVoteRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<GeneralMeetingVote>
+ */
 class GeneralMeetingVoteRepository extends Repository implements MetadataInitializer
 {
     public function loadByQuestionIdAndUserId($questionId, $userId)

--- a/sources/AppBundle/Association/Model/Repository/SubscriptionReminderLogRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/SubscriptionReminderLogRepository.php
@@ -10,6 +10,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<SubscriptionReminderLog>
+ */
 class SubscriptionReminderLogRepository extends Repository implements MetadataInitializer
 {
     public function getPaginatedLogs($page = 1, $limit = 50)

--- a/sources/AppBundle/Association/Model/Repository/SubscriptionRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/SubscriptionRepository.php
@@ -10,6 +10,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<User>
+ */
 class SubscriptionRepository extends Repository implements MetadataInitializer
 {
     public function getStats(\DateInterval $interval): void

--- a/sources/AppBundle/Association/Model/Repository/TechletterSubscriptionsRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/TechletterSubscriptionsRepository.php
@@ -13,6 +13,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TechletterSubscription>
+ */
 class TechletterSubscriptionsRepository extends Repository implements MetadataInitializer
 {
     public function subscribe(User $user = null): void

--- a/sources/AppBundle/Association/Model/Repository/TechletterUnsubscriptionsRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/TechletterUnsubscriptionsRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TechletterUnsubscription>
+ */
 class TechletterUnsubscriptionsRepository extends Repository implements MetadataInitializer
 {
     public function createFromWebhookData(array $data): TechletterUnsubscription

--- a/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
+++ b/sources/AppBundle/Controller/Admin/TechLetter/TechLetterGenerateController.php
@@ -107,9 +107,6 @@ class TechLetterGenerateController extends AbstractController
 
     public function generate($techletterId, Request $request)
     {
-        /**
-         * @var Techletter\Sending $sending
-         */
         $sending = $this->sendingRepository->get($techletterId);
         if ($sending === null) {
             throw $this->createNotFoundException('Could not find this techletter');
@@ -217,9 +214,6 @@ class TechLetterGenerateController extends AbstractController
     public function preview(Request $request): Response
     {
         $sendingId = $request->request->getInt('techletterId');
-        /**
-         * @var Techletter\Sending $sending
-         */
         $sending = $this->sendingRepository->get($sendingId);
 
         if ($sending === null) {
@@ -246,9 +240,6 @@ class TechLetterGenerateController extends AbstractController
     public function sendTest(Request $request): RedirectResponse
     {
         $sendingId = $request->query->getInt('techletterId');
-        /**
-         * @var Techletter\Sending $sending
-         */
         $sending = $this->sendingRepository->get($sendingId);
 
         if ($sending === null) {

--- a/sources/AppBundle/Event/Model/Repository/BadgeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/BadgeRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Badge>
+ */
 class BadgeRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/EventCouponRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventCouponRepository.php
@@ -12,6 +12,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<EventCoupon>
+ */
 class EventCouponRepository extends Repository implements MetadataInitializer
 {
     public static function initMetadata(SerializerFactoryInterface $serializerFactory, array $options = [])

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -19,6 +19,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Event>
+ */
 class EventRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/GithubUserRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/GithubUserRepository.php
@@ -16,6 +16,9 @@ use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
+/**
+ * @extends Repository<GithubUser>
+ */
 class GithubUserRepository extends Repository implements MetadataInitializer, UserProviderInterface
 {
     public static function initMetadata(SerializerFactoryInterface $serializerFactory, array $options = []): Metadata

--- a/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/InvoiceRepository.php
@@ -16,6 +16,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Invoice>
+ */
 class InvoiceRepository extends Repository implements MetadataInitializer
 {
     public function saveWithTickets(Invoice $invoice): void

--- a/sources/AppBundle/Event/Model/Repository/RoomRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/RoomRepository.php
@@ -12,6 +12,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Room>
+ */
 class RoomRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/SpeakerSuggestionRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerSuggestionRepository.php
@@ -10,6 +10,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<SpeakerSuggestion>
+ */
 class SpeakerSuggestionRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/SponsorScanRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SponsorScanRepository.php
@@ -12,6 +12,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<SponsorScan>
+ */
 class SponsorScanRepository extends Repository implements MetadataInitializer
 {
     public function getBySponsorTicket(SponsorTicket $sponsorTicket)

--- a/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SponsorTicketRepository.php
@@ -13,6 +13,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<SponsorTicket>
+ */
 class SponsorTicketRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/TalkInvitationRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkInvitationRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TalkInvitation>
+ */
 class TalkInvitationRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -21,6 +21,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Talk>
+ */
 class TalkRepository extends Repository implements MetadataInitializer
 {
     public function getNumberOfTalksByEvent(Event $event, \DateTime $since = null)

--- a/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
@@ -15,6 +15,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TalkToSpeaker>
+ */
 class TalkToSpeakersRepository extends Repository implements MetadataInitializer
 {
     public function getNumberOfSpeakers(Event $event, \DateTime $since = null)

--- a/sources/AppBundle/Event/Model/Repository/TicketEventTypeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketEventTypeRepository.php
@@ -14,6 +14,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TicketEventType>
+ */
 class TicketEventTypeRepository extends Repository implements MetadataInitializer
 {
     public const REMOVE_PAST_TICKETS = 1;

--- a/sources/AppBundle/Event/Model/Repository/TicketSpecialPriceRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketSpecialPriceRepository.php
@@ -15,6 +15,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TicketSpecialPrice>
+ */
 class TicketSpecialPriceRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/TicketTypeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TicketTypeRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<TicketType>
+ */
 class TicketTypeRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Event/Model/Repository/UserBadgeRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/UserBadgeRepository.php
@@ -12,6 +12,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<UserBadge>
+ */
 class UserBadgeRepository extends Repository implements MetadataInitializer
 {
     public function findByUserId($userId)

--- a/sources/AppBundle/Event/Model/Repository/VoteRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/VoteRepository.php
@@ -14,6 +14,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Vote>
+ */
 class VoteRepository extends Repository implements MetadataInitializer
 {
     public function getNumberOfVotesByEvent(Event $event)

--- a/sources/AppBundle/Security/ActionThrottling/LogRepository.php
+++ b/sources/AppBundle/Security/ActionThrottling/LogRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Log>
+ */
 class LogRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
+++ b/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
@@ -13,6 +13,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Article>
+ */
 class ArticleRepository extends Repository implements MetadataInitializer
 {
     /**

--- a/sources/AppBundle/Site/Model/Repository/RubriqueRepository.php
+++ b/sources/AppBundle/Site/Model/Repository/RubriqueRepository.php
@@ -11,6 +11,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Rubrique>
+ */
 class RubriqueRepository extends Repository implements MetadataInitializer
 {
     public function getAllRubriques($ordre = 'nom', $direction = 'asc', string $filtre = '%')

--- a/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
+++ b/sources/AppBundle/TechLetter/Model/Repository/SendingRepository.php
@@ -12,6 +12,9 @@ use CCMBenchmark\Ting\Repository\MetadataInitializer;
 use CCMBenchmark\Ting\Repository\Repository;
 use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
 
+/**
+ * @extends Repository<Sending>
+ */
 class SendingRepository extends Repository implements MetadataInitializer
 {
     public function getAllOrderedByDateDesc()


### PR DESCRIPTION
La classe `Repository` est generic et le type concret n'est pas spécifié dans la majorité des repositories.

L'ajouter va permettre de simplifier et de mieux typer pas mal de code les utilisant.