### PR TITLE
Conférences à planifier

### DIFF
--- a/sources/AppBundle/Event/Form/TalkAdminType.php
+++ b/sources/AppBundle/Event/Form/TalkAdminType.php
@@ -98,6 +98,10 @@ class TalkAdminType extends TalkType
                 'label' => 'Verbatim',
                 'required' => false,
             ])
+            ->add('scheduled', CheckboxType::class, [
+                'label' => 'Est-ce que cette conférence va être planifiée ?',
+                'required' => false,
+            ])
             ->add('save', SubmitType::class)
         ;
     }

--- a/templates/admin/talk/form.html.twig
+++ b/templates/admin/talk/form.html.twig
@@ -21,6 +21,7 @@
         <h3 class="ui header">Informations complémentaires</h3>
         {{ form_row(form.submittedOn) }}
         {{ form_row(form.publishedOn) }}
+        {{ form_row(form.scheduled) }}
         {{ form_row(form.joindinId) }}
         {{ form_row(form.youtubeId) }}
         {{ form_row(form.slidesUrl) }}


### PR DESCRIPTION
Lors de la refonte de la gestion des conférences, j'ai oublié la case à cocher à planifier.
Elle permet d'indiquer que cette conférence a été sélectionnée et va être planifier.