### PR TITLE
correction de menu sur la page de recherche comptable

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -227,6 +227,8 @@ parameters:
                     nom: 'Recherche comptable'
                     niveau: 'ROLE_ADMIN'
                     url: '/admin/accounting/search'
+                    extra_routes:
+                        - admin_accounting_search
         assemblee_generale:
             nom: 'Assemblée générale'
             niveau: 'ROLE_ADMIN'


### PR DESCRIPTION
avant : 

<img width="717" height="521" alt="Screenshot from 2025-11-03 23-47-34" src="https://github.com/user-attachments/assets/b1760713-6dd2-42db-88d2-101b28ccea85" />


après : 

<img width="717" height="566" alt="Screenshot from 2025-11-03 23-47-59" src="https://github.com/user-attachments/assets/93d0729c-fbb6-476f-a009-3ae2f1fbe133" />
