### PR TITLE
correction préremplissage formulaire speaker

### DIFF
--- a/sources/AppBundle/Event/Form/SpeakerType.php
+++ b/sources/AppBundle/Event/Form/SpeakerType.php
@@ -23,6 +23,7 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class SpeakerType extends AbstractType
 {
@@ -84,8 +85,8 @@ class SpeakerType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $formEvent): void {
             $speaker = $formEvent->getData();
             $user = null;
-            if ($this->tokenStorage->getToken() instanceof TokenStorageInterface) {
-                $user = $this->tokenStorage->getToken()->getUser();
+            if (($token = $this->tokenStorage->getToken()) instanceof TokenInterface) {
+                $user = $token->getUser();
             }
 
             if ($user instanceof GithubUser && $speaker instanceof Speaker && $speaker->getId() === null) {


### PR DESCRIPTION
le formulaire de speaker n'était pas prérempli, et ce car l'objet $user était null dans l'eventlistener qui s'occupe du préremplissage.

Cela car on faisait un test sur un `TokenStorageInterface` alors qu'on est sur une instance de `TokenInterface`.