### PR TITLE
on rends plus résilient le test sur le chemin openfeedback

### DIFF
--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -344,7 +344,13 @@ class Talk implements NotifyPropertyInterface
 
     public function getOpenfeedbackPath(): ?string
     {
-        return $this->openfeedbackPath;
+        $openfeedbackPath = (string) $this->openfeedbackPath;
+
+        if (0 === strlen(trim($openfeedbackPath))) {
+            return null;
+        }
+
+        return $openfeedbackPath;
     }
 
     public function setOpenfeedbackPath(?string $openfeedbackPath): self


### PR DESCRIPTION
sur la page de détail de afup.org/talks, on affiche un lien openfeedback alors qu'on en a pas. Cela car on a une chaine videe en base. Afin d'éviter ça on rends plus résilient le test.