### PR TITLE
suppression du message dans les cotisations suite aux changements de tarififications

### DIFF
--- a/templates/admin/association/membership/membershipfee.html.twig
+++ b/templates/admin/association/membership/membershipfee.html.twig
@@ -9,11 +9,6 @@
 {% block page_title %}Cotisations{% endblock %}
 
 {% block page_content %}
-    {# Ici ce message restera environ 6 mois, on se permet donc d'appliquer le style de cette façon #}
-    <div style="background-color: #ed0678; color: #fff; padding: 15px 20px; font-weight: bold">
-        Les cotisations évoluent, mais pour vous rien ne change. Retrouvez toutes les informations à propos de ce changement dans <a style="color: #fff" target="article-cotisations" href="https://afup.org/news/1204-passage-a-la-TVA-cotisations">notre article dédié</a>.
-    </div>
-
     <h2>Payer ma cotisation</h2>
 
     {% if message %}


### PR DESCRIPTION
avec le passage à la TVA on avait mis un message vers un article pour prévenir du changement. Cela va bientôt faire 2 ans, on supprime ce message.

le message avant :

<img width="1733" height="671" alt="Capture d’écran du 2025-12-06 16-27-36" src="https://github.com/user-attachments/assets/aef488c9-5d6e-420d-8575-539cca3b0156" />
