### PR TITLE
correction page liste events

### DIFF
--- a/sources/AppBundle/Controller/Event/Event/IndexAction.php
+++ b/sources/AppBundle/Controller/Event/Event/IndexAction.php
@@ -17,12 +17,14 @@ final class IndexAction extends AbstractController
 
     public function __invoke(): Response
     {
-        $events = $this->eventRepository->getNextEvents();
+        $events = $this->eventRepository->getNextPublicizedEvents();
 
-        if ($events === null) {
+        if (count($events) === 0) {
             return $this->render('event/none.html.twig');
-        } elseif ($events->count() === 1) {
-            $event = $events->first();
+        }
+
+        if (count($events) === 1) {
+            $event = array_pop($events);
             return new RedirectResponse($this->generateUrl('event', ['eventSlug' => $event->getPath()]), Response::HTTP_TEMPORARY_REDIRECT);
         }
 

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -44,7 +44,7 @@ class EventRepository extends Repository implements MetadataInitializer
     public function getNextEvents()
     {
         $query = $this
-            ->getQuery('SELECT id, path, titre, text, date_debut, date_fin, date_fin_appel_conferencier, date_fin_vente FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
+            ->getQuery('SELECT id, path, titre, text, date_debut, date_fin, date_debut_appel_conferencier, date_fin_appel_conferencier, date_fin_vente FROM afup_forum WHERE date_debut > NOW() ORDER BY date_debut')
         ;
 
         $events = $query->query($this->getCollection(new HydratorSingleObject()));
@@ -53,6 +53,26 @@ class EventRepository extends Repository implements MetadataInitializer
             return null;
         }
         return $events;
+    }
+
+    /**
+     * @return Event[]
+     */
+    public function getNextPublicizedEvents(): array
+    {
+        $nextPublizedEvents = [];
+        $currentDate = new \DateTime();
+
+        foreach ($this->getNextEvents() as $event) {
+
+            if ($currentDate < $event->getDateStartCallForPapers()) {
+                continue;
+            }
+
+            $nextPublizedEvents[] = $event;
+        }
+
+        return $nextPublizedEvents;
     }
 
     public function getLastEvent()


### PR DESCRIPTION
sur https://cfp.afup.org on redirige vers https://afup.org/event/ cette page liste tous les événements à venir, sans prendre en compte la date d'ouverture du CFP. on peux donc avant la keynote de cloture afficher les AFUP Days retenus. Pour éviter ça on ajoute un filtre sur la liste des événements sur la date d'ouverture du CFP (le changement a été appliqué en prod pour éviter de faire fuiter l'info (certaines personnes sont déjà tombées sur cette page et l'on remonté), mais sera perdu lors du prochain déploiement)