### PR TITLE
correction de l'ajout des dates/heure/salle sur une conf au planning

### DIFF
--- a/htdocs/pages/administration/forum_planning.php
+++ b/htdocs/pages/administration/forum_planning.php
@@ -102,7 +102,7 @@ if ($action == 'lister') {
     if ($formulaire->validate()) {
         $valeurs = $formulaire->exportValues();
 
-        if ($id == 0) {
+        if ($id == 0 || 0 === strlen(trim((string) $id))) {
             $planning_id = $forum_appel->ajouterSessionDansPlanning($valeurs['id_forum'],
                 $valeurs['id_session'],
                 mktime((int) $valeurs['debut']['H'], (int) $valeurs['debut']['i'], 0, (int) $valeurs['debut']['M'], (int) $valeurs['debut']['d'], (int) $valeurs['debut']['Y']),


### PR DESCRIPTION
on ne pouvait pas ajouter d'item dans la table car l'id n'était jamais à zéro mais à une chaine vide.

Le fix n'est pas très beau, mais ça devient urgent de pouvoir saisir le planning (et cette page sera probablement refondue prochainement).