### PR TITLE
Refonte - Événements > Conférences - Liste

### DIFF
--- a/app/config/packages/backoffice_menu.yaml
+++ b/app/config/packages/backoffice_menu.yaml
@@ -160,6 +160,9 @@ parameters:
                 forum_sessions:
                     nom: 'Conférences'
                     niveau: 'ROLE_FORUM'
+                    url: '/admin/talk/'
+                    extra_routes:
+                        - admin_talk_list
                 forum_vote_github:
                     nom: 'Votes visiteurs'
                     niveau: 'ROLE_FORUM'

--- a/app/config/routing/admin_talk.yml
+++ b/app/config/routing/admin_talk.yml
@@ -1,3 +1,7 @@
+admin_talk_list:
+  path: /
+  defaults: {_controller: AppBundle\Controller\Admin\Talk\IndexAction}
+
 admin_talk_export_joind_in:
   path: /export/joind-in/{eventId}/
   defaults: {_controller: AppBundle\Controller\Admin\Talk\ExportJoindInAction}
@@ -8,6 +12,6 @@ admin_talk_export:
   path: /export
   defaults: {_controller: AppBundle\Controller\Admin\Talk\ExportAction}
 
-admin_talk_index:
+admin_talk_indexation:
   path: /update_indexation
   defaults: {_controller: AppBundle\Controller\Admin\Talk\UpdateIndexationAction}

--- a/db/migrations/20251229135635_planning_index_session.php
+++ b/db/migrations/20251229135635_planning_index_session.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class PlanningIndexSession extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_forum_planning')
+            ->addIndex(['id_session'])
+            ->update();
+    }
+}

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -103,9 +103,9 @@ if ($action == 'lister') {
 } elseif ($action == 'supprimer') {
     if ($forum_appel->supprimerSession($_GET['id'])) {
         Logs::log('Suppression de la session ' . $_GET['id']);
-        afficherMessage('La session a été supprimée', 'index.php?page=forum_sessions&action=lister&type=' . $list_type);
+        afficherMessage('La session a été supprimée', '/admin/talk/');
     } else {
-        afficherMessage('Une erreur est survenue lors de la suppression de la session', 'index.php?page=forum_sessions&action=lister&type=' . $list_type, true);
+        afficherMessage('Une erreur est survenue lors de la suppression de la session', '/admin/talk/', true);
     }
 } else {
     $pays = new Pays($bdd);

--- a/htdocs/pages/administration/forum_sessions.php
+++ b/htdocs/pages/administration/forum_sessions.php
@@ -67,7 +67,7 @@ if ($action == 'lister') {
 
     $smarty->assign('forums', $forum->obtenirListe());
 
-    $listeSessions = $forum_appel->obtenirListeSessions($_GET['id_forum'], $list_champs, $list_ordre, $list_associatif, $list_filtre,$list_type, $needsMentoring, $planned);
+    $listeSessions = [];
     $moi = $droits->obtenirIdentifiant();
     $votant = in_array($_SESSION['afup_login'] ?? '', []);
     $maxVotant = count([]);
@@ -300,7 +300,7 @@ if ($action == 'lister') {
             } else {
                 Logs::log('Modification de la session de ' . $formulaire->exportValue('titre') . ' (' . $_GET['id'] . ')');
             }
-            afficherMessage('La session a été ' . (($action == 'ajouter') ? 'ajoutée' : 'modifiée'), 'index.php?page=forum_sessions&action=lister&id_forum=' . $valeurs['id_forum']);
+            afficherMessage('La session a été ' . (($action == 'ajouter') ? 'ajoutée' : 'modifiée'), '/admin/talk/?id=' . $valeurs['id_forum']);
         } else {
             $smarty->assign('erreur', 'Une erreur est survenue lors de ' . (($action == 'ajouter') ? "l'ajout" : 'la modification') . ' de la session');
         }

--- a/sources/Afup/Forum/AppelConferencier.php
+++ b/sources/Afup/Forum/AppelConferencier.php
@@ -218,59 +218,6 @@ class AppelConferencier
         }
     }
 
