### PR TITLE
Test automatique de l'exécution de la console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,6 +121,7 @@
       "Afup\\Site\\Tests\\": "tests/unit/Afup/",
       "Afup\\Tests\\Support\\": "tests/support/",
       "AppBundle\\Tests\\": "tests/unit/AppBundle/",
+      "AppBundle\\IntegrationTests\\": "tests/integration/AppBundle/",
       "PlanetePHP\\IntegrationTests\\": "tests/integration/PlanetePHP/"
     }
   },

--- a/tests/integration/AppBundle/ConsoleTest.php
+++ b/tests/integration/AppBundle/ConsoleTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\IntegrationTests;
+
+use AppBundle\Tests\TestCase;
+use Symfony\Component\Process\Process;
+
+final class ConsoleTest extends TestCase
+{
+    public function testConsoleRunsWithoutError(): void
+    {
+        $process = new Process(['php', 'bin/console']);
+        $process->run();
+
+        $this->assertSame(
+            0,
+            $process->getExitCode(),
+            sprintf(
+                "The console exited with a non-zero code. Output:\n%s\nError Output:\n%s",
+                $process->getOutput(),
+                $process->getErrorOutput(),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Il est arrivé qu'une PR contienne des modifications qui empêchent la console de fonctionner correctement, ce qui bloque presque tous les crons.

Ce test va simplement lancer la console sans argument pour s'assurer qu'elle fonctionne.