### PR TITLE
Suppression des CORS pour openfeedback

### DIFF
--- a/sources/AppBundle/Controller/Event/Event/OpenFeedbackJsonAction.php
+++ b/sources/AppBundle/Controller/Event/Event/OpenFeedbackJsonAction.php
@@ -7,6 +7,7 @@ namespace AppBundle\Controller\Event\Event;
 use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Openfeedback\OpenfeedbackJsonGenerator;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
 
 final readonly class OpenFeedbackJsonAction
 {
@@ -15,13 +16,15 @@ final readonly class OpenFeedbackJsonAction
         private OpenfeedbackJsonGenerator $openfeedbackJsonGenerator,
     ) {}
 
-    public function __invoke(string $eventSlug): JsonResponse
+    public function __invoke(string $eventSlug, Request $request): JsonResponse
     {
         $event = $this->eventActionHelper->getEvent($eventSlug);
 
         $response =  new JsonResponse($this->openfeedbackJsonGenerator->generate($event));
 
-        $response->headers->set('Access-Control-Allow-Origin', 'https://openfeedback.io');
+        $response->headers->set('Access-Control-Allow-Origin', $request->server->get('HTTP_ORIGIN'));
+        $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        $response->headers->set('Access-Control-Max-Age', '86400');
 
         return $response;
     }


### PR DESCRIPTION
J'ai besoin de récupérer les infos du JSON openfeedback pour un outil en cours de développement.

Cet PR permet de supprimer les CORS pour les appels javascript.