-    public function obtenirListeSessions($id_forum = null,
-                                  string $champs = 's.*',
-                                  string $ordre = 's.date_soumission',
-                                  $associatif = false,
-                                  $filtre = false,
-                                  $type = 'session',
-                                  $needsMentoring = null,
-                                  $planned = null,
-    ) {
-        $requete = ' SELECT ';
-        $requete .= '  COUNT(co.id) as commentaires_nombre, ';
-        $requete .= ' (SELECT AVG(vote) FROM afup_sessions_vote_github asvg WHERE asvg.session_id = s.session_id) AS note, ';
-        $requete .= ' (SELECT COUNT(vote) FROM afup_sessions_vote_github asvg WHERE asvg.session_id = s.session_id) AS nb_vote_visiteur, ';
-        $requete .= '  ' . $champs . ' ';
-        $requete .= ' FROM ';
-        $requete .= '  afup_sessions s ';
-        $requete .= ' LEFT JOIN afup_forum_sessions_commentaires co ';
-        $requete .= '  ON s.session_id = co.id_session ';
-
-        if (null !== $planned) {
-            $requete .= ' JOIN afup_forum_planning ON (s.session_id = afup_forum_planning.id_session) ';
-        }
-
-        $requete .= ' WHERE s.id_forum = ' . $this->_bdd->echapper($id_forum);
-        if ($filtre) {
-            $requete .= ' AND s.titre LIKE \'%' . $filtre . '%\' ';
-        }
-        switch ($type) {
-            case 'session':
-                $requete .= ' AND s.genre < 9 ';
-                break;
-            case 'projet':
-                $requete .= ' AND s.genre = 9 ';
-                break;
-
-            default:
-                ;
-                break;
-        }
-
-        if (null !== $needsMentoring) {
-            $requete .= ' AND s.needs_mentoring = ' . ((int) $needsMentoring);
-        }
-
-        $requete .= ' GROUP BY s.session_id ';
-        $requete .= ' ORDER BY ' . $ordre;
-        if ($associatif) {
-            return $this->_bdd->obtenirAssociatif($requete);
-        } else {
-            return $this->_bdd->obtenirTous($requete);
-        }
-    }
-
     public function modifierSession(
         $id,
         $id_forum,

--- a/sources/AppBundle/Controller/Admin/Talk/IndexAction.php
+++ b/sources/AppBundle/Controller/Admin/Talk/IndexAction.php
@@ -68,7 +68,7 @@ final class IndexAction extends AbstractController
         ]);
     }
 
