### PR TITLE
Correction erreurs de typage (phpstan 5)

### DIFF
--- a/sources/AppBundle/Association/Model/Repository/UserRepository.php
+++ b/sources/AppBundle/Association/Model/Repository/UserRepository.php
@@ -335,11 +335,11 @@ class UserRepository extends Repository implements MetadataInitializer, UserProv
     }
 
     /**
-     * @param int $countryId Country's identifier
+     * @param string $countryId Country's identifier
      *
      * @return bool TRUE if the country exists, FALSE otherwise
      */
-    private function countryExists($countryId): bool
+    private function countryExists(string $countryId): bool
     {
         return 0 < $this->getQuery('SELECT 1 FROM afup_pays WHERE id = :id')
                 ->setParams(['id' => $countryId])

--- a/sources/AppBundle/Association/Model/TechletterUnsubscription.php
+++ b/sources/AppBundle/Association/Model/TechletterUnsubscription.php
@@ -28,10 +28,7 @@ class TechletterUnsubscription implements NotifyPropertyInterface
      */
     private $reason;
 
-    /**
-     * @var string
-     */
-    private $mailchimpId;
+    private ?string $mailchimpId = null;
 
     /**
      * @return int
@@ -122,12 +119,7 @@ class TechletterUnsubscription implements NotifyPropertyInterface
         return $this->mailchimpId;
     }
 
-    /**
-     * @param string $mailchimpId
-     *
-     * @return $this
-     */
-    public function setMailchimpId($mailchimpId): self
+    public function setMailchimpId(?string $mailchimpId): self
     {
         $this->propertyChanged('mailchimpId', $this->mailchimpId, $mailchimpId);
         $this->mailchimpId = $mailchimpId;

--- a/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
+++ b/sources/AppBundle/Command/DevCallBackPayboxCotisationCommand.php
@@ -45,7 +45,7 @@ EOF;
 
         $curl = curl_init($url);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
+        curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 0);
         curl_exec($curl);
 
         $output->writeln("Appel au callback de paiement de cotisation effectué");

--- a/sources/AppBundle/Controller/Planete/ArticlesController.php
+++ b/sources/AppBundle/Controller/Planete/ArticlesController.php
@@ -16,7 +16,7 @@ final readonly class ArticlesController
     public function __invoke(Request $request): Response
     {
         $perPage = 20;
-        $page = (int) $request->query->get("page", 1);
+        $page = $request->query->getInt("page", 1);
 
         if ($page < 1) {
             $page = 1;

--- a/sources/AppBundle/Payment/PayboxFactory.php
+++ b/sources/AppBundle/Payment/PayboxFactory.php
@@ -33,7 +33,7 @@ class PayboxFactory
         $now = new \DateTime();
 
         $paybox
-            ->setTotal($montant * 100) // Total de la commande, en centimes d'euros
+            ->setTotal((int) $montant * 100) // Total de la commande, en centimes d'euros
             ->setCmd($facture) // Référence de la commande
             ->setPorteur($email) // Email du client final (Le porteur de la carte)
             ->setUrlRetourEffectue($this->router->generate('membership_payment_redirect', ['type' => 'success'], RouterInterface::ABSOLUTE_URL))

--- a/sources/AppBundle/Payment/PayboxResponseFactory.php
+++ b/sources/AppBundle/Payment/PayboxResponseFactory.php
@@ -24,7 +24,7 @@ class PayboxResponseFactory
         return new PayboxResponse(
             $query->get('cmd'),
             $query->get('status'),
-            $query->get('total'),
+            $query->getInt('total'),
             $query->get('autorisation'),
             $query->get('transaction'),
         );


### PR DESCRIPTION
Avant il y avait 23 erreurs sur le niveau 5
[before.txt](https://github.com/user-attachments/files/24273370/before.txt)

Après il en reste 16
[after.txt](https://github.com/user-attachments/files/24273369/after.txt)