### PR TITLE
Ajout de tests pour le rendu des articles en front

### DIFF
--- a/db/seeds/Articles.php
+++ b/db/seeds/Articles.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Afup\Site\Corporate\Article;
 use AppBundle\Site\Model\Rubrique;
 use Cocur\Slugify\Slugify;
 use Faker\Factory;
@@ -20,7 +21,6 @@ EOF;
 <p>Hormis la conf&eacute;rence "Cessons les estimations" de Fr&eacute;d&eacute;ric Legu&eacute;dois, qui n'&eacute;tait pas capt&eacute;e <a href="https://www.leguedois.fr/pourquoi-les-conferences-ne-sont-pas-filmees/">&agrave; sa demande</a>, tous les talks sont disponibles sur notre page "<a href="../../talks/">vid&eacute;os</a>". Faites passer &agrave; vos voisins et coll&egrave;gues, visionnez les sujets que vous avez manqu&eacute;s, revoyez ce talk qui vous a fascin&eacute;, et surtout, surtout, imaginez le plaisir de les voir en live : <strong>venez nous voir en octobre au Forum PHP 2019 ou en mai &agrave; l'AFUP Day !&nbsp;</strong></p>
 EOF;
 
-
         $data = [
             [
                 'titre' => "Les vidéos des talks du Forum PHP 2018 sont disponibles",
@@ -31,8 +31,12 @@ EOF;
                 'date' => 1542150000,
                 'id_forum' => Event::ID_FORUM,
                 'etat' => 1,
+                'type_contenu' => Article::TYPE_CONTENU_HTML,
             ],
         ];
+
+        $data[] = $this->createMarkdownArticle();
+        $data[] = $this->createHTMLArticle();
 
         $slugger = Slugify::create();
         $faker = Factory::create();
@@ -46,6 +50,7 @@ EOF;
                 'id_site_rubrique' => Rubrique::ID_RUBRIQUE_ACTUALITES,
                 'date' => $faker->unixTime(new DateTime('2017-12-31T23:59:59')),
                 'etat' => 1,
+                'type_contenu' => Article::TYPE_CONTENU_HTML,
             ];
         }
 
@@ -56,5 +61,64 @@ EOF;
             ->insert($data)
             ->save()
         ;
+    }
+
+    private function createMarkdownArticle(): array
+    {
+        $contenu = <<<MARKDOWN
+### Un premier titre !
+Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam aperiam dolor, eligendi expedita nisi quibusdam repellendus repudiandae!
+
+### Encore un titre
+Un peu **de texte en gras**.
+<br><br>
+Et un peu *de texte en italic*.
+
+### Une dernière section
+Un texte avec un lien [commodi delectus](https://afup.org) et encore un peu de texte.
+MARKDOWN;
+
+        return [
+            'titre' => "Un article en Markdown",
+            'chapeau' => "*Un peu* de text **avec de la mise** en forme",
+            'contenu' => $contenu,
+            'raccourci' => 'un-article-en-markdown',
+            'id_site_rubrique' => Rubrique::ID_RUBRIQUE_ACTUALITES,
+            'date' => 1761859722,
+            'id_forum' => Event::ID_FORUM,
+            'etat' => 1,
+            'type_contenu' => Article::TYPE_CONTENU_MARKDOWN,
+        ];
+    }
+
+    private function createHTMLArticle(): array
+    {
+        $contenu = <<<HTML
+<h3>Un premier titre !</h3>
+<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aliquam aperiam dolor, eligendi expedita nisi quibusdam repellendus repudiandae!</p>
+
+<h3>Encore un titre</h3>
+<p>Un peu <strong>de texte en gras</strong>.
+<br><br>
+Et un peu <em>de texte en italic</em>.</p>
+
+<h3>Une dernière section</h3>
+<p>Un texte avec un lien <a href="https://afup.org">commodi delectus</a> et encore un peu de texte.
+<br><br>
+<strong>Un peu de gras
+avec un saut de ligne en base</strong></p>
+HTML;
+
+        return [
+            'titre' => "Un article en HTML",
+            'chapeau' => "<p>Lorem <strong>ipsum</strong> dolor si amet.</p>",
+            'contenu' => $contenu,
+            'raccourci' => 'un-article-en-html',
+            'id_site_rubrique' => Rubrique::ID_RUBRIQUE_ACTUALITES,
+            'date' => 1761858722,
+            'id_forum' => Event::ID_FORUM,
+            'etat' => 1,
+            'type_contenu' => Article::TYPE_CONTENU_HTML,
+        ];
     }
 }

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -233,6 +233,19 @@ class FeatureContext implements Context
     }
 
     /**
+     * @Then /^the response should contain the html "(?P<text>(?:[^"]|\\")*)"$/
+     * @Then /^the response should contain the html$/
+     */
+    public function assertResponseHasHtml(PyStringNode|string $html): void
+    {
+        if ($html instanceof PyStringNode) {
+            $html = $html->getRaw();
+        }
+
+        $this->minkContext->assertResponseContains($html);
+    }
+
+    /**
      * @Then the current URL should match :arg1
      * @throws ExpectationException
      */

