### PR TITLE
Affichage du commit déployé dans le BO

### DIFF
--- a/sources/AppBundle/Controller/Admin/HealthcheckController.php
+++ b/sources/AppBundle/Controller/Admin/HealthcheckController.php
@@ -39,6 +39,9 @@ class HealthcheckController extends AbstractController
                 'php' => phpversion(),
                 'symfony' => Kernel::VERSION,
             ],
+            'deployment' => [
+                'commit' => getenv('CC_COMMIT_ID'),
+            ],
         ]);
     }
 }

--- a/templates/admin/healthcheck.html.twig
+++ b/templates/admin/healthcheck.html.twig
@@ -3,7 +3,7 @@
 {% block content %}
     <h1>Healthcheck</h1>
     <div class="ui grid">
-        <div class="eight wide column">
+        <div class="five wide column">
             <div class="ui segment">
                 <h2 class="ui header">Dates</h2>
                 <div class="ui clearing divider"></div>
@@ -21,7 +21,7 @@
                 </dl>
             </div>
         </div>
-        <div class="eight wide column">
+        <div class="five wide column">
             <div class="ui segment">
                 <h2 class="ui header">Versions</h2>
                 <div class="ui clearing divider"></div>
@@ -33,6 +33,21 @@
                 </dl>
             </div>
         </div>
+
+        {% if deployment.commit %}
+            <div class="five wide column">
+                <div class="ui segment">
+                    <h2 class="ui header">Déploiement</h2>
+                    <div class="ui clearing divider"></div>
+                    <dl>
+                        <dt>Commit</dt>
+                        <dd>
+                            <a href="https://github.com/afup/web/commit/{{ deployment.commit }}">{{ deployment.commit }}</a>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+        {% endif %}
     </div>
     <style>
         dt {


### PR DESCRIPTION
Clever Cloud met à dispo une variable d'env avec le hash du commit déployé. Je me dis que ça permet d'aller vérifier qu'un déploiement est bien passé (surtout quand on merge plusieurs PRs à la suite).

Le bloc ne s'affiche que si la variable est disponible donc y'a pas en dev.

<img width="529" height="167" alt="image" src="https://github.com/user-attachments/assets/dac0f247-acac-45cc-aab0-9e25dd8dc8ac" />
