### PR TITLE
page de talk : on corrige l'affichage des liens si on a seulement une interview

### DIFF
--- a/templates/site/talks/show.html.twig
+++ b/templates/site/talks/show.html.twig
@@ -98,7 +98,7 @@
                     </div>
                 </div>
 
-                {% if talk.hasSlidesUrl or talk.hasBlogPostUrl or talk.hasJoindinId or talk.getVideoHasEnSubtitles or talk.getVideoHasFrSubtitles or talk.hasOpenfeedbackPath %}
+                {% if talk.hasSlidesUrl or talk.hasBlogPostUrl or talk.hasInterviewUrl or talk.hasJoindinId or talk.getVideoHasEnSubtitles or talk.getVideoHasFrSubtitles or talk.hasOpenfeedbackPath %}
                 <div class="container">
                     <div class="col-md-12">
                         <h2>Informations complémentaires</h2>


### PR DESCRIPTION
si on avait seulement une interview on affichait pas le lien car il manquait une condition dans le if.