--- a/tests/behat/features/Admin/Site/AdminSiteArticles.feature
+++ b/tests/behat/features/Admin/Site/AdminSiteArticles.feature
@@ -40,7 +40,7 @@ Feature: Administration - Partie Site
     When I should see "Liste des articles"
     Then the ".content table" element should contain "Le titre de l'article"
     # vérification de l'article sur le site publique
-    When I go to "/news/16-url-article"
+    When I go to "/news/18-url-article"
     Then I should see "Le titre de l'article"
     Then I should see "Le chapeau de l'article"
     Then I should see "Le contenu de l'article"

--- a/tests/behat/features/PublicSite/News.feature
+++ b/tests/behat/features/PublicSite/News.feature
@@ -16,7 +16,7 @@ Feature: Site Public - News
     When I follow "Actualités"
     Then I should see "Actualités"
     And I should see "Les vidéos des talks du Forum PHP 2018 sont disponibles"
-    And I check "news_filters_year_0"
+    And I check "news_filters_year_1"
     And I submit the form with name "news_filters"
     And I should be on "/news/?news_filters[year][0]=2018"
     And I should see "Les vidéos des talks du Forum PHP 2018 sont disponibles"
@@ -24,3 +24,33 @@ Feature: Site Public - News
     And I submit the form with name "news_filters"
     And I should be on "/news/?news_filters[theme][0]=1"
     And I should not see "Les vidéos des talks du Forum PHP 2018 sont disponibles"
+
+  @reloadDbWithTestData
+  Scenario: Affichage d'un article MARKDOWN
+    Given I am on the homepage
+    When I follow "Actualités"
+    And I follow "Lire l'article: Un article en Markdown"
+    Then I should not see "### Un premier titre !"
+    And the response should contain the html "<h3>Un premier titre !</h3>"
+    And I should not see "**de texte en gras**"
+    And the response should contain the html "<strong>de texte en gras</strong>"
+    And I should not see "*de texte en italic*"
+    And the response should contain the html "<em>de texte en italic</em>"
+    And I should not see "[commodi delectus](https://afup.org)"
+    And the response should contain the html
+    """
+    <a href="https://afup.org">commodi delectus</a>
+    """
+
+  @reloadDbWithTestData
+  Scenario: Affichage d'un article HTML
+    Given I am on the homepage
+    When I follow "Actualités"
+    And I follow "Lire l'article: Un article en HTML"
+    And the response should contain the html "<h3>Un premier titre !</h3>"
+    And the response should contain the html "<strong>de texte en gras</strong>"
+    And the response should contain the html "<em>de texte en italic</em>"
+    And the response should contain the html
+    """
+    <a href="https://afup.org">commodi delectus</a>
+    """


### PR DESCRIPTION
Les anciens articles étaient rédigés en HTML et sont stockés en HTML. Les nouveaux sont en markdown avec un rendu HTML en front.

Le test s'assure que les deux formats sont affichés correctement.