### PR TITLE
Utilisation d'un fork de l'action de cache Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: |
             docker-${{ runner.os }}-${{ hashFiles(
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
+        uses: AndreKurait/docker-cache@0.6.0
         with:
           key: |
             docker-${{ runner.os }}-${{ hashFiles(


### PR DESCRIPTION
Il y a une PR ouverte depuis un moment sans réponse donc en attendant, on passe sur un fork à jour.

https://github.com/ScribeMD/docker-cache/pull/835

see #1834