### PR TITLE
Refactor des stats de la notif slack

### DIFF
--- a/sources/AppBundle/Controller/Admin/HomeAction.php
+++ b/sources/AppBundle/Controller/Admin/HomeAction.php
@@ -47,7 +47,7 @@ class HomeAction extends AbstractController
                 $info = [];
                 if ($event->lastsOneDay()) {
                     $ticketsLabel = 'entrées';
-                    $tickets = $stats->firstDay->registered;
+                    $tickets = $stats->firstDay->confirmed + $stats->firstDay->pending;
                     if ($event->getSeats()) {
                         $percentage = floor(($tickets * 100) / $event->getSeats());
                         $tickets = $tickets . ' / ' . $event->getSeats();
@@ -57,8 +57,8 @@ class HomeAction extends AbstractController
 
                     $info['statistics'][$ticketsLabel] = $tickets;
                 } else {
-                    $info['statistics']['entrées (premier jour)'] = $stats->firstDay->registered;
-                    $info['statistics']['entrées (deuxième jour)'] = $stats->secondDay->registered;
+                    $info['statistics']['entrées (premier jour)'] = $stats->firstDay->confirmed + $stats->firstDay->pending;
+                    $info['statistics']['entrées (deuxième jour)'] = $stats->secondDay->confirmed + $stats->secondDay->pending;
                 }
                 $info['title'] = $event->getTitle();
                 $info['subtitle'] = 'Inscriptions';

--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -203,13 +203,18 @@ class MessageFactory
         $attachment = new Attachment();
         $attachment
             ->setTitle('Total des inscriptions')
-            ->setTitleLink('https://afup.org/pages/administration/index.php?page=forum_inscriptions')
+            ->setTitleLink('https://afup.org/pages/administration/index.php?page=forum_inscriptions&id_forum=' . $event->getId())
         ;
 
-
         if ($event->lastsOneDay()) {
+            $tickets = $eventStats->firstDay->confirmed + $eventStats->firstDay->pending;
+            if ($event->getSeats()) {
+                $percentage = floor(($tickets * 100) / $event->getSeats());
+                $tickets = $tickets . ' / ' . $event->getSeats() . " ($percentage%)";
+            }
+
             $attachment->addField((new Field())->setShort(true)->setTitle('Journée unique')
-                ->setValue($eventStats->firstDay->confirmed + $eventStats->firstDay->pending));
+                ->setValue($tickets));
         } else {
             $attachment
                 ->addField((new Field())->setShort(true)->setTitle('Premier jour')


### PR DESCRIPTION
Pour faire suite à #2013 

Voilà le rendu :
<img width="179" height="73" alt="image" src="https://github.com/user-attachments/assets/605cf574-42c8-494c-9c55-caf16c34bf9a" />

J'ai aussi modifié les quantités indiquées pour avoir les mêmes que la page d'accueil du BO.