### PR TITLE
Gestion des hosting et travel sponsor sur les infos speaker

### DIFF
--- a/db/migrations/20250630170520_add_sponsors_to_speakers.php
+++ b/db/migrations/20250630170520_add_sponsors_to_speakers.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddSponsorsToSpeakers extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_conferenciers')
+            ->addColumn('has_hosting_sponsor', 'boolean', [
+                'default' => false,
+                'null' => false,
+            ])
+            ->addColumn('travel_refund_needed', 'boolean', [
+                'default' => true,
+                'null' => false,
+            ])
+            ->addColumn('travel_refund_sponsored', 'boolean', [
+                'default' => false,
+                'null' => false,
+            ])
+            ->update();
+    }
+}

--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -60,7 +60,10 @@ class SpeakerRepository extends Repository implements MetadataInitializer
         speaker.referent_person_email,
         speaker.special_diet_description,
         speaker.hotel_nights,
-        speaker.phone_number
+        speaker.phone_number,
+        speaker.has_hosting_sponsor,
+        speaker.travel_refund_needed,
+        speaker.travel_refund_sponsored
         FROM afup_conferenciers speaker
         INNER JOIN afup_conferenciers_sessions cs ON cs.conferencier_id = speaker.conferencier_id
         INNER JOIN afup_sessions talk ON talk.session_id = cs.session_id
@@ -293,6 +296,24 @@ SQL
                 'columnName' => 'referent_person_email',
                 'fieldName' => 'referentPersonEmail',
                 'type' => 'string',
+            ])
+            ->addField([
+                'columnName' => 'has_hosting_sponsor',
+                'fieldName' => 'hasHostingSponsor',
+                'type' => 'bool',
+                'serializer' => Boolean::class,
+            ])
+            ->addField([
+                'columnName' => 'travel_refund_needed',
+                'fieldName' => 'travelRefundNeeded',
+                'type' => 'bool',
+                'serializer' => Boolean::class,
+            ])
+            ->addField([
+                'columnName' => 'travel_refund_sponsored',
+                'fieldName' => 'travelRefundSponsored',
+                'type' => 'bool',
+                'serializer' => Boolean::class,
             ])
         ;
 

--- a/sources/AppBundle/Event/Model/Speaker.php
+++ b/sources/AppBundle/Event/Model/Speaker.php
@@ -135,6 +135,11 @@ class Speaker implements NotifyPropertyInterface
      */
     private $referentPersonEmail;
 
+    private bool $hasHostingSponsor = false;
+
+    private bool $travelRefundNeeded = true;
+    private bool $travelRefundSponsored = false;
+
     /**
      * @return int
      */
@@ -637,6 +642,42 @@ class Speaker implements NotifyPropertyInterface
         $this->propertyChanged('hotelNights', $this->hotelNights, $hotelNights);
         $this->hotelNights = $hotelNights;
 
+        return $this;
+    }
+
+    public function hasHostingSponsor(): bool
+    {
+        return $this->hasHostingSponsor;
+    }
+
+    public function setHasHostingSponsor(bool $hasHostingSponsor): self
+    {
+        $this->propertyChanged('hasHostingSponsor', $this->hasHostingSponsor, $hasHostingSponsor);
+        $this->hasHostingSponsor = $hasHostingSponsor;
+        return $this;
+    }
+
+    public function isTravelRefundNeeded(): bool
+    {
+        return $this->travelRefundNeeded;
+    }
+
+    public function setTravelRefundNeeded(bool $travelRefundNeeded): self
+    {
+        $this->propertyChanged('travelRefundNeeded', $this->travelRefundNeeded, $travelRefundNeeded);
+        $this->travelRefundNeeded = $travelRefundNeeded;
+        return $this;
+    }
+
+    public function isTravelRefundSponsored(): bool
+    {
+        return $this->travelRefundSponsored;
+    }
+
+    public function setTravelRefundSponsored(bool $travelRefundSponsored): self
+    {
+        $this->propertyChanged('travelRefundSponsored', $this->travelRefundSponsored, $travelRefundSponsored);
+        $this->travelRefundSponsored = $travelRefundSponsored;
         return $this;
     }
 

