### PR TITLE
Refactor de la récupération de l'event dans le BO

### DIFF
--- a/doc/backoffice/event-selector.md
+++ b/doc/backoffice/event-selector.md
@@ -1,0 +1,55 @@
+# Sélecteur d'évènement
+
+Les pages de gestion des events ont (presque) toutes un sélecteur d'event en haut qui permet de switcher le contexte de
+la page en cours d'un event à un autre.
+
+Ce sélecteur ajouter un paramètre `id` dans la query string de l'url et stocke cet id en session, qui est ensuite lu
+quand on navigue dans les pages de la section event. Cela permet de ne pas avoir à re-selectionner un event à chaque fois.
+
+## Utilisation
+
+Pour que ce sélecteur fonctionne, il faut plusieurs éléments dans un controller du backoffice :
+
+```php
+use AppBundle\Event\AdminEventSelection;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ExampleAction extends AbstractController
+{
+    public function __invoke(AdminEventSelection $eventSelection): Response
+    {
+        // Accès direct à l'event sélectionné
+        $event = $eventSelection->event;
+        
+        // ... logique du controller ...
+        
+        return $this->render('admin/event/rooms.html.twig', [
+            // Permet l'affichage du sélecteur
+            'event_select_form' => $eventSelection->selectForm(),
+        ]);
+    }
+}
+```
+Et dans le template :
+
+```html
+{% extends 'admin/base_with_header.html.twig' %}
+
+{% block content %}
+    <h2>Ma super page</h2>
+
+    {% include 'admin/event/change_event.html.twig' with {form: event_select_form} only %}
+
+    <div>
+        Le contenu de la page
+    </div>
+
+{% endblock %}
+```
+
+## Comment ça fonctionne ?
+
+La classe `AdminEventSelection` est injectée automatiquement grâce au [value resolver][value-resolver] `AppBundle\Controller\ValueResolver\AdminEventSelectionValueResolver`.
+
+[value-resolver]: https://symfony.com/doc/current/controller/value_resolver.html#adding-a-custom-value-resolver

