### PR TITLE
Fusion des constantes du status d'un event

### DIFF
--- a/db/seeds/Inscriptions.php
+++ b/db/seeds/Inscriptions.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use AppBundle\Event\Model\Ticket;
 use Phinx\Seed\AbstractSeed;
 
 class Inscriptions extends AbstractSeed
@@ -23,7 +24,7 @@ class Inscriptions extends AbstractSeed
                 'newsletter_afup' => '1',
                 'newsletter_nexen' => '0',
                 'id_forum' => Event::ID_FORUM,
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
             ],
             [
                 'reference' => 'REF-TEST-002',
@@ -38,7 +39,7 @@ class Inscriptions extends AbstractSeed
                 'newsletter_afup' => '1',
                 'newsletter_nexen' => '0',
                 'id_forum' => Event::ID_FORUM,
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
             ],
             [
                 'reference' => 'REF-TEST-003',
@@ -53,7 +54,7 @@ class Inscriptions extends AbstractSeed
                 'newsletter_afup' => '1',
                 'newsletter_nexen' => '0',
                 'id_forum' => Event::ID_FORUM,
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
             ],
         ];
 
@@ -81,7 +82,7 @@ class Inscriptions extends AbstractSeed
                 'id_pays' => 'FR',
                 'autorisation' => 'otzbfksgve',
                 'transaction' => 'taedsken',
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
                 'facturation' => 0,
                 'id_forum' => Event::ID_FORUM,
                 'date_facture' => time(),
@@ -100,7 +101,7 @@ class Inscriptions extends AbstractSeed
                 'id_pays' => 'FR',
                 'autorisation' => 'otzbfksgvz',
                 'transaction' => 'taedskem',
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
                 'facturation' => 1,
                 'id_forum' => Event::ID_FORUM,
                 'date_facture' => (new \DateTime("2023-06-25"))->getTimestamp(),
@@ -119,7 +120,7 @@ class Inscriptions extends AbstractSeed
                 'id_pays' => 'FR',
                 'autorisation' => 'ozzbfksgvz',
                 'transaction' => 'yaedskem',
-                'etat' => AFUP_FORUM_ETAT_REGLE,
+                'etat' => Ticket::STATUS_PAID,
                 'facturation' => 1,
                 'id_forum' => Event::ID_FORUM,
                 'date_facture' => (new \DateTime("2024-01-02"))->getTimestamp(),

