### PR TITLE
on supprime l'affichage du compte Twitter sur la page des speakers sur event

### DIFF
--- a/templates/blog/speakers.html.twig
+++ b/templates/blog/speakers.html.twig
@@ -9,16 +9,6 @@
             {{ row.speaker.label }}
             {% if row.speaker.company %}<span class="societe">{{ row.speaker.company }}</span>{% endif %}
         </h3>
-        {% if row.speaker.getUsernameTwitter %}
-            <a class="follow-button"
-               href="{{ row.speaker.getUrlTwitter }}"
-               target="_blank">
-                <svg height="12" viewBox="0 0 271 300" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
-                    <path d="m236 0h46l-101 115 118 156h-92.6l-72.5-94.8-83 94.8h-46l107-123-113-148h94.9l65.5 86.6zm-16.1 244h25.5l-165-218h-27.4z"/>
-                </svg>
-                <span>Suivre @{{ row.speaker.getUsernameTwitter }}</span>
-            </a>
-        {% endif %}
         {% if row.speaker.getUsernameMastodon %}
             <a class="follow-button"
                href="{{ row.speaker.getUrlMastodon }}"


### PR DESCRIPTION
…
pour le moment il est toujours demandé sur le CFP, on le masque sur la page des speakers affichée sur event.