### PR TITLE
Ajout d'une règle PHPStan pour les fonctions de debug

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,3 +8,6 @@ parameters:
     stubFiles:
             - tests/stubs/Ting/Repository/Repository.php.stub
             - tests/stubs/Ting/Repository/RepositoryFactory.php.stub
+
+rules:
+    - AppBundle\StaticAnalysis\Rule\NoDebugFunctionsRule

--- a/sources/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRule.php
+++ b/sources/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRule.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\StaticAnalysis\Rule;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * Cette règle PHPStan bloque les oublis de fonctions de debug.
+ *
+ * @implements Rule<FuncCall>
+ */
+final class NoDebugFunctionsRule implements Rule
+{
+    private const FORBIDDEN_FUNCTIONS = ['var_dump', 'dump', 'dd', 'print_r'];
+
+    public function getNodeType(): string
+    {
+        return FuncCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Name) {
+            return [];
+        }
+
+        $functionName = strtolower((string) $node->name);
+
+        if (!in_array($functionName, self::FORBIDDEN_FUNCTIONS, true)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(sprintf('Usage of %s() is forbidden.', $functionName))
+                ->identifier('afup.forbiddenFunctionCall')
+                ->build(),
+        ];
+    }
+}

--- a/tests/stubs/phpstan/debug-functions.php
+++ b/tests/stubs/phpstan/debug-functions.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+var_dump('a');
+
+print_r('b');
+
+dump('c');
+
+dd('d');

--- a/tests/unit/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRuleTest.php
+++ b/tests/unit/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRuleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Tests\StaticAnalysis\Rule;
+
+use AppBundle\StaticAnalysis\Rule\NoDebugFunctionsRule;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+
+final class NoDebugFunctionsRuleTest extends RuleTestCase
+{
+    protected function getRule(): Rule
+    {
+        return new NoDebugFunctionsRule();
+    }
+
+    public function testRule(): void
+    {
+        $this->analyse([__DIR__ . '/../../../../stubs/phpstan/debug-functions.php'], [
+            ['Usage of var_dump() is forbidden.', 5],
+            ['Usage of print_r() is forbidden.', 7],
+            ['Usage of dump() is forbidden.', 9],
+            ['Usage of dd() is forbidden.', 11],
+        ]);
+    }
+}


### PR DESCRIPTION
Cela permet de détecter les oublis dans les PRs.