### PR TITLE
correction affichage lien article de blog

### DIFF
--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -370,11 +370,13 @@ class Talk implements NotifyPropertyInterface
 
     public function getBlogPostUrl(): ?string
     {
-        if (0 === strlen(trim($this->blogPostUrl))) {
+        $blogPostUrl = (string) $this->blogPostUrl;
+
+        if (0 === strlen(trim($blogPostUrl))) {
             return null;
         }
 
-        return $this->blogPostUrl;
+        return $blogPostUrl;
     }
 
     public function setBlogPostUrl(?string $blogPostUrl): self


### PR DESCRIPTION
on affiche un lien vers l'article de blog alors qu'il n'y en a pas on rends plus sur la vérification de sa présence.