### PR TITLE
Correction du titre de l'email d'inscription

### DIFF
--- a/templates/mail/_base_mail.html.twig
+++ b/templates/mail/_base_mail.html.twig
@@ -13,7 +13,8 @@
         .ExternalClass span,
         .ExternalClass font,
         .ExternalClass td,
-        .ExternalClass div {
+        .ExternalClass div,
+        h1 {
             line-height: 100%;
         }
         @media screen and (max-width:0) {


### PR DESCRIPTION
Corrige le #1934.
On retrouve le problème dans le MailCatcher en local.
Avant : 
<img width="653" height="438" alt="Capture d’écran 2025-11-03 à 20 54 30" src="https://github.com/user-attachments/assets/396c235b-c2e6-461e-8982-47d54b3f72f3" />
Après : 
<img width="653" height="438" alt="Capture d’écran 2025-11-03 à 20 54 26" src="https://github.com/user-attachments/assets/b3262309-66c9-4be2-9fd6-48c35083a214" />

J'ai simplement ajusté le line-height du h1.