-    public function filterForm(array $data): FormInterface
+    private function filterForm(array $data): FormInterface
     {
         return $this->formFactory->createNamedBuilder('', FormType::class, $data, [
             'csrf_protection' => false,

--- a/sources/AppBundle/Controller/Admin/Talk/IndexAction.php
+++ b/sources/AppBundle/Controller/Admin/Talk/IndexAction.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Talk;
+
+use AppBundle\Event\AdminEventSelection;
+use AppBundle\Event\Model\Repository\TalkRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IndexAction extends AbstractController
+{
+    public function __construct(
+        private readonly FormFactoryInterface $formFactory,
+        private readonly TalkRepository $talkRepository,
+    ) {}
+
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
+    {
+        //TODO : à supprimer quand les actions via le formulaire auront été migrées
+        if (isset($_SESSION['flash']['message'])) {
+            $this->addFlash('notice', $_SESSION['flash']['message']);
+        }
+        if (isset($_SESSION['flash']['erreur'])) {
+            $this->addFlash('error', $_SESSION['flash']['erreur']);
+        }
+        unset($_SESSION['flash']);
+
+        $event = $eventSelection->event;
+
+        $data = [
+            'id' => $event->getId(),
+        ];
+        $filterForm = $this->filterForm($data);
+        $filterForm->handleRequest($request);
+
+        if ($filterForm->isSubmitted() && $filterForm->isValid()) {
+            $data = $filterForm->getData();
+            $data = array_filter($data);
+        }
+
+        $data['sort_key'] ??= 'talk.date_soumission';
+        $data['sort_direction'] ??= 'asc';
+
+        $sessions = $this->talkRepository->getByEventWithSpeakersAndVotes(
+            event: $event,
+            search: $data['q'] ?? '',
+            orderBy: $data['sort_key'] . ' ' . $data['sort_direction'],
+            planned: $data['planned'] ?? false,
+            needMentoring: $data['needs_mentoring'] ?? false,
+        );
+
+        return $this->render('admin/talk/index.html.twig', [
+            'event' => $event,
+            'filter_form' => $filterForm,
+            'filter' => $data,
+            'event_select_form' => $eventSelection->selectForm(),
+            'sessions' => $sessions,
+        ]);
+    }
+
+    public function filterForm(array $data): FormInterface
+    {
+        return $this->formFactory->createNamedBuilder('', FormType::class, $data, [
+            'csrf_protection' => false,
+        ])
+            ->setMethod('GET')
+            ->add('q', TextType::class, ['required' => false])
+            ->add('needs_mentoring', CheckboxType::class, ['required' => false])
+            ->add('planned', CheckboxType::class, ['required' => false])
+            ->add('id', HiddenType::class, ['required' => false])
+            ->add('sort_key', HiddenType::class, ['required' => false])
+            ->add('sort_direction', HiddenType::class, ['required' => false])
+            ->add('submit', SubmitType::class)
+            ->getForm();
+    }
+}

--- a/sources/AppBundle/Event/Model/TalkAggregate.php
+++ b/sources/AppBundle/Event/Model/TalkAggregate.php
@@ -12,5 +12,6 @@ final readonly class TalkAggregate
         public array $speakers,
         public ?Room $room,
         public ?Planning $planning,
+        public ?TalkAggregateVote $vote = null,
     ) {}
 }

--- a/sources/AppBundle/Event/Model/TalkAggregateVote.php
+++ b/sources/AppBundle/Event/Model/TalkAggregateVote.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Event\Model;
+
+final readonly class TalkAggregateVote
+{
+    public function __construct(
+        public float $note,
+        public int $total,
+    ) {}
+}

--- a/templates/admin/talk/index.html.twig
+++ b/templates/admin/talk/index.html.twig
@@ -1,0 +1,255 @@
+{% extends 'admin/base_with_header.html.twig' %}
+
+
+{% block content %}
+    <h2>Conférences</h2>
+    {% include 'admin/event/change_event.html.twig' with {form: event_select_form} only %}
+
+    <div class="ui menu">
+        <a href="/pages/administration/index.php?page=forum_sessions&amp;action=ajouter&amp;id_forum={{ event.id }}" class="item">
+            <div data-tooltip="Ajouter une conférence"
+                 data-position="bottom left">
+                <i class="icon plus square"></i>
+                Ajouter
+            </div>
+        </a>
+        <a href="{{ path('admin_talk_export', {id: event.id}) }}" class="item">
+            <div data-tooltip="Exporter les inscriptions pour les badges"
+                 data-position="bottom left">
+                <i class="icon file"></i>
+                Exporter les conférences
+            </div>
+        </a>
+        <a href="{{ path('admin_talk_export_joind_in', {eventId: event.id}) }}" class="item">
+            <div data-tooltip="Télécharger un fichier CSV des conférences pour joind.in"
+                 data-position="bottom left">
+                <i class="icon file"></i>
+                Export joindIn
+            </div>
+        </a>
+        <a href="{{ path('admin_talk_indexation') }}" class="item">
+            <div data-tooltip="Met à jour algolia, permet d'avoir la liste des talks publique à jour"
+                 data-position="bottom left">
+                <i class="icon algolia"></i>
+                Indexer toutes les conférences
+            </div>
+        </a>
+    </div>
+
+    <div class="ui segment">
+        {% form_theme filter_form 'form_theme_admin_filter.html.twig' %}
+
+        {{ form_start(filter_form) }}
+        <div class="ui form">
+            <div class="inline fields">
+                {{ form_row(filter_form.q, {label: 'Titre'}) }}
+                {{ form_row(filter_form.needs_mentoring, {label: 'Afficher seulement les conférences dont le speaker a demandé un accompagnement'}) }}
+                {{ form_row(filter_form.planned, {label: 'Afficher seulement les conférences plannifiées'}) }}
+                {{ form_row(filter_form.submit, {label: 'Filtrer'}) }}
+            </div>
+        </div>
+        {{ form_end(filter_form) }}
+
+        <div class="ui mini horizontal statistic">
+            <div class="value">
+                {{ sessions|length }}
+            </div>
+            <div class="label">
+                conférence(s)
+            </div>
+        </div>
+
+
+        {% if sessions|length %}
+            {% set sort_direction = filter.sort_direction == 'asc' ? 'desc' : 'asc'%}
+            <table class="ui table striped compact celled">
+                <thead>
+                <tr>
+                    <th>
+                        <a href="{{ url('admin_talk_list', filter|merge({sort_key: 'talk.date_soumission', sort_direction: sort_direction})) }}">
+                            Soumission
+                        </a>
+                    </th>
+                    <th>
+                        <a href="{{ url('admin_talk_list', filter|merge({sort_key: 'talk.titre', sort_direction: sort_direction})) }}">
+                            Titre
+                        </a>
+                    </th>
+                    <th>Speaker(s)</th>
+                    <th class="right aligned" data-position="bottom center" data-tooltip="Moyenne notes visiteurs (sur 5)">Moy. notes</th>
+                    <th class="right aligned" data-position="bottom center" data-tooltip="Nombre notes visiteurs">Nb. notes</th>
+                    <th>
+                        <div class="ui small basic icon buttons">
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de demande d'accompagnement de la part du speaker">
+                                <i class="universal access icon grey"></i>
+                            </span>
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de présence de l'ID joindIn">
+                                <i class="comment icon grey"></i>
+                            </span>
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de présence de vidéo">
+                                <i class="youtube icon grey"></i>
+                            </span>
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de présence de slides">
+                                <i class="slideshare icon grey"></i>
+                            </span>
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de présence de transcript en article de blog">
+                                <i class="newspaper icon grey"></i>
+                            </span>
+                            <span class="ui button" data-position="left center"
+                                  data-tooltip="Indicateur de présence d'interview">
+                                <i class="rss icon grey"></i>
+                            </span>
+                        </div>
+                    </th>
+                    <th>&nbsp;</th>
+                </tr>
+                </thead>
+                <tbody>
+
+                {% for aggregate in sessions %}
+                    {% set edit_url = "/pages/administration/index.php?page=forum_sessions&action=modifier&id="~aggregate.talk.id %}
+                    <tr>
+                        <td class="single line">{{ aggregate.talk.submittedOn|date('d/m/Y') }}</td>
+                        <td>{{ aggregate.talk.title }}</td>
+                        <td>
+                            <div class="ui list">
+                                {% for speaker in aggregate.speakers %}
+                                <div class="item">
+                                    <i class="microphone icon"></i>
+                                    <div class="content">
+                                        <a href="{{ url('admin_speaker_edit', {id: speaker.id}) }}">
+                                            {{ speaker.label }}
+                                        </a>
+                                    </div>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </td>
+                        <td class="right aligned">
+                            {{ aggregate.vote ? aggregate.vote.note|number_format(1, ',') : "n/a" }}
+                        </td>
+                        <td class="right aligned">
+                            {{ aggregate.vote ? aggregate.vote.total : 0 }}
+                        </td>
+                        <td>
+                            <div class="ui small basic icon buttons">
+
+                                {% if aggregate.talk.needsMentoring %}
+                                    <a class="ui button"
+                                       href="{{ edit_url }}"
+                                       data-position="top center"
+                                       data-tooltip="Le speaker a demandé un accompagnement"
+                                    >
+                                        <i class="icon universal access"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+
+                                {% if aggregate.talk.joindinUrl %}
+                                    <a class="ui button"
+                                       href="{{ aggregate.talk.joindinUrl }}"
+                                       target="_blank"
+                                       data-position="top center"
+                                       data-tooltip="L'id joindIn est renseigné">
+                                        <i class="icon comment"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+
+                                {% if aggregate.talk.youtubeUrl %}
+                                    <a class="ui button" target="_blank"
+                                       href="{{ aggregate.talk.youtubeUrl }}"
+                                       data-position="top center"
+                                       data-tooltip="La conférence a une vidéo">
+                                        <i class="icon youtube"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+
+                                {% if aggregate.talk.slidesUrl %}
+                                    <a class="ui button" target="_blank"
+                                       href="{{ aggregate.talk.slidesUrl }}"
+                                       data-position="top center"
+                                       data-tooltip="La conférence a des slides">
+                                        <i class="icon slideshare"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+
+                                {% if aggregate.talk.interviewUrl %}
+                                    <a class="ui button" target="_blank"
+                                       href="{{ aggregate.talk.interviewUrl }}"
+                                       data-position="top center"
+                                       data-tooltip="La conférence a une interview">
+                                        <i class="icon newspaper"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+
+                                {% if aggregate.talk.blogPostUrl %}
+                                    <a class="ui button" target="_blank"
+                                       href="{{ aggregate.talk.blogPostUrl }}"
+                                       data-position="top center"
+                                       data-tooltip="La conférence a un transcript">
+                                        <i class="icon rss"></i>
+                                    </a>
+                                {% else %}
+                                    <span class="ui button disabled">
+                                        <i class="icon"></i>
+                                    </span>
+                                {% endif %}
+                            </div>
+                        </td>
+                        <td class="single line right aligned">
+                            <a href="{{ edit_url }}"
+                               data-position="left center"
+                               data-tooltip="Modifier la conférence {{ aggregate.talk.title }}"
+                               class="compact ui icon button"
+                            >
+                                <i class="pencil alernate icon"></i>
+                            </a>
+                            <a href="index.php?page=forum_sessions&amp;action=supprimer&amp;id={{ aggregate.talk.id }}"
+                               data-position="left center"
+                               data-tooltip="Supprimer la conférence {{ aggregate.talk.title }}"
+                               class="compact ui red icon button confirmable"
+                               data-confirmable-label="Etes-vous sûr de vouloir supprimer la session {{ aggregate.talk.title }} ?"
+                            >
+                                <i class="trash icon"></i>
+                            </a>
+                        </td>
+                    </tr>
+
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="ui placeholder segment">
+                <div class="ui icon header">
+                    <i class="meh outline icon"></i>
+                    Aucune conférence
+                </div>
+            </div>
+        {% endif %}
+
+    </div>
+{% endblock %}

--- a/templates/admin/talk/index.html.twig
+++ b/templates/admin/talk/index.html.twig
@@ -228,7 +228,7 @@
                             >
                                 <i class="pencil alernate icon"></i>
                             </a>
-                            <a href="index.php?page=forum_sessions&amp;action=supprimer&amp;id={{ aggregate.talk.id }}"
+                            <a href="/pages/administration/index.php?page=forum_sessions&amp;action=supprimer&amp;id={{ aggregate.talk.id }}"
                                data-position="left center"
                                data-tooltip="Supprimer la conférence {{ aggregate.talk.title }}"
                                class="compact ui red icon button confirmable"

--- a/templates/form_theme_admin_filter.html.twig
+++ b/templates/form_theme_admin_filter.html.twig
@@ -1,0 +1,27 @@
+{% use 'form_div_layout.html.twig' %}
+
+{%- block form_label -%}
+    {{ parent() }}
+{%- endblock form_label -%}
+
+{%- block form_row -%}
+    <div class="field">
+        {{ form_label(form) }}
+        {{ form_widget(form) }}
+        {{ form_errors(form) }}
+    </div>
+{%- endblock form_row -%}
+
+{%- block checkbox_row -%}
+    <div class="field">
+        <div class="ui checkbox">
+            <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+            {{ form_label(form) }}
+        </div>
+    </div>
+{%- endblock checkbox_row -%}
+
+
+{%- block button_attributes -%}
+{{  parent() }} class="ui button"
+{%- endblock button_attributes -%}

--- a/tests/behat/features/Admin/Events/Conferences.feature
+++ b/tests/behat/features/Admin/Events/Conferences.feature
@@ -12,7 +12,7 @@ Feature: Administration - Évènements - Conférences
     And the "table" element should contain "Moy. notes"
     And the "table" element should contain "Nb. notes"
     And the "table" element should contain "Soumission"
-    When I fill in "filtre" with "Jouons"
+    When I fill in "q" with "Jouons"
     And I press "Filtrer"
     Then I should see "1 CONFÉRENCE(S)"
 
@@ -34,9 +34,9 @@ Feature: Administration - Évènements - Conférences
     And I press "Soumettre"
     Then I should see "La session a été ajoutée"
     And I should see "4 CONFÉRENCE(S)"
-    And I should see "2022-01-01"
+    And I should see "01/01/2022"
     And I should see "Une autre conference"
-    And I should see "Gallou Adrien"
+    And I should see "Adrien Gallou"
 
   @reloadDbWithTestData
   Scenario: Modification d'une conférence
@@ -55,9 +55,9 @@ Feature: Administration - Évènements - Conférences
     And I press "Soumettre"
     Then I should see "La session a été modifiée"
     And I should see "3 CONFÉRENCE(S)"
-    And I should see "2022-12-31"
+    And I should see "31/12/2022"
     And I should see "Jouons à un jeu"
-    And I should see "Gallou Adrien"
+    And I should see "Adrien Gallou"
 
   @reloadDbWithTestData
   Scenario: Exporter les conférences

--- a/tests/behat/features/Admin/Events/Conferences.feature
+++ b/tests/behat/features/Admin/Events/Conferences.feature
@@ -60,6 +60,17 @@ Feature: Administration - Évènements - Conférences
     And I should see "Adrien Gallou"
 
   @reloadDbWithTestData
+  Scenario: Suppression d'une conférence
+    Given I am logged in as admin and on the Administration
+    And I follow "Conférences"
+    Then the ".content h2" element should contain "Conférence"
+    And I should see "3 CONFÉRENCE(S)"
+    When I follow the button of tooltip "Supprimer la conférence Jouons tous ensemble à un petit jeu"
+    Then I should see "La session a été supprimée"
+    And I should not see "Jouons tous ensemble à un petit jeu"
+    And I should see "2 CONFÉRENCE(S)"
+
+  @reloadDbWithTestData
   Scenario: Exporter les conférences
     Given I am logged in as admin and on the Administration
     And I follow "Conférences"


### PR DESCRIPTION
Refonte de la liste des conférences.
Reprise de la requête SQL dans Ting et optimisation en ajoutant un index sur la table `afup_forum_planning`.
Correction des tris des colonnes.

Avant : 
<img width="1680" height="1050" alt="Capture d’écran 2025-12-20 à 14 16 50" src="https://github.com/user-attachments/assets/c5bcbd74-a924-4373-8264-d682ec01a263" />


Après : 
<img width="1680" height="1050" alt="Capture d’écran 2025-12-20 à 14 18 02" src="https://github.com/user-attachments/assets/aa9c3997-c6c7-4ba7-b7cc-c516a966242a" />
