### PR TITLE
Affichage des stats du CFP en cours sur la home du BO

### DIFF
--- a/sources/AppBundle/Event/Model/EventStats.php
+++ b/sources/AppBundle/Event/Model/EventStats.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Event\Model;
 
+use AppBundle\Event\Model\EventStats\CFPStats;
 use AppBundle\Event\Model\EventStats\DailyStats;
 use AppBundle\Event\Model\EventStats\TicketTypeStats;
 
@@ -13,5 +14,6 @@ final readonly class EventStats
         public DailyStats $firstDay,
         public DailyStats $secondDay,
         public TicketTypeStats $ticketType,
+        public CFPStats $cfp,
     ) {}
 }

--- a/sources/AppBundle/Event/Model/EventStats/CFPStats.php
+++ b/sources/AppBundle/Event/Model/EventStats/CFPStats.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Event\Model\EventStats;
+
+final readonly class CFPStats
+{
+    public function __construct(
+        public int $talks,
+        public int $speakers,
+    ) {}
+}

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -39,7 +39,7 @@ class EventRepository extends Repository implements MetadataInitializer
     }
 
     /**
-     * @return CollectionInterface|Event|null
+     * @return CollectionInterface<Event>|null
      */
     public function getNextEvents()
     {

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -30,15 +30,19 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
  */
 class TalkRepository extends Repository implements MetadataInitializer
 {
-    public function getNumberOfTalksByEvent(Event $event, \DateTime $since = null)
+    public function getNumberOfTalksByEvent(Event|int $event, \DateTime $since = null)
     {
         return $this->getNumberOfTalksByEventAndLanguage($event, null, $since);
     }
 
-    public function getNumberOfTalksByEventAndLanguage(Event $event, $languageCode = null, \DateTime $since = null)
+    public function getNumberOfTalksByEventAndLanguage(Event|int $event, $languageCode = null, \DateTime $since = null)
     {
+        if ($event instanceof Event) {
+            $event = $event->getId();
+        }
+
         $sql = 'SELECT COUNT(session_id) AS talks FROM afup_sessions WHERE id_forum = :event';
-        $params = ['event' => $event->getId()];
+        $params = ['event' => $event];
         if ($since instanceof \DateTime) {
             $sql .= ' AND date_soumission >= :since ';
             $params['since'] = $since->format('Y-m-d');

--- a/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkToSpeakersRepository.php
@@ -20,14 +20,18 @@ use CCMBenchmark\Ting\Serializer\SerializerFactoryInterface;
  */
 class TalkToSpeakersRepository extends Repository implements MetadataInitializer
 {
-    public function getNumberOfSpeakers(Event $event, \DateTime $since = null)
+    public function getNumberOfSpeakers(Event|int $event, \DateTime $since = null)
     {
+        if ($event instanceof Event) {
+            $event = $event->getId();
+        }
+
         $sql = 'SELECT COUNT(distinct conferencier_id) AS count 
                 FROM afup_conferenciers_sessions
                 JOIN afup_sessions ON (afup_conferenciers_sessions.session_id = afup_sessions.session_id)
                 WHERE id_forum = :event
         ';
-        $params = ['event' => $event->getId()];
+        $params = ['event' => $event];
         if ($since instanceof \DateTime) {
             $sql .= ' AND afup_sessions.date_soumission >= :since ';
             $params['since'] = $since->format('Y-m-d');

--- a/templates/admin/home.html.twig
+++ b/templates/admin/home.html.twig
@@ -53,7 +53,15 @@
                                 {% for label, statistic in card.statistics %}
                                     <div class="statistic">
                                         <div class="value">
-                                            {{ statistic }}
+                                            {% if statistic is iterable %}
+                                                <div class="ui horizontal labels">
+                                                {% for entry in statistic %}
+                                                    <div class="ui label"><i class="{{ entry.icon }} icon"></i> {{ entry.value }}</div>
+                                                {% endfor %}
+                                                </div>
+                                            {% else %}
+                                                {{ statistic }}
+                                            {% endif %}
                                         </div>
                                         <div class="label">
                                             {{ label }}


### PR DESCRIPTION
Cela fait suite à une idée d'Amélie.

Voilà un exemple de rendu avec les données des seeds :
<img width="309" height="275" alt="image" src="https://github.com/user-attachments/assets/66d64ca2-0f18-4188-a139-27986b8855af" />

Les informations sont les mêmes que celles du bot slack sauf que là c'est en temps réel.

J'ai conditionné l'affichage du bloc à une période après la fin du CFP donc c'est facile à modifier si besoin.