### PR TITLE
Refactor des targets de QA pour pouvoir les lancer depuis le host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           composer-options: "--no-scripts"
 
       - name: PHPStan
-        run: make phpstan
+        run: php ./bin/phpstan
 
   functional:
     name: "Functional tests"
@@ -139,4 +139,4 @@ jobs:
           composer-options: "--no-scripts"
 
       - name: Rector
-        run: make rector
+        run: php ./bin/rector


### PR DESCRIPTION
L'idée est d'éviter d'avoir à savoir s'il faut lancer un target depuis le host ou le docker.