### PR TITLE
Correction du comportement du menu principal sur les pages de configuration de la trésorie

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -217,11 +217,12 @@ parameters:
                     niveau: 'ROLE_ADMIN'
                     url: '/admin/accounting/events/list'
                     extra_routes:
-                        - compta_conf_categorie
-                        - compta_conf_operation
-                        - compta_conf_reglement
-                        - compta_conf_compte
-                        - compta_conf_regle
+                        - admin_accounting_events_list
+                        - admin_accounting_categories_list
+                        - admin_accounting_operations_list
+                        - admin_accounting_payments_list
+                        - admin_accounting_accounts_list
+                        - admin_accounting_rules_list
                 compta_recherche:
                     nom: 'Recherche comptable'
                     niveau: 'ROLE_ADMIN'


### PR DESCRIPTION
Suite à la refonte des pages, les éléments du menu "Trésorerie" n'étaient plus visibles lorsque l'on était sur ces pages.

Avant :
<img width="451" height="398" alt="Screenshot from 2025-10-23 19-53-59" src="https://github.com/user-attachments/assets/08da3c1b-1096-482a-b009-276914a17395" />

Après :
<img width="451" height="538" alt="Screenshot from 2025-10-23 19-54-25" src="https://github.com/user-attachments/assets/1bbcd7ae-717b-4ecc-bd04-d1047a85b36a" />