--- a/sources/AppBundle/Controller/Admin/Event/BadgesGenerateAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/BadgesGenerateAction.php
@@ -20,7 +20,7 @@ class BadgesGenerateAction
 
     public function __invoke(Request $request): BinaryFileResponse
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'), false);
+        $event = $this->eventActionHelper->getFromRequest('id', false)->event;
         $file = new SplFileObject(sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('badges_', true), 'w+');
         $this->registrationsExportGenerator->export($event, $file);
         $response = new BinaryFileResponse($file, BinaryFileResponse::HTTP_OK, [

--- a/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PendingBankwiresAction.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Event;
 
 use Afup\Site\Forum\Facturation;
-use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Email\Emails;
 use AppBundle\Email\Mailer\MailUser;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Invoice;
 use AppBundle\Event\Model\Repository\InvoiceRepository;
@@ -26,21 +25,19 @@ use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 class PendingBankwiresAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly InvoiceRepository $invoiceRepository,
         private readonly TicketRepository $ticketRepository,
         private readonly Emails $emails,
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
-        private readonly EventSelectFactory $eventSelectFactory,
         private readonly Facturation $facturation,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
         $id = $request->query->get('id');
 
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
 
         if ($request->isMethod(Request::METHOD_POST)) {
             if (!$this->csrfTokenManager->isTokenValid(new CsrfToken('admin_event_bankwires',
@@ -61,7 +58,7 @@ class PendingBankwiresAction extends AbstractController
             'event' => $event,
             'title' => 'Virements en attente',
             'token' => $this->csrfTokenManager->getToken('admin_event_bankwires'),
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 

--- a/sources/AppBundle/Controller/Admin/Event/PricesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAction.php
@@ -4,25 +4,20 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\TicketEventTypeRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class PricesAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly TicketEventTypeRepository $ticketEventTypeRepository,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(AdminEventSelection $eventSelection): Response
     {
-        $id = $request->query->get('id');
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
         $ticketEventTypes = $this->ticketEventTypeRepository->getTicketsByEvent($event);
 
         return $this->render('admin/event/prices.html.twig', [
@@ -30,7 +25,7 @@ class PricesAction extends AbstractController
             'has_prices_defined_with_vat' => $event->hasPricesDefinedWithVat(),
             'event' => $event,
             'title' => 'Liste des prix',
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesAddAction.php
@@ -5,8 +5,7 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Event;
 
 use AppBundle\Association\Form\TicketEventType;
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\TicketEventTypeRepository;
 use AppBundle\Event\Model\Repository\TicketTypeRepository;
 use AppBundle\Event\Model\TicketEventType as ModelTicketEventType;
@@ -20,17 +19,15 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class PricesAddAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly TicketTypeRepository $ticketTypeRepository,
         private readonly TicketEventTypeRepository $ticketEventTypeRepository,
         private readonly ValidatorInterface $validator,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
         $id = $request->query->getInt('event');
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
 
         $ticketEventType = new ModelTicketEventType();
         $ticketEventType->setEventId($event->getId());
@@ -74,7 +71,7 @@ class PricesAddAction extends AbstractController
             'event' => $event,
             'title' => 'Tarifications - Ajouter',
             'button_text' => 'Ajouter',
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/PricesEditAction.php
@@ -21,7 +21,7 @@ class PricesEditAction extends AbstractController
         private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request, $event, $id)
+    public function __invoke(Request $request, int $event, int $id)
     {
         $event = $this->eventActionHelper->getEventById($event);
         $ticketType = $this->ticketTypeRepository->get($id);

--- a/sources/AppBundle/Controller/Admin/Event/ResendSponsorTokenAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/ResendSponsorTokenAction.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\SponsorTicketRepository;
 use AppBundle\Event\Ticket\SponsorTokenMail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,14 +14,12 @@ use Symfony\Component\HttpFoundation\Request;
 class ResendSponsorTokenAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly SponsorTicketRepository $sponsorTicketRepository,
         private readonly SponsorTokenMail $sponsorTokenMail,
     ) {}
 
-    public function __invoke(Request $request): RedirectResponse
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): RedirectResponse
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'));
         $token = $this->sponsorTicketRepository->get($request->request->get('sponsor_token_id'));
         if ($token === null) {
             throw $this->createNotFoundException(sprintf('Could not find token with id: %s', $request->request->get('sponsor_token_id')));
@@ -31,7 +29,7 @@ class ResendSponsorTokenAction extends AbstractController
         $this->addFlash('notice', 'Le mail a été renvoyé');
 
         return $this->redirectToRoute('admin_event_sponsor_ticket', [
-            'id' => $event->getId(),
+            'id' => $eventSelection->event->getId(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/RoomAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/RoomAction.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
+use AppBundle\Event\AdminEventSelection;
 use Symfony\Component\Form\FormView;
-use AppBundle\Controller\Event\EventActionHelper;
 use AppBundle\Event\Form\RoomType;
-use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\RoomRepository;
 use AppBundle\Event\Model\Room;
 use CCMBenchmark\Ting\Repository\CollectionInterface;
@@ -16,21 +15,18 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class RoomAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly FormFactoryInterface $formFactory,
         private readonly RoomRepository $roomRepository,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request)
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
-        $id = $request->query->get('id');
-
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
         $rooms = $this->roomRepository->getByEvent($event);
         $editForms = $this->getFormsForRooms($rooms);
 
@@ -74,7 +70,7 @@ class RoomAction extends AbstractController
             'addForm' => $addForm->createView(),
             'editForms' => array_map(static fn(Form $form): FormView => $form->createView(), $editForms),
             'title' => 'Gestion des salles',
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 

--- a/sources/AppBundle/Controller/Admin/Event/SendLastCallSponsorTokenAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SendLastCallSponsorTokenAction.php
@@ -22,7 +22,7 @@ class SendLastCallSponsorTokenAction extends AbstractController
 
     public function __invoke(Request $request): RedirectResponse
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'), false);
+        $event = $this->eventActionHelper->getFromRequest('id', false)->event;
         /** @var SponsorTicket[] $tokens */
         $tokens = $this->sponsorTicketRepository->getByEvent($event);
         $mailSent = 0;

--- a/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event\Session;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\RoomRepository;
 use AppBundle\Event\Model\Repository\TalkRepository;
@@ -21,21 +20,19 @@ use Symfony\Component\HttpFoundation\Response;
 final class IndexAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
-        private readonly EventSelectFactory $eventSelectFactory,
         private readonly TalkRepository $talkRepository,
         private readonly RoomRepository $roomRepository,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'));
+        $event = $eventSelection->event;
         $sessions = $this->talkRepository->getByEventWithSpeakers($event, false);
 
         return $this->render('event/session/index.html.twig', [
             'event' => $event,
             'sessions' => $sessions,
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
             'calendar' => [
                 'date' => $event->getDateStart()?->format('Y-m-d'),
                 'events' => $this->calendarEvents($sessions),

--- a/sources/AppBundle/Controller/Admin/Event/SpeakerInfosAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakerInfosAction.php
@@ -19,7 +19,7 @@ class SpeakerInfosAction
 
     public function __invoke(Request $request)
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'), false);
+        $event = $this->eventActionHelper->getFromRequest('id', false)->event;
         $speaker = $this->speakerRepository->get($request->get('speaker_id'));
 
         return $this->speakerPage->handleRequest($request, $event, $speaker);

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersExpensesAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
 use AppBundle\SpeakerInfos\SpeakersExpensesStorage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -15,17 +14,15 @@ use Symfony\Component\HttpFoundation\Response;
 class SpeakersExpensesAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly SpeakerRepository $speakerRepository,
         private readonly SpeakersExpensesStorage $speakersExpensesStorage,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
         $id = $request->query->get('id');
 
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
 
         $speakers = $this->speakerRepository->getScheduledSpeakersByEvent($event, true);
         if ($speakers->count() > 0) {
@@ -39,7 +36,7 @@ class SpeakersExpensesAction extends AbstractController
         return $this->render('admin/event/speakers_expenses.html.twig', [
             'event' => $event,
             'speakers' => $speakers,
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpeakersManagementAction.php
@@ -4,27 +4,22 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
 use AppBundle\SpeakerInfos\SpeakersExpensesStorage;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 class SpeakersManagementAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly SpeakerRepository $speakerRepository,
         private readonly SpeakersExpensesStorage $speakersExpensesStorage,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(AdminEventSelection $eventSelection): Response
     {
-        $id = $request->query->get('id');
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
         $speakers = $this->speakerRepository->getScheduledSpeakersByEvent($event, true);
 
         if ($speakers->count() > 0) {
@@ -38,7 +33,7 @@ class SpeakersManagementAction extends AbstractController
         return $this->render('admin/event/speakers_management.html.twig', [
             'event' => $event,
             'speakers' => $speakers,
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SpecialPriceAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Form\TicketSpecialPriceType;
 use AppBundle\Event\Model\Repository\TicketSpecialPriceRepository;
 use AppBundle\Event\Model\TicketSpecialPrice;
@@ -18,17 +17,13 @@ use Symfony\Component\HttpFoundation\Response;
 class SpecialPriceAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly TicketSpecialPriceRepository $ticketSpecialPriceRepository,
-        private readonly EventSelectFactory $eventSelectFactory,
         private readonly Authentication $authentication,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
-        $id = $request->query->get('id');
-
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
 
         $specialPrice = new TicketSpecialPrice();
         $specialPrice
@@ -57,7 +52,7 @@ class SpecialPriceAction extends AbstractController
             'event' => $event,
             'title' => 'Gestion des prix custom',
             'form' => $form->createView(),
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/SponsorTicketAction.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Form\SponsorTokenType;
-use AppBundle\Event\Form\Support\EventSelectFactory;
 use AppBundle\Event\Model\Repository\SponsorTicketRepository;
 use AppBundle\Event\Model\SponsorTicket;
 use AppBundle\Event\Ticket\SponsorTokenMail;
@@ -19,18 +18,14 @@ use Symfony\Component\HttpFoundation\Response;
 class SponsorTicketAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly SponsorTicketRepository $sponsorTicketRepository,
         private readonly SponsorTokenMail $sponsorTokenMail,
-        private readonly EventSelectFactory $eventSelectFactory,
         private readonly Authentication $authentication,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
-        $id = $request->query->get('id');
-
-        $event = $this->eventActionHelper->getEventById($id);
+        $event = $eventSelection->event;
         $tokens = $this->sponsorTicketRepository->getByEvent($event);
         $edit = $request->query->has('ticket');
         if ($edit) {
@@ -65,7 +60,7 @@ class SponsorTicketAction extends AbstractController
             'title' => 'Gestion des inscriptions sponsors',
             'form' => $form->createView(),
             'edit' => $edit,
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Event/StatsAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/StatsAction.php
@@ -26,7 +26,7 @@ class StatsAction extends AbstractController
 
     public function __invoke(Request $request): Response
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('event_id'));
+        $event = $this->eventActionHelper->getFromRequest('event_id')->event;
         if ($comparedEventId = $request->query->get('compared_event_id')) {
             $comparedEvent = $this->eventActionHelper->getEventById($comparedEventId, false);
         } else {

--- a/sources/AppBundle/Controller/Admin/Event/VotesListeAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/VotesListeAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Repository\VoteRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -14,21 +13,18 @@ use Symfony\Component\HttpFoundation\Response;
 final class VotesListeAction extends AbstractController
 {
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
-        private readonly EventSelectFactory $eventSelectFactory,
         private readonly VoteRepository $voteRepository,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
-        $eventId = $request->query->get('id');
-        $event = $this->eventActionHelper->getEventById($eventId);
+        $event = $eventSelection->event;
         $votes = $this->voteRepository->getVotesByEvent($event->getId());
 
         return $this->render('admin/vote/liste.html.twig', [
             'votes' => $votes,
             'event' => $event,
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerListAction.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Speaker;
 
-use AppBundle\Controller\Event\EventActionHelper;
-use AppBundle\Event\Form\Support\EventSelectFactory;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
@@ -22,24 +21,21 @@ class SpeakerListAction
     public const VALID_DIRECTIONS = ['asc', 'desc'];
 
     public function __construct(
-        private readonly EventActionHelper $eventActionHelper,
         private readonly EventRepository $eventRepository,
         private readonly SpeakerRepository $speakerRepository,
         private readonly TalkRepository $talkRepository,
         private readonly Environment $twig,
-        private readonly EventSelectFactory $eventSelectFactory,
     ) {}
 
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
         $sort = $request->query->get('sort', 'name');
         $direction = $request->query->get('direction', 'asc');
         Assertion::inArray($sort, self::VALID_SORTS);
         Assertion::inArray($direction, self::VALID_DIRECTIONS);
         $filter = $request->query->get('filter');
-        $eventId = $request->query->get('id');
 
-        $event = $this->eventActionHelper->getEventById($eventId);
+        $event = $eventSelection->event;
         $speakers = $this->speakerRepository->searchSpeakers($event, $sort, $direction, $filter);
         $talks = [];
         foreach ($speakers as $speaker) {
@@ -58,7 +54,7 @@ class SpeakerListAction
 
         return new Response($this->twig->render('admin/speaker/list.html.twig', [
             'eventId' => $event->getId(),
-            'event_select_form' => $this->eventSelectFactory->create($event, $request)->createView(),
+            'event_select_form' => $eventSelection->selectForm(),
             'events' => $events,
             'speakers' => $speakers,
             'talks' => $talks,

--- a/sources/AppBundle/Controller/Admin/Speaker/SpeakerRegisterAction.php
+++ b/sources/AppBundle/Controller/Admin/Speaker/SpeakerRegisterAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Speaker;
 
 use AppBundle\AuditLog\Audit;
-use AppBundle\Controller\Event\EventActionHelper;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Invoice\InvoiceService;
 use AppBundle\Event\Model\Repository\InvoiceRepository;
 use AppBundle\Event\Model\Repository\SpeakerRepository;
@@ -23,7 +23,6 @@ class SpeakerRegisterAction extends AbstractController
 {
     public function __construct(
         private readonly SpeakerRepository $speakerRepository,
-        private readonly EventActionHelper $eventActionHelper,
         private readonly TalkRepository $talkRepository,
         private readonly TicketRepository $ticketRepository,
         private readonly InvoiceService $invoiceService,
@@ -31,9 +30,9 @@ class SpeakerRegisterAction extends AbstractController
         private readonly Audit $audit,
     ) {}
 
-    public function __invoke(Request $request): RedirectResponse
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): RedirectResponse
     {
-        $event = $this->eventActionHelper->getEventById($request->query->get('id'));
+        $event = $eventSelection->event;
         $talkAggregates = $this->talkRepository->getByEventWithSpeakers($event);
         $nbSpeakers = 0;
 

--- a/sources/AppBundle/Controller/Event/EventActionHelper.php
+++ b/sources/AppBundle/Controller/Event/EventActionHelper.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Event;
 
+use AppBundle\Controller\Admin\Event\RedirectEventFromSessionListener;
+use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 final readonly class EventActionHelper
 {
     public function __construct(
         private EventRepository $eventRepository,
+        private FormFactoryInterface $formFactory,
+        private RequestStack $requestStack,
     ) {}
 
     /**
@@ -36,11 +42,7 @@ final readonly class EventActionHelper
         if (null !== $id) {
             $event = $this->eventRepository->get((int) $id);
         } elseif ($allowFallback) {
-            $event = $this->eventRepository->getNextEvent();
-
-            if (null === $event && null !== ($latestEvent = $this->eventRepository->getLastEvent())) {
-                $event = $latestEvent;
-            }
+            $event = $this->getFromRequest('id', $allowFallback)->event;
         }
 
         if ($event === null) {
@@ -48,5 +50,37 @@ final readonly class EventActionHelper
         }
 
         return $event;
+    }
+
+    public function getFromRequest(string $queryParamName, bool $allowFallback = true): AdminEventSelection
+    {
+        $request = $this->requestStack->getMainRequest();
+
+        // L'id dans l'URL est prioritaire sur celui de la session
+        $selectedEventId = $request->query->get($queryParamName) ?? $request->getSession()->get(RedirectEventFromSessionListener::SESSION_KEY);
+
+        // Si l'id est présent dans l'URL, il est stocké en session
+        if ($request->query->has($queryParamName)) {
+            $request->getSession()->set(RedirectEventFromSessionListener::SESSION_KEY, $selectedEventId);
+        }
+
+        $selectedEvent = $this->eventRepository->get($selectedEventId);
+        if ($selectedEvent === null && $allowFallback) {
+            $selectedEvent = $this->eventRepository->getNextEvent() ?? $this->eventRepository->getLastEvent();
+        }
+
+        if ($selectedEvent === null) {
+            if ($request->query->has($queryParamName)) {
+                // Si l'id n'existe pas, erreur 404
+                throw new NotFoundHttpException("Event $selectedEventId inexistant");
+            }
+
+            throw new NotFoundHttpException("Impossible de trouver le bon event");
+        }
+
+        return new AdminEventSelection(
+            $this->formFactory,
+            $selectedEvent,
+        );
     }
 }

--- a/sources/AppBundle/Controller/ValueResolver/AdminEventSelectionValueResolver.php
+++ b/sources/AppBundle/Controller/ValueResolver/AdminEventSelectionValueResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\ValueResolver;
+
+use AppBundle\Controller\Event\EventActionHelper;
+use AppBundle\Event\AdminEventSelection;
+use Symfony\Component\DependencyInjection\Attribute\AsTaggedItem;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+#[AsTaggedItem(index: 'admin_event_selection', priority: 150)]
+final readonly class AdminEventSelectionValueResolver implements ValueResolverInterface
+{
+    public function __construct(
+        private EventActionHelper $eventActionHelper,
+    ) {}
+
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        $argumentType = $argument->getType();
+
+        if ($argumentType !== AdminEventSelection::class) {
+            return [];
+        }
+
+        return [
+            $this->eventActionHelper->getFromRequest('id'),
+        ];
+    }
+}

--- a/sources/AppBundle/Event/AdminEventSelection.php
+++ b/sources/AppBundle/Event/AdminEventSelection.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Event;
+
+use AppBundle\Event\Form\EventSelectType;
+use AppBundle\Event\Model\Event;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormView;
+
+final readonly class AdminEventSelection
+{
+    public function __construct(
+        private FormFactoryInterface $formFactory,
+        public Event $event,
+    ) {}
+
+    public function selectForm(): FormView
+    {
+        return $this->formFactory->create(EventSelectType::class, $this->event, [
+            'data' => $this->event,
+        ])->createView();
+    }
+}


### PR DESCRIPTION
Le sélecteur d'event écrit l'id sélectionné en session, qui n'était pas toujours utilisé pour récupérer le bon event.

Cela peut créer une situation oû le sélecteur affiche un event mais les données de la page en concernent un autre (le plus récent).

Dans la majorité des cas il suffit d'injecter la classe `AdminEventSelection` qui va s'occuper de récupérer correctement le bon event.