### PR TITLE
correction gestion des rôles

### DIFF
--- a/sources/AppBundle/Association/Model/User.php
+++ b/sources/AppBundle/Association/Model/User.php
@@ -639,7 +639,9 @@ class User implements NotifyPropertyInterface, NotifiableInterface, UserInterfac
         }
 
         // On enlève le rôle ROLE_MEMBER_EXPIRED vu qu'il est défini en fonction de la cotisation dans les defaultRoles
-        $userRoles = array_diff($this->roles, ['ROLE_MEMBER_EXPIRED']);
+        // on fait de même avec tous les autres rôles définis en fonction des champs levelModules car ils peuvent se retrouver
+        // en base dans le tableau de rôle, et on ne veux pas que si on modifie le levelModules pour l'enlever, il reste via le roles
+        $userRoles = array_diff($this->roles, ['ROLE_MEMBER_EXPIRED', 'ROLE_SUPER_ADMIN', 'ROLE_APERO', 'ROLE_ANNUAIRE', 'ROLE_SITE', 'ROLE_FORUM', 'ROLE_ANTENNE']);
 
         return array_unique(array_merge($userRoles, $defaultRoles));
     }


### PR DESCRIPTION
On a des utilisateurs qui avaient le droit d'accéder à la partie evenement de l'admin qui ont indiqué toujours y avoir accès, alors même qu'il leur avait été enlevé.

Cela car le rôle au niveau du levelModules a bien été enlevé, mais dans le json des roles on a ROLE_FORUM, alors qu'on ne devrait pas se retrouver avec cette valeur enregistrée, elle est ajoutée dynamiquement (ici https://github.com/afup/web/blob/01dc60b713d6ff937aeefd2f20f36b0b4c16f115/sources/AppBundle/Association/Model/User.php#L635). En supprimant ces rôles ajoutés dynamiquement venant du json de rôles on gère ainsi aussi l'historique des cas qui ne devraient plus y avoir accès.