### PR TITLE
fix: déclaration d'une valeur par défaut pour l'option "init" #1884

### DIFF
--- a/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
+++ b/sources/AppBundle/Command/UpdateMailchimpMembersCommand.php
@@ -26,9 +26,9 @@ final readonly class UpdateMailchimpMembersCommand
     ) {}
 
     public function __invoke(
-        #[Option(description: 'Add all active members to the list')]
-        bool $init,
         OutputInterface $output,
+        #[Option(description: 'Add all active members to the list')]
+        bool $init = false,
     ): int {
         $mailchimp = $this->mailchimp;
 


### PR DESCRIPTION
En dev l'erreur est plus explicite :
<img width="916" height="273" alt="Screenshot from 2025-07-13 23-16-50" src="https://github.com/user-attachments/assets/ae5cd900-5bb1-4a92-9fb3-3d8cc8288a5a" />

fixes #1884 