### PR TITLE
Amélioration du typage des articles

### DIFF
--- a/db/migrations/20251208130026_article_non_nullable_columns.php
+++ b/db/migrations/20251208130026_article_non_nullable_columns.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Db\Adapter\MysqlAdapter;
+use Phinx\Migration\AbstractMigration;
+
+final class ArticleNonNullableColumns extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_site_article')
+            ->changeColumn('titre', 'text', [
+                'null' => false,
+            ])
+            ->changeColumn('contenu', 'text', [
+                'null' => false,
+                'limit' => MysqlAdapter::TEXT_LONG,
+            ])
+            ->changeColumn('raccourci', 'string', [
+                'null' => false,
+            ])
+            ->changeColumn('id_site_rubrique', 'integer', [
+                'null' => false,
+            ])
+            ->changeColumn('type_contenu', 'string', [
+                'null' => false,
+                'limit' => 30,
+                'default' => 'markdown',
+            ])
+            ->update();
+    }
+}

--- a/sources/AppBundle/Site/Form/ArticleType.php
+++ b/sources/AppBundle/Site/Form/ArticleType.php
@@ -11,7 +11,6 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -45,7 +44,7 @@ class ArticleType extends AbstractType
         /** @var \AppBundle\Site\Model\Article|null $article */
         $article = $builder->getData();
         $textareaCssClass = 'simplemde';
-        if ($article !== null && $article->usesMarkdown() === false) {
+        if ($article !== null && $article->isContentTypeMarkdown() === false) {
             $textareaCssClass = 'tinymce';
         }
 
@@ -77,7 +76,7 @@ class ArticleType extends AbstractType
             ])
             ->add('content', TextareaType::class, [
                 'label' => 'Contenu',
-                'required' => false,
+                'required' => true,
                 'attr' => [
                     'cols' => 42,
                     'rows' => 20,
@@ -102,11 +101,8 @@ class ArticleType extends AbstractType
                     new Assert\Regex('/(\s)/', 'Ne doit pas contenir d\'espaces', null, false),
                 ],
             ])
-            ->add('contentType', HiddenType::class, [
-                'required' => true,
-            ])
             ->add('rubricId', ChoiceType::class, [
-                'placeholder' => '',
+                'required' => true,
                 'label' => 'Rubrique',
                 'choices' => $rubriques,
                 'constraints' => [
@@ -159,7 +155,7 @@ class ArticleType extends AbstractType
                 ],
             ])
             ->add('eventId', ChoiceType::class, [
-                'label' => 'Evênement',
+                'label' => 'Événement',
                 'required' => false,
                 'choices' => $events,
                 'constraints' => [

--- a/sources/AppBundle/Site/Model/Article.php
+++ b/sources/AppBundle/Site/Model/Article.php
@@ -383,9 +383,4 @@ class Article implements NotifyPropertyInterface
         $this->authorId = $authorId;
         return $this;
     }
-
-    public function usesMarkdown(): bool
-    {
-        return $this->getContentType() === 'markdown';
-    }
 }

--- a/templates/admin/site/article_form.html.twig
+++ b/templates/admin/site/article_form.html.twig
@@ -28,7 +28,6 @@
                     {{ form_row(form.title) }}
                     {{ form_row(form.leadParagraph) }}
                     {{ form_row(form.content) }}
-                    {{ form_row(form.contentType) }}
                 </div>
             </div>
         </div>

--- a/tests/behat/features/Admin/Site/AdminSiteRubriques.feature
+++ b/tests/behat/features/Admin/Site/AdminSiteRubriques.feature
@@ -35,7 +35,7 @@ Feature: Administration - Partie Site
     Then I should see "Liste des articles"
     When I follow "Ajouter"
     Then I should see "Ajouter un article"
-    Then The "article[rubricId]" field should only contain the follow values '["", "Actualités", "Évènements"]'
+    Then The "article[rubricId]" field should only contain the follow values '["Actualités", "Évènements"]'
 
     # suppression d'une rubrique
     When I follow "Rubriques"


### PR DESCRIPTION
Certains champs sont obligatoires et aucune ligne en base n'a de valeur à null donc autant verrouiller.

J'ai lancé ça sur la base de prod et le résultat est `0` :

```sql
select count(*) from afup_site_article
where titre is null
or contenu is null
or raccourci is null
or id_site_rubrique is null
or type_contenu is null;
```