### PR TITLE
Suppression de variables d'env non-utilisées

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -68,8 +68,6 @@ SMTP_PORT=1025
 SMTP_TLS=0
 SMTP_USERNAME=""
 SMTP_PASSWORD=""
-MAILER_FORCE_RECIPIENTS=""
-MAILER_BCC=""
 
 QR_CODE_SALT=""
 # https://symfony.com/doc/current/reference/configuration/framework.html#ide

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -24,8 +24,6 @@ parameters:
     smtp_username: ""
     smtp_password: ""
     smtp_port: 1025
-    mailer_force_recipients: []
-    mailer_bcc: []
 
 services:
     AppBundle\Offices\OfficeFinder:

--- a/sources/Afup/Utils/Configuration.php
+++ b/sources/Afup/Utils/Configuration.php
@@ -23,7 +23,6 @@ class Configuration
         $parameters = [
             'database_host', 'database_name', 'database_user', 'database_password', 'database_port',
             'smtp_host', 'smtp_port', 'smtp_tls', 'smtp_username', 'smtp_password',
-            'mailer_force_recipients', 'mailer_bcc',
         ];
 
         foreach ($parameters as $param) {

--- a/sources/Afup/Utils/Mail.php
+++ b/sources/Afup/Utils/Mail.php
@@ -22,7 +22,6 @@ class Mail
             new NullLogger(),
             new Environment(new FilesystemLoader(self::PROJECT_DIR . '/templates/')),
             PhpMailerAdapter::createFromConfiguration($configuration),
-            $configuration,
         );
     }
 }

--- a/sources/AppBundle/Email/Mailer/Mailer.php
+++ b/sources/AppBundle/Email/Mailer/Mailer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AppBundle\Email\Mailer;
 
-use Afup\Site\Utils\Configuration;
 use AppBundle\Email\Mailer\Adapter\MailerAdapter;
 use Psr\Log\LoggerInterface;
 use Twig\Environment;
@@ -14,38 +13,20 @@ use Twig\Environment;
  */
 class Mailer
 {
-    /** @var string|null */
-    private $forcedRecipient;
-    /** @var string[] */
-    private readonly array $defaultBccs;
-
     public function __construct(
         private readonly LoggerInterface $logger,
         private readonly Environment $twig,
         private readonly MailerAdapter $adapter,
-        Configuration $configuration,
-    ) {
-        $this->forcedRecipient = $configuration->obtenir('mailer_force_recipients');
-        $defaultBccs = $configuration->obtenir('mailer_bcc');
-        $this->defaultBccs = is_array($defaultBccs) ? $defaultBccs : [$defaultBccs];
-    }
+    ) {}
 
     /**
      * @return boolean true on success, false on failure
      */
-    public function send(Message $message, $addDefaultBccs = false): bool
+    public function send(Message $message): bool
     {
         try {
             if (!$message->getFrom() instanceof MailUser) {
                 $message->setFrom(MailUserFactory::afup());
-            }
-            if ($this->forcedRecipient) {
-                $message->addRecipient(new MailUser($this->forcedRecipient));
-            }
-            if ($addDefaultBccs) {
-                foreach ($this->defaultBccs as $bcc) {
-                    $message->addBcc(new MailUser($bcc));
-                }
             }
             $this->adapter->send($message);
 


### PR DESCRIPTION
Ces variables ne sont pas présentes ni en prod ni en preprod.

En local il y a mailcatcher donc pas besoin non plus.