### PR TITLE
Refactor du test de validité des flux

### DIFF
--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -32,6 +32,15 @@ services:
         class: AppBundle\Offices\NullOfficeFinder
         arguments: ['@geocoder']
 
+    Afup\Tests\Support\PlanetePHP\FeedHttpClientFactory: ~
+    planetephp.http_client:
+        class: Symfony\Contracts\HttpClient\HttpClientInterface
+        factory: '@Afup\Tests\Support\PlanetePHP\FeedHttpClientFactory'
+
+    PlanetePHP\SymfonyFeedClient:
+        arguments:
+            $httpClient: '@planetephp.http_client'
+
 ewz_recaptcha:
     enabled: false
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -31,6 +31,8 @@ services:
               db_password: '%database_password%'
               lock_mode: !php/const Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler::LOCK_NONE
 
+    Laminas\Feed\Reader\Http\ClientInterface: '@PlanetePHP\SymfonyFeedClient'
+
     AppBundle\:
         resource: '../../sources/AppBundle/'
         autowire: true

--- a/sources/PlanetePHP/FeedTester.php
+++ b/sources/PlanetePHP/FeedTester.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PlanetePHP;
+
+use Laminas\Feed\Reader\Http\ClientInterface;
+use SimpleXMLElement;
+
+final readonly class FeedTester
+{
+    public function __construct(
+        private ClientInterface $feedClient,
+    ) {}
+
+    public function test(Feed $feed): bool
+    {
+        try {
+            $xml = $this->feedClient->get($feed->getFeed());
+
+            new SimpleXmlElement($xml->getBody());
+
+            return true;
+        } catch (\Exception) {
+            return false;
+        }
+    }
+}

--- a/tests/behat/features/Admin/PlanetePHP/Flux.feature
+++ b/tests/behat/features/Admin/PlanetePHP/Flux.feature
@@ -21,14 +21,24 @@ Feature: Administration - Planète PHP - Flux
     Then the ".content h2" element should contain "Ajouter un flux"
     When I fill in "feed_form[name]" with "Site web les-tilleuls.coop"
     And I fill in "feed_form[url]" with "https://les-tilleuls.coop"
-    And I fill in "feed_form[feed]" with "http://statictestresources/feed.xml"
+    And I fill in "feed_form[feed]" with "https://fake.afup/working-feed.xml"
+    And I press "Ajouter"
+    Then the ".content .message" element should contain "Le flux a été ajouté"
+    # Ajout d'un flux avec feed invalide
+    When I follow "Ajouter"
+    Then the ".content h2" element should contain "Ajouter un flux"
+    When I fill in "feed_form[name]" with "Mon super site"
+    And I fill in "feed_form[url]" with "https://fake.afup"
+    And I fill in "feed_form[feed]" with "https://fake.afup/invalid-feed.xml"
     And I press "Ajouter"
     Then the ".content .message" element should contain "Le flux a été ajouté"
     # Liste des flux
     And I should see "les-tilleuls.coop https://les-tilleuls.coop Actif Oui non testé"
+    And I should see "Mon super site https://fake.afup Actif Oui non testé"
     # Test de validité
     When I follow "Test validité"
     And I should see "les-tilleuls.coop https://les-tilleuls.coop Actif Oui validé"
+    And I should see "Mon super site https://fake.afup Actif Oui erreur"
     # Modification + désactivation d'un flux
     When I follow the button of tooltip "Modifier la fiche de Site web les-tilleuls.coop"
     Then the ".content h2" element should contain "Modifier un flux"

--- a/tests/support/PlanetePHP/FeedHttpClientFactory.php
+++ b/tests/support/PlanetePHP/FeedHttpClientFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Afup\Tests\Support\PlanetePHP;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class FeedHttpClientFactory
+{
+    public function __invoke(): HttpClientInterface
+    {
+        return new MockHttpClient(function (string $method, string $url): MockResponse {
+            if ($url === 'https://fake.afup/working-feed.xml') {
+                return new MockResponse('<?xml version="1.0" encoding="UTF-8"?><a/>');
+            }
+
+            return new MockResponse('', ['http_code' => 500]);
+        });
+    }
+}


### PR DESCRIPTION
Le système ne permettait pas de mock l'appel HTTP lors des tests Behat, qui se retrouvaient à échouer si un feed testé n'est pas disponible, ou si les tests sont lancés sans connexion internet.