### PR TITLE
Prise en compte des nouveaux badges d'ancienneté sur les personnes morales

### DIFF
--- a/sources/AppBundle/Association/UserMembership/BadgesComputer.php
+++ b/sources/AppBundle/Association/UserMembership/BadgesComputer.php
@@ -12,6 +12,8 @@ use AppBundle\Event\Model\Repository\UserBadgeRepository;
 
 class BadgesComputer
 {
+    private const MAX_BADGES_SENIORITY = 17;
+
     public function __construct(
         private readonly SeniorityComputer $seniorityComputer,
         private readonly EventRepository $eventRepository,
@@ -65,11 +67,10 @@ class BadgesComputer
     private function prepareCompanyBadgesInfos(CompanyMember $companyMember): array
     {
         $seniorityInfos = $this->seniorityComputer->computeCompanyAndReturnInfos($companyMember);
-        $maxBadgesSeniority = 17;
 
         $badgesCodes = [];
 
-        for ($i = min($seniorityInfos['years'], $maxBadgesSeniority); $i > 0; $i--) {
+        for ($i = min($seniorityInfos['years'], self::MAX_BADGES_SENIORITY); $i > 0; $i--) {
             $badgesCodes[] = [
                 'date' => ($seniorityInfos['first_year'] + $i) . '-01-01',
                 'code' => $i . 'ans',
@@ -124,9 +125,8 @@ class BadgesComputer
         }
 
         $seniorityInfos = $this->seniorityComputer->computeAndReturnInfos($user);
-        $maxBadgesSeniority = 17;
 
-        for ($i = min($seniorityInfos['years'], $maxBadgesSeniority); $i > 0; $i--) {
+        for ($i = min($seniorityInfos['years'], self::MAX_BADGES_SENIORITY); $i > 0; $i--) {
             $badgesCodes[] = [
                 'date' => ($seniorityInfos['first_year'] + $i) . '-01-01',
                 'code' => $i . 'ans',


### PR DESCRIPTION
En repassant sur ma modification, je me suis rendu compte que dans ma précédente MR https://github.com/afup/web/pull/2082 je n'ai fait la modification que pour les personnes physiques. 

Mais je n'avais pas fait la modification pour les personnes morales.