### PR TITLE
retrait du filtre par date du planning

### DIFF
--- a/sources/Afup/Forum/Forum.php
+++ b/sources/Afup/Forum/Forum.php
@@ -89,10 +89,6 @@ class Forum
     {
         $aWhere = [];
         if (isset($annee)) {
-            $tdebut = mktime(0, 0, 0, 1, 1, (int) $annee);
-            $tfin = mktime(0, 0, 0, 1, 1, (int) ($annee + 1));
-            $aWhere[] = "p.debut >= " . $tdebut;
-            $aWhere[] = "p.fin < " . $tfin;
             $aWhere[] = "s.plannifie = 1";
         }
 


### PR DESCRIPTION
:warning: Je me suis basé sur les données locales après un reset de la base.

Le reset de la base crée un forum à J + 5 mois (donc en 2026), le champs "année" de la table afup_fprum vaut donc 2026.
On se sert ce cette valeur pour pouvoir générer le planning (cf. https://github.com/afup/web/blob/master/htdocs/pages/administration/forum_planning.php#L49) principalement pour filtrer les date de début et fin de la plannification de la conférence

Je pense que c'est ce filtre qui pose problème.

Une autre hypothèse est que la conférence est bien créée mais n'est pas considérée comme plannifiée. Dans ce cas là c'est le filtre sur `$aWhere[] = "s.plannifie = 1";` qui bloque l'affichage du planning.

