### PR TITLE
Correction de l'obligation du champ content d'un article

### DIFF
--- a/sources/AppBundle/Site/Form/ArticleType.php
+++ b/sources/AppBundle/Site/Form/ArticleType.php
@@ -76,14 +76,16 @@ class ArticleType extends AbstractType
             ])
             ->add('content', TextareaType::class, [
                 'label' => 'Contenu',
-                'required' => true,
+                // Désactive la validation HTML5, nécessaire à cause du wysiwyg qui masque l'input
+                // tout en le mettant à required, ce qui bloque la soumission du formulaire.
+                'required' => false,
                 'attr' => [
                     'cols' => 42,
                     'rows' => 20,
                     'class' => $textareaCssClass,
                 ],
                 'constraints' => [
-                    new Assert\NotBlank(),
+                    new Assert\NotBlank(message: 'Ce champ est obligatoire'),
                     new Assert\Type('string'),
                 ],
             ])


### PR DESCRIPTION
Le wysiwyg masque l'input avec un `display: none;` tout en gardant l'attribut `required`.

Au moment de la validation du formulaire, le navigateur voit le champ vide, tente d'afficher qu'il est requis, mais ne peut pas car il est masqué et donc il ne se passe rien de visuel (il y a une erreur dans la console).