### PR TITLE
Mise à jour de presta/sitemap-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "phpmailer/phpmailer": "^6.9",
     "phpoffice/phpspreadsheet": "^1.6",
     "pimple/pimple": "^3.5",
-    "presta/sitemap-bundle": "3.3.0",
+    "presta/sitemap-bundle": "4.*",
     "psr/clock": "^1.0",
     "robmorgan/phinx": "^0.14.0",
     "sabre/vobject": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df2a5156b0e703ebc88301d9b2f6f223",
+    "content-hash": "25aae956c5f07968b00d366e8ccd8ad3",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3661,41 +3661,41 @@
         },
         {
             "name": "presta/sitemap-bundle",
-            "version": "v3.3.0",
+            "version": "v4.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/prestaconcept/PrestaSitemapBundle.git",
-                "reference": "ad23fe594ff0fedb4e7be638873a19c39eb6ed7b"
+                "reference": "296be93025405ae98fc5c803bdc8b2dc8638a85a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/prestaconcept/PrestaSitemapBundle/zipball/ad23fe594ff0fedb4e7be638873a19c39eb6ed7b",
-                "reference": "ad23fe594ff0fedb4e7be638873a19c39eb6ed7b",
+                "url": "https://api.github.com/repos/prestaconcept/PrestaSitemapBundle/zipball/296be93025405ae98fc5c803bdc8b2dc8638a85a",
+                "reference": "296be93025405ae98fc5c803bdc8b2dc8638a85a",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
-                "php": ">=7.1.3",
-                "symfony/console": "^4.4|^5.0|^6.0",
-                "symfony/framework-bundle": "^4.4|^5.0|^6.0"
+                "php": ">=7.2.5|>=8.0.2",
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/framework-bundle": "^5.4|^6.0|^7.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.0",
-                "phpstan/phpstan": "^0.12.82",
+                "phpstan/phpstan": "^1.4",
                 "phpunit/phpunit": "^7.5|^8.0",
-                "sensio/framework-extra-bundle": "^5.5|^6.1",
                 "squizlabs/php_codesniffer": "^3.5",
-                "symfony/browser-kit": "^4.4|^5.0|^6.0",
-                "symfony/messenger": "^4.4|^5.0|^6.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0|^6.0",
-                "symfony/yaml": "^4.4|^5.0|^6.0"
+                "symfony/browser-kit": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
                     "1.x": "1.x-dev",
                     "2.x": "2.x-dev",
-                    "3.x": "3.x-dev"
+                    "3.x": "3.x-dev",
+                    "4.x": "4.x-dev"
                 }
             },
             "autoload": {
@@ -3723,9 +3723,9 @@
             ],
             "support": {
                 "issues": "https://github.com/prestaconcept/PrestaSitemapBundle/issues",
-                "source": "https://github.com/prestaconcept/PrestaSitemapBundle/tree/v3.3.0"
+                "source": "https://github.com/prestaconcept/PrestaSitemapBundle/tree/v4.1.3"
             },
-            "time": "2022-01-24T07:37:28+00:00"
+            "time": "2025-01-10T10:30:15+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
On met à jour `presta/sitemap-bundle` en version 4 pour la préparation de la montée de version en Symfony 7.3