### PR TITLE
Correction gestion de la mise en avant tickets soutien

### DIFF
--- a/htdocs/css/tickets-2025.css
+++ b/htdocs/css/tickets-2025.css
@@ -378,13 +378,16 @@ button {
   border: 2px solid var(--medium-gray);
   border-radius: var(--border-radius);
   margin-bottom: 1.25rem;
-  padding: 1.25rem;
   transition: var(--transition);
+  background-color: white;
+  box-shadow: var(--shadow);
+}
+
+.ticket-type-item-content {
   position: relative;
   display: flex;
   align-items: flex-start;
-  background-color: white;
-  box-shadow: var(--shadow);
+  padding: 1.25rem;
 }
 
 .ticket-type-item:hover {
@@ -474,7 +477,6 @@ button {
 }
 
 .ticket-type-promo {
-  margin: -1.25rem -1.25rem 1rem -1.25rem;
   padding: 0.75rem 1.25rem;
   background-color: rgba(80, 160, 221, 0.1);
   color: var(--primary-dark);
@@ -974,10 +976,6 @@ button {
   
   .form-section {
     padding: 1.25rem 1rem;
-  }
-  
-  .ticket-type-item {
-    padding: 1rem;
   }
   
   .ticket-type-content {

--- a/templates/event/ticket/ticket.html.twig
+++ b/templates/event/ticket/ticket.html.twig
@@ -153,47 +153,51 @@
                             <ul class="ticket-type-list">
                                 {% set endDate = null %}
                                 {% for type in ticket.ticketEventType %}
+                                    {% if endDate == null and (type.vars.attr['disabled'] ?? false) == false %}
+                                        {% set endDate=type.vars.attr['data-date-end-raw'] %}
+                                    {% endif %}
                                     <li class="ticket-type-item {% if endDate != type.vars.attr['data-date-end-raw'] and endDate != null %}ticket-type-item-emphasized{% endif %}">
                                         {% if endDate != type.vars.attr['data-date-end-raw'] and endDate != null and endDate > currentDate %}
                                             <div class="ticket-type-promo">Vous souhaitez soutenir l'AFUP ? Vous pouvez prendre ces billets dès aujourd'hui.</div>
                                         {% endif %}
-                                        {% set endDate=type.vars.attr['data-date-end-raw'] %}
-                                        {{ form_widget(type) }}
-                                        <div class="ticket-type-content">
-                                            <div class="ticket-type-title">{{ form_label(type) }}</div>
-                                            <div class="ticket-type-price">
-                                                {% if type.vars.attr['data-price'] == 0 %}
-                                                    OFFERT
-                                                {% else %}
-                                                    {{ type.vars.attr['data-price'] }}€
-                                                    {% if isSubjectedToVat %}
-                                                        {% if hasPricesDefinedWithVat %}
-                                                            TTC
-                                                        {% else %}
-                                                            HT
+                                        <div class="ticket-type-item-content">
+                                            {{ form_widget(type) }}
+                                            <div class="ticket-type-content">
+                                                <div class="ticket-type-title">{{ form_label(type) }}</div>
+                                                <div class="ticket-type-price">
+                                                    {% if type.vars.attr['data-price'] == 0 %}
+                                                        OFFERT
+                                                    {% else %}
+                                                        {{ type.vars.attr['data-price'] }}€
+                                                        {% if isSubjectedToVat %}
+                                                            {% if hasPricesDefinedWithVat %}
+                                                                TTC
+                                                            {% else %}
+                                                                HT
+                                                            {% endif %}
                                                         {% endif %}
                                                     {% endif %}
-                                                {% endif %}
-                                            </div>
-                                            <div class="ticket-type-details">
+                                                </div>
+                                                <div class="ticket-type-details">
                                                 <span class="ticket-type-dateEnd">
                                                     Disponible jusqu'au {{ type.vars.attr['data-date-end'] }}
                                                     {% if type.vars.attr['data-max-tickets'] > 0 %}
                                                         (ou jusqu'à écoulement des {{ type.vars.attr['data-max-tickets'] }} billets à ce tarif).
                                                     {% endif %}
                                                 </span>
-                                                {% if type.vars.attr['data-members-only'] %} - <span class="ticket-type-members">Réservé aux membres AFUP</span>{% endif %}
-                                                {% if type.vars.attr['data-stock'] <= 0 %}
-                                                    <div class="ticket-type-stock sold-out">Plus aucun billet disponible</div>
-                                                {% elseif type.vars.attr['data-stock'] < 10 %}
-                                                    <div class="ticket-type-stock ticket-type-stock-close-to-sold-out">Peu de billets disponibles</div>
+                                                    {% if type.vars.attr['data-members-only'] %} - <span class="ticket-type-members">Réservé aux membres AFUP</span>{% endif %}
+                                                    {% if type.vars.attr['data-stock'] <= 0 %}
+                                                        <div class="ticket-type-stock sold-out">Plus aucun billet disponible</div>
+                                                    {% elseif type.vars.attr['data-stock'] < 10 %}
+                                                        <div class="ticket-type-stock ticket-type-stock-close-to-sold-out">Peu de billets disponibles</div>
+                                                    {% endif %}
+                                                </div>
+                                                {% if type.vars.attr['data-description'] %}
+                                                    <div class="ticket-type-description">
+                                                        {{ type.vars.attr['data-description']|markdown }}
+                                                    </div>
                                                 {% endif %}
                                             </div>
-                                            {% if type.vars.attr['data-description'] %}
-                                                <div class="ticket-type-description">
-                                                    {{ type.vars.attr['data-description']|markdown }}
-                                                </div>
-                                            {% endif %}
                                         </div>
                                     </li>
                                 {% endfor %}


### PR DESCRIPTION
Hello,

2 petits bugs repérés lors de la mise en prod:
- La gestion de la mise en avant des tickets ne tenait pas compte des tickets non commandable (i.e: plus de stock en late bird ou réservé aux membres pour un user non connecté)
- L'affichage de cette mise en avant était incorrect

**Rendu actuel**
![afup org_event_forumphp2025_tickets](https://github.com/user-attachments/assets/91792c23-b4d7-48d2-b9e4-6dc67deb4e02)

**Après PR:**
![127 0 0 1_9205_event_forum_tickets](https://github.com/user-attachments/assets/186d4e7f-e54c-4596-89e1-6565cd0b9051)
