### PR TITLE
Liste des antennes dans le BO

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -276,6 +276,17 @@ parameters:
                     url: '/admin/planete/feed-articles'
                     extra_routes:
                       - admin_planete_feed_article_list
+        antenne:
+            nom: 'Antennes'
+            niveau: 'ROLE_ADMIN'
+            icon: 'map marker alternate piece'
+            elements:
+                antennes_index:
+                    nom: 'Liste'
+                    niveau: 'ROLE_ADMIN'
+                    url: '/admin/antennes'
+                    extra_routes:
+                        - admin_antennes_list
         divers:
             nom: 'Divers'
             niveau: 'ROLE_ADMIN'

--- a/app/config/routing/admin.yml
+++ b/app/config/routing/admin.yml
@@ -41,6 +41,10 @@ admin_planete_routes:
   resource: "admin_planete.yml"
   prefix: /planete
 
+admin_antennes:
+  resource: "admin_antennes.yml"
+  prefix: /antennes
+
 admin_members_reporting:
   path: /members/reporting
   defaults: {_controller: AppBundle\Controller\MembershipAdmin\ReportingAction}

--- a/app/config/routing/admin_antennes.yml
+++ b/app/config/routing/admin_antennes.yml
@@ -1,0 +1,3 @@
+admin_antennes_list:
+    path: /
+    defaults: {_controller: AppBundle\Controller\Admin\Antennes\AntenneListAction}

--- a/sources/AppBundle/Controller/Admin/Antennes/AntenneListAction.php
+++ b/sources/AppBundle/Controller/Admin/Antennes/AntenneListAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Antennes;
+
+use AppBundle\Antennes\Antenne;
+use AppBundle\Antennes\AntennesCollection;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Twig\Environment;
+
+final readonly class AntenneListAction
+{
+    public function __construct(
+        private AntennesCollection $antennesCollection,
+        private Environment $twig,
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        $antennes = $this->antennesCollection->getAll();
+
+        uasort(
+            $antennes,
+            fn(Antenne $a, Antenne $b) => strcmp($a->label, $b->label),
+        );
+
+        return new Response($this->twig->render('admin/antennes/list.html.twig', [
+            'antennes' => $antennes,
+        ]));
+    }
+}