--- a/sources/AppBundle/SpeakerInfos/Form/HotelReservationType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/HotelReservationType.php
@@ -19,6 +19,7 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class HotelReservationType extends AbstractType
 {
     public const NIGHT_NONE = 'none';
+    public const NIGHT_TRAVEL_SPONSOR = 'hosting_sponsor';
 
     public function __construct(private readonly TranslatorInterface $translator) {}
 
@@ -35,7 +36,6 @@ class HotelReservationType extends AbstractType
         $start = \DateTimeImmutable::createFromMutable($event->getDateStart());
         $end = \DateTimeImmutable::createFromMutable($event->getDateEnd());
 
-
         $nights = [
             Speaker::NIGHT_BEFORE => ['from' => $start->modify('-1 day'), 'to' => $start],
             Speaker::NIGHT_BETWEEN => ['from' => $start, 'to' => $end],
@@ -48,6 +48,7 @@ class HotelReservationType extends AbstractType
         }
 
         $choices['Aucune nuité'] = self::NIGHT_NONE;
+        $choices['speaker_infos.sponsor.hosting.checkbox_label'] = self::NIGHT_TRAVEL_SPONSOR;
 
         $builder
             ->add(
@@ -61,8 +62,15 @@ class HotelReservationType extends AbstractType
                     'constraints' => [
                         new Choice(['choices' => array_values($choices), 'multiple' => true, 'min' => 1, 'strict' => true]),
                         new Callback(['callback' => function ($values, ExecutionContextInterface $context): void {
+                            if (count($values) === 2
+                                && in_array(self::NIGHT_NONE, $values)
+                                && in_array(self::NIGHT_TRAVEL_SPONSOR, $values)
+                            ) {
+                                return;
+                            }
+
                             if (in_array(self::NIGHT_NONE, $values)
-                            && 1 !== count($values)) {
+                                && 1 !== count($values)) {
                                 $context
                                     ->buildViolation('Impossible de choisir à la fois aucune nuité et une nuité')
                                     ->addViolation()

--- a/sources/AppBundle/SpeakerInfos/Form/TravelSponsorType.php
+++ b/sources/AppBundle/SpeakerInfos/Form/TravelSponsorType.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SpeakerInfos\Form;
+
+use AppBundle\Event\Model\Speaker;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class TravelSponsorType extends AbstractType
+{
+    public const OPTION_SPONSORED = 'sponsored';
+    public const OPTION_NOT_NEEDED = 'not_needed';
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'choices',
+                ChoiceType::class,
+                [
+                    'expanded' => true,
+                    'multiple' => true,
+                    'choices' => [
+                        'speaker_infos.travel_expenses.checkbox_label.not_needed' => self::OPTION_NOT_NEEDED,
+                        'speaker_infos.travel_expenses.checkbox_label.sponsored' => self::OPTION_SPONSORED,
+                    ],
+                ],
+            )
+            ->add('submit', SubmitType::class, ['label' => 'Enregistrer']);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+        ]);
+    }
+
+    /**
+     * @return array{choices: array<self::OPTION_*>}|null
+     */
+    public static function buildDefaultFromSpeaker(Speaker $speaker): ?array
+    {
+        $values = [];
+
+        if (!$speaker->isTravelRefundNeeded()) {
+            $values[] = self::OPTION_NOT_NEEDED;
+        }
+
+        if ($speaker->isTravelRefundSponsored()) {
+            $values[] = self::OPTION_SPONSORED;
+        }
+
+        if (count($values) === 0) {
+            return null;
+        }
+
+        return [
+            'choices' => $values,
+        ];
+    }
+}

--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -66,6 +66,12 @@
                 display: block;
                 text-align: right;
             }
+
+            .vertical-labels {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+            }
         </style>
 
     </head>

--- a/templates/admin/event/speakers_management.html.twig
+++ b/templates/admin/event/speakers_management.html.twig
@@ -17,6 +17,7 @@
                 <th data-tf-filter-type="select" class="center aligned">Nuit d'hotel entre les deux jours ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Nuit d'hotel après l'évènement ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Pas de nuit d'hotel ?</th>
+                <th data-tf-filter-type="select" class="center aligned">Sponsors ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Justificatifs envoyés ?</th>
                 <th></th>
             </tr>
@@ -76,7 +77,7 @@
                     {% endif %}
                 </td>
                 <td class="center aligned">
-                    <span {% if speaker.speaker.hasHotelNightBefore is null %}class="ui red label" {% endif %}>
+                    <span class="ui {% if speaker.speaker.hasHotelNightBefore is null %}red{% endif %} label">
                     {% if speaker.speaker.hasHotelNightBefore is null %}
                         N/A
                     {% elseif speaker.speaker.hasHotelNightBefore %}
@@ -118,6 +119,20 @@
                         non
                     {% endif %}
                     </span>
+                </td>
+                <td  class="center aligned">
+                    {% if not speaker.speaker.travelRefundSponsored and not speaker.speaker.hasHostingSponsor %}
+                        <span class="ui label">non</span>
+                    {% else %}
+                        <div class="vertical-labels">
+                            {% if speaker.speaker.travelRefundSponsored %}
+                                <span class="ui label">travel</span>
+                            {% endif %}
+                            {% if speaker.speaker.hasHostingSponsor %}
+                                <span class="ui label">hosting</span>
+                            {% endif %}
+                        </div>
+                    {% endif %}
                 </td>
                 <td  class="center aligned">
                     <span class="ui label">

--- a/templates/event/speaker/page.html.twig
+++ b/templates/event/speaker/page.html.twig
@@ -12,6 +12,7 @@
 
 {% form_theme speakers_diner_form 'bootstrap_3_layout.html.twig' %}
 {% form_theme hotel_reservation_form 'bootstrap_3_layout.html.twig' %}
+{% form_theme travel_sponsor_form 'bootstrap_3_layout.html.twig' %}
 
 {% block content %}
 
@@ -42,6 +43,9 @@
         }
         .speakers-infos-form .submit-container {
             padding: 0 15px 0 0;
+        }
+        .submit-container {
+            margin-top: 15px;
         }
 
         .speakers-infos-form--phone label {
@@ -110,9 +114,9 @@
                     {{ form_widget(speakers_contact_form.phone_number) }}
                     {{ form_errors(speakers_contact_form.phone_number) }}
                 </span>
-                <span>
+                <div class="submit-container">
                     {{ form_widget(speakers_contact_form.submit, {attr: {title: "Enregistrer le contact"}}) }}
-                </span>
+                </div>
             </div>
 
             {{ form_end(speakers_contact_form) }}
@@ -183,15 +187,18 @@
             {% if should_display_hotel_reservation_form %}
                 {{ form_start(hotel_reservation_form, { attr: { class: 'speakers-infos-form'}, action: '#hotel'}) }}
 
-                <div class="container">
+                <div class="container" id="hotel-reservation-choices-form-container">
                     <div class="col-md-6">
                         {{ form_label(hotel_reservation_form.nights) }}
                         {{ form_errors(hotel_reservation_form.nights) }}
                         {{ form_widget(hotel_reservation_form.nights) }}
                     </div>
-                    <div class="col-md-6">
+                    <div class="col-md-6 pt3">
                         <i>{% trans %}Vous disposez de deux nuits d'hôtel maximum. Donnez-nous les dates qui vous conviennent, nous nous chargeons de la réservation ! (les speakers intercontinentaux peuvent bénéficier de plus de nuités, si vous êtes dans ce cas, le pôle conférence vous aura contacté).{% endtrans %}</i>
 
+                        <div class="pt1">
+                            <i>{% trans %}speaker_infos.hosting_sponsor.intro{% endtrans %}</i>
+                        </div>
                     </div>
                 </div>
 
@@ -222,7 +229,25 @@
 
             <h2><a id="expenses" href="#expenses">💶 {% trans %}Nous vous défrayons{% endtrans %}</a></h2>
 
-            <div class="container">
+            {{ form_start(travel_sponsor_form, { attr: { class: 'speakers-infos-form'}, action: '#expenses' }) }}
+                <div class="container">
+                    <div class="col-md-6">
+                        {{ form_errors(travel_sponsor_form.choices) }}
+                        {{ form_widget(travel_sponsor_form.choices) }}
+
+                        <div>
+                            <small>
+                                {% trans %}speaker_infos.sponsor.travel.intro{% endtrans %}
+                            </small>
+                        </div>
+                    </div>
+                    <div class="col-md-6">
+                        {{ form_widget(travel_sponsor_form.submit, {attr: {title: "Enregistrer le travel sponsor"}}) }}
+                    </div>
+                </div>
+            {{ form_end(travel_sponsor_form) }}
+
+            <div class="container mt2" id="travel-expenses-form-container">
                 <p>
                     {% trans %}venue_speaker.expenses.intro{% endtrans %}
                 </p>

--- a/tests/behat/features/EventPages/SpeakerInfos.feature
+++ b/tests/behat/features/EventPages/SpeakerInfos.feature
@@ -29,9 +29,40 @@ Feature: Event > Profil speaker
     When I check "hotel_reservation_nights_0"
     And I press "Enregistrer les nuitées"
     Then I should see "Informations sur votre venue à l'hôtel enregistrées"
-    Then the "hotel_reservation_nights_0" checkbox is checked
+    Then the "hotel_reservation_nights_0" checkbox should be checked
 
     When I attach the file "test_file2.pdf" to "speakers_expenses[files][]"
     And I press "Ajouter des fichiers"
     When I should see "Fichiers ajoutés"
     Then I should see "test_file2.pdf"
+
+  @reloadDbWithTestData
+  Scenario: Saisie du hosting sponsor
+    Given I go to "/event/forum/speaker-infos"
+    When I follow "Connect as agallou"
+
+    When I check "hotel_reservation_nights_4"
+    And I press "Enregistrer les nuitées"
+    Then I should see "Informations sur votre venue à l'hôtel enregistrées"
+    Then the "hotel_reservation_nights_3" checkbox should be checked
+    Then the "hotel_reservation_nights_4" checkbox should be checked
+
+  @reloadDbWithTestData
+  Scenario: Saisie du travel - pas besoin
+    Given I go to "/event/forum/speaker-infos"
+    When I follow "Connect as agallou"
+
+    When I check "travel_sponsor_choices_0"
+    And I press "Enregistrer le travel sponsor"
+    Then I should see "Informations sur vos transports enregistrées "
+    Then the "travel_sponsor_choices_0" checkbox should be checked
+
+  @reloadDbWithTestData
+  Scenario: Saisie du travel - sponsorisé
+    Given I go to "/event/forum/speaker-infos"
+    When I follow "Connect as agallou"
+
+    When I check "travel_sponsor_choices_1"
+    And I press "Enregistrer le travel sponsor"
+    Then I should see "Informations sur vos transports enregistrées "
+    Then the "travel_sponsor_choices_1" checkbox should be checked

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -204,3 +204,8 @@ speaker_from_previous_event: "We filled the form with the profile you used on a 
 sponsor.qr_code_scanner.disclaimer: Please confirm that the participant agrees for you to scan their badge!
 sponsor.qr_code_scanner.valid_code: Code valid! Please wait...
 sponsor.qr_code_scanner.invalid_code: Incorrect QR Code!
+speaker_infos.sponsor.hosting.checkbox_label: "My hosting is sponsored"
+speaker_infos.hosting_sponsor.intro: "If your hosting is sponsored by your company, please check the corresponding box."
+speaker_infos.travel_expenses.checkbox_label.not_needed: "I don't need it"
+speaker_infos.travel_expenses.checkbox_label.sponsored: "My transports costs are sponsored"
+speaker_infos.sponsor.travel.intro: "Check one of these boxes if you don't need to be refunded your transports costs or if they are are sponsored by your company."

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -229,3 +229,8 @@ cfp_propose_workshop: |
 cfp_authorize_forward: |
   Les équipes des antennes AFUP peuvent être intéressées par votre sujet en vue d’un événement local
   (meetup, Super Apéro PHP, soirée d’élection dans l’antenne...) et pourrait aimer vous inviter dans leur ville.
+speaker_infos.sponsor.hosting.checkbox_label: "Mon logement est sponsorisé"
+speaker_infos.hosting_sponsor.intro: "Si votre hébergement est pris en charge par votre entreprise, merci de cocher la case correspondante."
+speaker_infos.travel_expenses.checkbox_label.not_needed: "Je n’en n’ai pas besoin"
+speaker_infos.travel_expenses.checkbox_label.sponsored: "Mon transport est sponsorisé"
+speaker_infos.sponsor.travel.intro: "Cochez une de ces cases si vous n'avez pas besoin de défrayment ou si votre transport est pris en charge par votre entreprise."


### PR DESCRIPTION
Cela permet aux speakers d'indiquer sur leur hébergement et/ou transport est pris en charge par leur entreprise.

Les cases affichent/masquent le reste de leur section en direct mais il faut soumettre chaque formulaire pour l'enregistrer.

## Rendu sur la page speaker
![image](https://github.com/user-attachments/assets/0141a6b2-8e52-4e61-9115-c7b76df64aaa)

## Dans le BO les valeurs sont dans une nouvelle colonne
![image](https://github.com/user-attachments/assets/38ac65ba-8118-45a3-8525-efd6fedbb469)
