### PR TITLE
correction du calcul des montants HT

### DIFF
--- a/sources/AppBundle/Accounting/Form/TransactionType.php
+++ b/sources/AppBundle/Accounting/Form/TransactionType.php
@@ -13,6 +13,7 @@ use AppBundle\Accounting\Entity\Repository\OperationRepository;
 use AppBundle\Accounting\Entity\Repository\PaymentRepository;
 use AppBundle\Accounting\Model\Transaction;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\DataTransformer\MoneyToLocalizedStringTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
@@ -166,6 +167,27 @@ class TransactionType extends AbstractType
                 ],
             ]);
         }
+
+        $builder->get('amount')->resetViewTransformers();
+        $builder->get('amount')->addViewTransformer(
+            new MoneyToLocalizedStringTransformer(2, false, null, null, 'en'),
+        );
+        $builder->get('amountTva0')->resetViewTransformers();
+        $builder->get('amountTva0')->addViewTransformer(
+            new MoneyToLocalizedStringTransformer(2, false, null, null, 'en'),
+        );
+        $builder->get('amountTva5_5')->resetViewTransformers();
+        $builder->get('amountTva5_5')->addViewTransformer(
+            new MoneyToLocalizedStringTransformer(2, false, null, null, 'en'),
+        );
+        $builder->get('amountTva10')->resetViewTransformers();
+        $builder->get('amountTva10')->addViewTransformer(
+            new MoneyToLocalizedStringTransformer(2, false, null, null, 'en'),
+        );
+        $builder->get('amountTva20')->resetViewTransformers();
+        $builder->get('amountTva20')->addViewTransformer(
+            new MoneyToLocalizedStringTransformer(2, false, null, null, 'en'),
+        );
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/templates/admin/accounting/journal/vat_calculation.js.twig
+++ b/templates/admin/accounting/journal/vat_calculation.js.twig
@@ -8,7 +8,9 @@ $(document).ready(function () {
     ];
     for (let i = 0; i < vatFields.length; i++) {
         document.getElementById(vatFields[i].link).addEventListener('click', function (event) {
-            document.getElementById(vatFields[i].input).value = Number.parseFloat(Math.round(parseFloat(document.getElementById('transaction_amount').value) / (1 + vatFields[i].rate) * 100) / 100).toFixed(2);
+            let value = document.getElementById('transaction_amount').value;
+            value = value.replace(',', '.');
+            document.getElementById(vatFields[i].input).value = Number.parseFloat(Math.round(parseFloat(value) / (1 + vatFields[i].rate) * 100) / 100).toFixed(2);
             event.preventDefault();
             return false;
         });


### PR DESCRIPTION
## force l'utilisation du point pour séparer les décimales à l'affichage

avant :
<img width="916" height="65" alt="Screenshot from 2026-02-02 11-19-30" src="https://github.com/user-attachments/assets/6ed5ad8b-47c2-4c8c-bd42-5a70427269ab" />


après :
<img width="916" height="65" alt="Screenshot from 2026-02-02 11-19-46" src="https://github.com/user-attachments/assets/633fbdd2-7525-4410-a959-1b7409714994" />


## supporte les nombres avec virgule ou point dans le calcul des montants HT

avant :
<img width="916" height="651" alt="Screenshot from 2026-02-02 10-47-43" src="https://github.com/user-attachments/assets/25da6eb2-44dd-4a62-a088-bf19497d8a61" />

après :
<img width="916" height="651" alt="Screenshot from 2026-02-02 10-50-07" src="https://github.com/user-attachments/assets/4800da9a-0ee4-4ac2-a574-9a5981b43152" />
