### PR TITLE
Documentation de l'utilisation des security advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,15 @@
 
 Si vous découvrez un problème de sécurité dans ce projet, **merci de ne pas ouvrir un ticket public**.
 
-À la place, contactez-nous à `outils[at]afup[dot]org` avec les détails de la vulnérabilité et des étapes pour la reproduire.
+À la place, utilisez le [système intégré à GitHub](https://github.com/afup/web/security/advisories/new) pour créer un [security advisory](https://github.com/afup/web/security/advisories).
+
+Ce système nous permettra de facilement discuter des détails de la vulnérabilité et des étapes pour la reproduire en
+privé tout en gérant un fork privé pour la correction.
+
+---
 
 Si vous êtes adhérent à l'association, vous pouvez également nous contacter via le Slack des membres.
+
+---
+
+Nous avons également un email : `outils[at]afup[dot]org`


### PR DESCRIPTION
Maintenant que l'option est activée sur le repository, il faut la documenter et la prioriser.