--- a/templates/admin/antennes/list.html.twig
+++ b/templates/admin/antennes/list.html.twig
@@ -1,0 +1,169 @@
+{% extends 'admin/base_with_header.html.twig' %}
+
+{% block content %}
+    <h2>Antennes</h2>
+
+    <div class="ui message">
+        <div class="header">
+            Liste en lecture seule
+        </div>
+
+        <p>Les modifications sont à faire dans le code (il faut demander au pole outils).</p>
+    </div>
+
+    <div class="ui segment">
+        {% if antennes|length > 0 %}
+            <table class="ui table striped compact celled">
+                <thead>
+                <tr>
+                    <th>Nom</th>
+                    <th>Status</th>
+                    <th>
+                        <div class="ui small basic icon buttons">
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="Meetup"
+                            >
+                                <i class="meetup icon grey"></i>
+                            </span>
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="LinkedIn"
+                            >
+                                <i class="linkedin icon grey"></i>
+                            </span>
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="Bluesky"
+                            >
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="15" height="15" class="icon grey">
+                                    <path fill="currentColor" d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z"></path>
+                                </svg>
+                            </span>
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="Blog"
+                            >
+                                <i class="rss icon grey"></i>
+                            </span>
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="YouTube"
+                            >
+                                <i class="youtube icon grey"></i>
+                            </span>
+                            <span class="ui button"
+                                  data-position="top center"
+                                  data-tooltip="Twitter"
+                            >
+                                <i class="twitter icon grey"></i>
+                            </span>
+                        </div>
+                    </th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for antenne in antennes %}
+                    <tr data-qa="antenne-{{ antenne.code }}">
+                        <td class="{{ antenne.hideOnOfficesPage ? 'disabled' : 'actif' }}">
+                            <span class="ui image spaced"><img src="{{ antenne.logoUrl }}" width="30" height="30" /></span>
+                            {{ antenne.label }}
+                        </td>
+                        <td style="text-align: center">
+                            {% if antenne.hideOnOfficesPage %}
+                                <div class="ui label red">Inactive</div>
+                            {% else %}
+                                <div class="ui label green">Active</div>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <div class="ui small basic icon buttons">
+                                {% if antenne.meetup %}
+                                    <a href="https://meetup.com/fr-FR/{{ antenne.meetup.urlName }}"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="Meetup"
+                                    >
+                                        <i class="meetup icon grey"></i>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+
+                                {% if antenne.socials.linkedin %}
+                                    <a href="https://www.linkedin.com/company/{{ antenne.socials.linkedin }}/"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="LinkedIn"
+                                    >
+                                        <i class="linkedin icon grey"></i>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+
+                                {% if antenne.socials.bluesky %}
+                                    <a href="https://bsky.app/profile/{{ antenne.socials.bluesky }}"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="Bluesky"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="15" height="15" class="icon grey">
+                                            <path fill="currentColor" d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z"></path>
+                                        </svg>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+
+                                {% if antenne.socials.blog %}
+                                    <a href="{{ antenne.socials.blog }}"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="Blog"
+                                    >
+                                        <i class="rss icon grey"></i>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+
+                                {% if antenne.socials.youtube %}
+                                    <a href="{{ antenne.socials.youtube }}"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="YouTube"
+                                    >
+                                        <i class="youtube icon grey"></i>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+
+                                {% if antenne.socials.twitter %}
+                                    <a href="https://twitter.com/{{ antenne.socials.twitter }}"
+                                       class="ui button"
+                                       data-position="top center"
+                                       data-tooltip="Twitter"
+                                    >
+                                        <i class="twitter icon grey"></i>
+                                    </a>
+                                {% else %}
+                                    <a class="ui button disabled"><i class="icon"></i></a>
+                                {% endif %}
+                            </div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="ui placeholder segment">
+                <div class="ui icon header">
+                    <i class="meh outline icon"></i>
+                    Aucune antenne
+                </div>
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/tests/behat/features/Admin/Antennes/List.feature
+++ b/tests/behat/features/Admin/Antennes/List.feature
@@ -1,0 +1,20 @@
+Feature: Administration - Partie Antennes
+
+  @reloadDbWithTestData
+  Scenario: Liste des antennes
+    Given I am logged in as admin and on the Administration
+    And I follow "afup-main-menu-item--antennes_index"
+    Then the ".content h2" element should contain "Antennes"
+
+    And the "tr[data-qa='antenne-marseille']" element should contain "Aix-Marseille"
+    And the "tr[data-qa='antenne-bordeaux']" element should contain "meetup.com"
+    And the "tr[data-qa='antenne-lille']" element should contain "linkedin.com"
+    And the "tr[data-qa='antenne-limoges']" element should contain "limoges.afup.org"
+    And the "tr[data-qa='antenne-lorraine']" element should contain "bsky.app"
+    And the "tr[data-qa='antenne-lyon']" element should contain "youtube.com"
+    And the "tr[data-qa='antenne-luxembourg']" element should contain "twitter.com"
+
+    And the "tr[data-qa='antenne-nantes']" element should not contain "youtube.com"
+
+    And the "tr[data-qa='antenne-montpellier']" element should contain "Active"
+    And the "tr[data-qa='antenne-clermont']" element should contain "Inactive"


### PR DESCRIPTION
Cela permet un accès facile à la configuration actuelle et d'avoir une vue d'ensemble sur les réseaux sociaux des antennes.

Voilà un aperçu du rendu :
<img width="1002" height="317" alt="image" src="https://github.com/user-attachments/assets/1b5c834d-e9a1-4ebb-916b-ea0a909d7938" />

Avec le chantier en cours sur les mini-sites ça aidera à voir ce qu'il manque/ce qui est configuré par antenne sans avoir à aller fouiller le code.

Et pourquoi pas devenir une page plus dynamique un jour pour ne plus avoir ça en dur dans le code selon les besoins.