--- a/htdocs/pages/administration/forum_inscriptions.php
+++ b/htdocs/pages/administration/forum_inscriptions.php
@@ -218,15 +218,16 @@ if ($action == 'lister') {
     $formulaire->addElement('text'  , 'autorisation', 'Autorisation', ['size' => 50, 'maxlength' => 100]);
     $formulaire->addElement('text'  , 'transaction' , 'Transaction' , ['size' => 50, 'maxlength' => 100]);
 
-    $state = [AFUP_FORUM_ETAT_CREE          => 'Inscription créée',
-        AFUP_FORUM_ETAT_ANNULE            => 'Inscription annulée',
-        AFUP_FORUM_ETAT_ERREUR            => 'Paiement CB erreur',
-        AFUP_FORUM_ETAT_REFUSE            => 'Paiement CB refusé',
-        AFUP_FORUM_ETAT_REGLE             => 'Inscription réglée',
-        AFUP_FORUM_ETAT_INVITE            => 'Invitation',
-        AFUP_FORUM_ETAT_ATTENTE_REGLEMENT => 'Attente règlement',
-        AFUP_FORUM_ETAT_CONFIRME          => 'Inscription confirmée',
-        AFUP_FORUM_ETAT_A_POSTERIORI      => 'Inscription à posteriori',
+    $state = [
+        Ticket::STATUS_CREATED      => 'Inscription créée',
+        Ticket::STATUS_CANCELLED    => 'Inscription annulée',
+        Ticket::STATUS_ERROR        => 'Paiement CB erreur',
+        Ticket::STATUS_DECLINED     => 'Paiement CB refusé',
+        Ticket::STATUS_PAID         => 'Inscription réglée',
+        Ticket::STATUS_GUEST        => 'Invitation',
+        Ticket::STATUS_WAITING      => 'Attente règlement',
+        Ticket::STATUS_CONFIRMED    => 'Inscription confirmée',
+        Ticket::STATUS_PAID_AFTER   => 'Inscription à posteriori',
     ];
     $formulaire->addElement('select', 'etat'        , 'Etat'        , $state);
 

--- a/sources/Afup/Bootstrap/commonStart.php
+++ b/sources/Afup/Bootstrap/commonStart.php
@@ -31,16 +31,6 @@ if (isset($_SERVER['HTTP_HOST']) && $_SERVER['HTTP_HOST'] === 'afup.dev') {
     $debug = true;
 }
 
-define('AFUP_FORUM_ETAT_CREE', 0);
-define('AFUP_FORUM_ETAT_ANNULE', 1);
-define('AFUP_FORUM_ETAT_ERREUR', 2);
-define('AFUP_FORUM_ETAT_REFUSE', 3);
-define('AFUP_FORUM_ETAT_REGLE', 4);
-define('AFUP_FORUM_ETAT_INVITE', 5);
-define('AFUP_FORUM_ETAT_ATTENTE_REGLEMENT', 6);
-define('AFUP_FORUM_ETAT_CONFIRME', 7);
-define('AFUP_FORUM_ETAT_A_POSTERIORI', 8);
-
 define('AFUP_FORUM_FACTURE_A_ENVOYER', 0);
 define('AFUP_FORUM_FACTURE_ENVOYEE', 1);
 define('AFUP_FORUM_FACTURE_RECUE', 2);

--- a/sources/Afup/Forum/Facturation.php
+++ b/sources/Afup/Forum/Facturation.php
@@ -60,7 +60,7 @@ class Facturation
         $requete .= '  ' . $champs . ' ';
         $requete .= 'FROM';
         $requete .= '  afup_facturation_forum ';
-        $requete .= 'WHERE etat IN ( ' . AFUP_FORUM_ETAT_REGLE . ', ' . AFUP_FORUM_ETAT_ATTENTE_REGLEMENT . ', ' . AFUP_FORUM_ETAT_CONFIRME . ') ';
+        $requete .= 'WHERE etat IN ( ' . Ticket::STATUS_PAID . ', ' . Ticket::STATUS_WAITING . ', ' . Ticket::STATUS_CONFIRMED . ') ';
         $requete .= '  AND id_forum =' . $id_forum . ' ';
         if ($filtre) {
             $requete .= '  AND (societe LIKE \'%' . $filtre . '%\' OR reference LIKE \'%' . $filtre . '%\' ) ';

--- a/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
@@ -8,6 +8,7 @@ use AppBundle\Event\Model\EventStats\CFPStats;
 use AppBundle\Event\Model\EventStats\TicketTypeStats;
 use AppBundle\Event\Model\EventStats;
 use AppBundle\Event\Model\EventStats\DailyStats;
+use AppBundle\Event\Model\Ticket;
 use Assert\Assertion;
 use Datetime;
 use Doctrine\DBAL\ArrayParameterType;
@@ -52,7 +53,7 @@ class EventStatsRepository
 
         $queryBuilder = clone $baseQueryBuilder;
         $statement = $queryBuilder->andWhere('etat IN(:states)')
-            ->setParameter('states', [AFUP_FORUM_ETAT_REGLE, AFUP_FORUM_ETAT_ATTENTE_REGLEMENT, AFUP_FORUM_ETAT_INVITE], ArrayParameterType::INTEGER)
+            ->setParameter('states', [Ticket::STATUS_PAID, Ticket::STATUS_WAITING, Ticket::STATUS_GUEST], ArrayParameterType::INTEGER)
             ->executeQuery();
 
         $confirmed = [];
@@ -62,7 +63,7 @@ class EventStatsRepository
 
         $queryBuilder = clone $baseQueryBuilder;
         $statement = $queryBuilder->andWhere('etat IN(:states)')
-            ->setParameter('states', [AFUP_FORUM_ETAT_REGLE, AFUP_FORUM_ETAT_ATTENTE_REGLEMENT], ArrayParameterType::INTEGER)
+            ->setParameter('states', [Ticket::STATUS_PAID, Ticket::STATUS_WAITING], ArrayParameterType::INTEGER)
             ->executeQuery();
 
         $paying = [];
@@ -72,7 +73,7 @@ class EventStatsRepository
 
         $queryBuilder = clone $baseQueryBuilder;
         $statement = $queryBuilder->andWhere('etat NOT IN(:states)')
-            ->setParameter('states', [AFUP_FORUM_ETAT_ANNULE, AFUP_FORUM_ETAT_ERREUR, AFUP_FORUM_ETAT_REFUSE], ArrayParameterType::INTEGER)
+            ->setParameter('states', [Ticket::STATUS_CANCELLED, Ticket::STATUS_ERROR, Ticket::STATUS_DECLINED], ArrayParameterType::INTEGER)
             ->executeQuery();
 
         $registered = [];
@@ -101,19 +102,19 @@ class EventStatsRepository
 
         $queryBuilder = clone $baseQueryBuilder;
         $registered = $queryBuilder->andWhere('etat NOT IN(:states)')
-            ->setParameter('states', [AFUP_FORUM_ETAT_ANNULE, AFUP_FORUM_ETAT_ERREUR, AFUP_FORUM_ETAT_REFUSE], ArrayParameterType::INTEGER)
+            ->setParameter('states', [Ticket::STATUS_CANCELLED, Ticket::STATUS_ERROR, Ticket::STATUS_DECLINED], ArrayParameterType::INTEGER)
             ->executeQuery()
             ->fetchOne();
 
         $queryBuilder = clone $baseQueryBuilder;
         $confirmed = $queryBuilder->andWhere('etat IN(:states)')
-            ->setParameter('states', [AFUP_FORUM_ETAT_REGLE, AFUP_FORUM_ETAT_INVITE, AFUP_FORUM_ETAT_CONFIRME], ArrayParameterType::INTEGER)
+            ->setParameter('states', [Ticket::STATUS_PAID, Ticket::STATUS_GUEST, Ticket::STATUS_CONFIRMED], ArrayParameterType::INTEGER)
             ->executeQuery()
             ->fetchOne();
 
         $queryBuilder = clone $baseQueryBuilder;
         $pending = $queryBuilder->andWhere('etat = :state')
-            ->setParameter('state', AFUP_FORUM_ETAT_ATTENTE_REGLEMENT)
+            ->setParameter('state', Ticket::STATUS_WAITING)
             ->executeQuery()
             ->fetchOne();
 

--- a/sources/AppBundle/Event/Model/Ticket.php
+++ b/sources/AppBundle/Event/Model/Ticket.php
@@ -38,15 +38,15 @@ class Ticket implements NotifyPropertyInterface
         AFUP_TRANSPORT_DISTANCE_1000 => '> 1000 km',
     ];
 
-    public const STATUS_CREATED = AFUP_FORUM_ETAT_CREE;
-    public const STATUS_CANCELLED = AFUP_FORUM_ETAT_ANNULE;
-    public const STATUS_ERROR = AFUP_FORUM_ETAT_ERREUR;
-    public const STATUS_DECLINED = AFUP_FORUM_ETAT_REFUSE;
-    public const STATUS_PAID = AFUP_FORUM_ETAT_REGLE;
-    public const STATUS_GUEST = AFUP_FORUM_ETAT_INVITE;
-    public const STATUS_WAITING = AFUP_FORUM_ETAT_ATTENTE_REGLEMENT;
-    public const STATUS_CONFIRMED = AFUP_FORUM_ETAT_CONFIRME; // Je ne comprends pas ce que veut dire ce statut @todo check & delete
-    public const STATUS_PAID_AFTER = AFUP_FORUM_REGLEMENT_A_POSTERIORI; // Je ne comprends pas l'intéret @todo check & delete
+    public const STATUS_CREATED = 0;
+    public const STATUS_CANCELLED = 1;
+    public const STATUS_ERROR = 2;
+    public const STATUS_DECLINED = 3;
+    public const STATUS_PAID = 4;
+    public const STATUS_GUEST = 5;
+    public const STATUS_WAITING = 6;
+    public const STATUS_CONFIRMED = 7;
+    public const STATUS_PAID_AFTER = 8;
 
     public const INVOICE_TODO = AFUP_FORUM_FACTURE_A_ENVOYER;
     public const INVOICE_SENT = AFUP_FORUM_FACTURE_ENVOYEE;


### PR DESCRIPTION
Dans le chantier pour DotEnv, je me suis rendu compte qu'on charge deux fichiers via composer (`sources/Afup/Bootstrap/_Common.php` et `sources/Afup/Bootstrap/commonStart.php`).

Ces fichiers rendent le setup de DotEnv un peu plus compliqué donc je vais les refacto avant de continuer. Cette PR est la première pour ça.