### PR TITLE
Déplacement des tests des rules PHPStan dans les tests d'intégration

### DIFF
--- a/tests/integration/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRuleTest.php
+++ b/tests/integration/AppBundle/StaticAnalysis/Rule/NoDebugFunctionsRuleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AppBundle\Tests\StaticAnalysis\Rule;
+namespace AppBundle\IntegrationTests\StaticAnalysis\Rule;
 
 use AppBundle\StaticAnalysis\Rule\NoDebugFunctionsRule;
 use PHPStan\Rules\Rule;

--- a/tests/integration/AppBundle/StaticAnalysis/Rule/NoGetUserMethodRuleTest.php
+++ b/tests/integration/AppBundle/StaticAnalysis/Rule/NoGetUserMethodRuleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace AppBundle\Tests\StaticAnalysis\Rule;
+namespace AppBundle\IntegrationTests\StaticAnalysis\Rule;
 
 use AppBundle\StaticAnalysis\Rule\NoGetUserMethodRule;
 use PHPStan\Rules\Rule;


### PR DESCRIPTION
Cela semble plus logique, et permet de retrouver une exécution instantanée des tests unitaires.