### PR TITLE
Remplissage automatique du champ `annee` à partir de `date_debut`

### DIFF
--- a/sources/AppBundle/Event/Form/EventType.php
+++ b/sources/AppBundle/Event/Form/EventType.php
@@ -15,6 +15,8 @@ use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -168,6 +170,13 @@ class EventType extends AbstractType
                     new Assert\File(mimeTypes: 'application/pdf'),
                 ],
             ])
+            ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+                /** @var Event $event */
+                $event = $event->getData();
+                if ($event->getDateStart() !== null) {
+                    $event->setYear($event->getDateStart()->format('Y'));
+                }
+            })
         ;
     }
 

--- a/sources/AppBundle/Event/Model/Event.php
+++ b/sources/AppBundle/Event/Model/Event.php
@@ -27,6 +27,8 @@ class Event implements NotifyPropertyInterface
 
     private ?DateTime $dateEnd = null;
 
+    private ?string $year = null;
+
     /**
      * @var DateTime
      */
@@ -184,6 +186,18 @@ class Event implements NotifyPropertyInterface
     {
         $this->propertyChanged('dateEnd', $this->dateEnd, $dateEnd);
         $this->dateEnd = $dateEnd;
+        return $this;
+    }
+
+    public function getYear(): ?string
+    {
+        return $this->year;
+    }
+
+    public function setYear(?string $year): self
+    {
+        $this->propertyChanged('year', $this->year, $year);
+        $this->year = $year;
         return $this;
     }
 

--- a/sources/AppBundle/Event/Model/Repository/EventRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventRepository.php
@@ -324,6 +324,11 @@ SQL;
                 ],
             ])
             ->addField([
+                'columnName' => 'annee',
+                'fieldName' => 'year',
+                'type' => 'string',
+            ])
+            ->addField([
                 'columnName' => 'date_fin_appel_projet',
                 'fieldName' => 'dateEndCallForProjects',
                 'type' => 'datetime',


### PR DESCRIPTION
Cette pull request implémente une logique pour remplir automatiquement le champ `annee` s’il est vide, en utilisant la même méthode que celle présente dans le fichier `sources/Afup/Forum/Forum.php` (lignes 364 et 425), qui se base sur le champ `date_debut`.

- Le champ `annee` est désormais rempli automatiquement si absent, en utilisant `date_debut` comme référence.
- fixes #2105.

Il restera à mettre à jour en base de données les enregistrements où `annee` est `NULL`, en calculant leur valeur à partir de `date_debut`.
<img width="799" height="187" alt="image" src="https://github.com/user-attachments/assets/c1702254-3e6b-48b6-8cce-952842469906" />
