### PR TITLE
Correction de l'affichage du target `assets` dans l'aide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ help:
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 
-.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init console phpstan
+.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init console phpstan assets
 
 ##@ Setup
 
@@ -120,7 +120,6 @@ phpstan:
 ##@ Frontend
 
 ### Compiler les assets pour la production
-.PHONY: assets
 assets:
 	./node_modules/.bin/webpack -p
 


### PR DESCRIPTION
Avant :
<img width="692" height="76" alt="image" src="https://github.com/user-attachments/assets/77c11adb-0aa1-4dab-a4ee-40392da78c38" />

Après :
<img width="672" height="69" alt="image" src="https://github.com/user-attachments/assets/5460cd99-81f9-4171-94f2-b334bfe7a5d0" />
