### PR TITLE
Gestion des Super Apéros depuis le BO

### DIFF
--- a/app/config/packages/backoffice_menu.yaml
+++ b/app/config/packages/backoffice_menu.yaml
@@ -100,6 +100,14 @@ parameters:
                         - admin_site_articles_list
                         - admin_site_articles_add
                         - admin_site_articles_edit
+                super_apero_infos:
+                    nom: 'Super Apéro'
+                    niveau: 'ROLE_ADMIN'
+                    url: '/admin/super-apero'
+                    extra_routes:
+                        - admin_super_apero_list
+                        - admin_super_apero_add
+                        - admin_super_apero_edit
         forum:
             nom: 'Évènements'
             niveau: 'ROLE_FORUM'

--- a/app/config/packages/doctrine.yaml
+++ b/app/config/packages/doctrine.yaml
@@ -29,6 +29,11 @@ doctrine:
         is_bundle: false
         dir: '%kernel.project_dir%/../sources/AppBundle/Site/Entity'
         prefix: 'AppBundle\Site\Entity'
+      SuperApero:
+        type: attribute
+        is_bundle: false
+        dir: '%kernel.project_dir%/../sources/AppBundle/SuperApero/Entity'
+        prefix: 'AppBundle\SuperApero\Entity'
 
 when@test:
   doctrine:

--- a/app/config/routing/admin.yml
+++ b/app/config/routing/admin.yml
@@ -45,6 +45,10 @@ admin_antennes:
   resource: "admin_antennes.yml"
   prefix: /antennes
 
+admin_super_apero:
+  resource: "admin_super_apero.yml"
+  prefix: /super-apero
+
 admin_members_reporting:
   path: /members/reporting
   defaults: {_controller: AppBundle\Controller\MembershipAdmin\ReportingAction}

--- a/app/config/routing/admin_super_apero.yml
+++ b/app/config/routing/admin_super_apero.yml
@@ -1,0 +1,20 @@
+admin_super_apero_list:
+  path: /
+  defaults: {_controller: AppBundle\Controller\Admin\SuperApero\ListAction}
+
+admin_super_apero_add:
+  path: /add
+  defaults: {_controller: AppBundle\Controller\Admin\SuperApero\AddAction}
+
+admin_super_apero_edit:
+  path: /edit/{id}
+  defaults: {_controller: AppBundle\Controller\Admin\SuperApero\EditAction}
+  requirements:
+    id: '\d+'
+
+admin_super_apero_delete:
+  path: /delete/{id}
+  defaults: {_controller: AppBundle\Controller\Admin\SuperApero\DeleteAction}
+  methods: [POST]
+  requirements:
+    id: '\d+'

--- a/db/migrations/20260217124904_create_super_apero_tables.php
+++ b/db/migrations/20260217124904_create_super_apero_tables.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class CreateSuperAperoTables extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('super_apero')
+            ->addColumn('date', 'date', ['null' => false])
+            ->create();
+
+        $this->table('super_apero_meetup')
+            ->addColumn('super_apero_id', 'integer', [
+                'null' => false,
+                'signed' => false,
+            ])
+            ->addColumn('antenne', 'string', ['limit' => 255, 'null' => false])
+            ->addColumn('meetup_id', 'integer', ['null' => true])
+            ->addColumn('description', 'text', ['null' => true])
+            ->addForeignKey('super_apero_id', 'super_apero', 'id', ['delete' => 'CASCADE', 'update' => 'NO_ACTION'])
+            ->create();
+    }
+}

--- a/sources/AppBundle/Controller/Admin/SuperApero/AddAction.php
+++ b/sources/AppBundle/Controller/Admin/SuperApero/AddAction.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\SuperApero;
+
+use AppBundle\AuditLog\Audit;
+use AppBundle\SuperApero\Entity\SuperApero;
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
+use AppBundle\SuperApero\Form\SuperAperoType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class AddAction extends AbstractController
+{
+    public function __construct(
+        private readonly SuperAperoRepository $superAperoRepository,
+        private readonly Audit $audit,
+    ) {}
+
+    public function __invoke(Request $request): Response
+    {
+        $superApero = new SuperApero();
+        $form = $this->createForm(SuperAperoType::class, $superApero);
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->superAperoRepository->save($superApero);
+            $this->audit->log('Ajout du Super Apéro ' . $superApero->annee());
+            $this->addFlash('notice', 'Le Super Apéro ' . $superApero->annee() . ' a été ajouté');
+
+            return $this->redirectToRoute('admin_super_apero_list');
+        }
+
+        return $this->render('admin/super_apero/form.html.twig', [
+            'form' => $form->createView(),
+            'formTitle' => 'Ajouter un Super Apéro',
+            'submitLabel' => 'Ajouter',
+        ]);
+    }
+}

--- a/sources/AppBundle/Controller/Admin/SuperApero/DeleteAction.php
+++ b/sources/AppBundle/Controller/Admin/SuperApero/DeleteAction.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\SuperApero;
+
+use AppBundle\AuditLog\Audit;
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+final class DeleteAction extends AbstractController
+{
+    public function __construct(
+        private readonly SuperAperoRepository $superAperoRepository,
+        private readonly Audit $audit,
+    ) {}
+
+    public function __invoke(int $id, Request $request): RedirectResponse
+    {
+        if (!$this->isCsrfTokenValid('super_apero_delete', $request->request->getString('_token'))) {
+            $this->addFlash('error', 'Token invalide');
+
+            return $this->redirectToRoute('admin_super_apero_list');
+        }
+
+        $superApero = $this->superAperoRepository->find($id);
+
+        if ($superApero === null) {
+            throw $this->createNotFoundException('Super apéro non trouvé');
+        }
+
+        $annee = $superApero->annee();
+        $this->superAperoRepository->delete($superApero);
+        $this->audit->log('Suppression du Super Apéro ' . $annee);
+        $this->addFlash('notice', 'Le Super Apéro ' . $annee . ' a été supprimé');
+
+        return $this->redirectToRoute('admin_super_apero_list');
+    }
+}

--- a/sources/AppBundle/Controller/Admin/SuperApero/EditAction.php
+++ b/sources/AppBundle/Controller/Admin/SuperApero/EditAction.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\SuperApero;
+
+use AppBundle\AuditLog\Audit;
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
+use AppBundle\SuperApero\Entity\SuperApero;
+use AppBundle\SuperApero\Form\SuperAperoType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EditAction extends AbstractController
+{
+    public function __construct(
+        private readonly SuperAperoRepository $superAperoRepository,
+        private readonly Audit $audit,
+    ) {}
+
+    public function __invoke(int $id, Request $request): Response
+    {
+        $superApero = $this->superAperoRepository->find($id);
+
+        if (!$superApero instanceof SuperApero) {
+            throw $this->createNotFoundException('Super apéro non trouvé');
+        }
+
+        $form = $this->createForm(SuperAperoType::class, $superApero);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $this->superAperoRepository->save($superApero);
+            $this->audit->log('Modification du Super Apéro ' . $superApero->annee());
+            $this->addFlash('notice', 'Le Super Apéro ' . $superApero->annee() . ' a été modifié');
+
+            return $this->redirectToRoute('admin_super_apero_list');
+        }
+
+        return $this->render('admin/super_apero/form.html.twig', [
+            'form' => $form->createView(),
+            'formTitle' => 'Modifier le Super Apéro ' . $superApero->annee(),
+            'submitLabel' => 'Modifier',
+        ]);
+    }
+}

--- a/sources/AppBundle/Controller/Admin/SuperApero/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/SuperApero/ListAction.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\SuperApero;
+
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
+use AppBundle\SuperApero\Entity\SuperApero;
+use Psr\Clock\ClockInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+final class ListAction extends AbstractController
+{
+    public function __construct(
+        private readonly SuperAperoRepository $superAperoRepository,
+        private readonly ClockInterface $clock,
+    ) {}
+
+    public function __invoke(): Response
+    {
+        $currentYear = (int) $this->clock->now()->format('Y');
+
+        return $this->render('admin/super_apero/index.html.twig', [
+            'aperos' => $this->superAperoRepository->getAllSortedByYear(),
+            'currentYear' => $currentYear,
+            'hasSuperAperoForCurrentYear' => $this->superAperoRepository->findOneByYear($currentYear) instanceof SuperApero,
+        ]);
+    }
+}

--- a/sources/AppBundle/Controller/Website/Static/SuperAperoAction.php
+++ b/sources/AppBundle/Controller/Website/Static/SuperAperoAction.php
@@ -4,56 +4,30 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Website\Static;
 
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
 use AppBundle\Twig\ViewRenderer;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 final readonly class SuperAperoAction
 {
     public function __construct(
         private ViewRenderer $view,
-        #[Autowire('%super_apero_csv_url%')]
-        private string $superAperoCsvUrl,
+        private SuperAperoRepository $superAperoRepository,
+        private UrlGeneratorInterface $urlGenerator,
     ) {}
 
     public function __invoke(): Response
     {
+        $superApero = $this->superAperoRepository->findActive();
+
+        if ($superApero === null) {
+            return new RedirectResponse($this->urlGenerator->generate('home'));
+        }
+
         return $this->view->render('site/superapero.html.twig', [
-            'aperos' => $this->getAperos($this->superAperoCsvUrl),
+            'superApero' => $superApero,
         ]);
-    }
-
-    /**
-     * @return array{code: (string | null), content: (string | null), meetup_id?: (string | null)}[]
-     */
-    protected function getAperos(string $url): array
-    {
-        $fp = fopen($url, 'rb');
-        if (!$fp) {
-            throw new \RuntimeException("Error opening spreadsheet");
-        }
-
-        $aperos = [];
-
-        while (false !== ($row = fgetcsv($fp))) {
-            if (trim((string) $row[0]) === '') {
-                continue;
-            }
-
-            [$code, $meeetupId, $content] = $row;
-
-            $apero = [
-                'code' => mb_strtolower((string) $code),
-                'content' => $content,
-            ];
-
-            if (strlen(trim((string) $meeetupId)) !== 0) {
-                $apero['meetup_id'] = $meeetupId;
-            }
-
-            $aperos[] = $apero;
-        }
-
-        return $aperos;
     }
 }

--- a/sources/AppBundle/SuperApero/Entity/Repository/SuperAperoRepository.php
+++ b/sources/AppBundle/SuperApero/Entity/Repository/SuperAperoRepository.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Entity\Repository;
+
+use AppBundle\Doctrine\EntityRepository;
+use AppBundle\SuperApero\Entity\SuperApero;
+use DateTimeImmutable;
+use Doctrine\Persistence\ManagerRegistry;
+use Psr\Clock\ClockInterface;
+
+/**
+ * @extends EntityRepository<SuperApero>
+ */
+final class SuperAperoRepository extends EntityRepository
+{
+    private ClockInterface $clock;
+
+    public function __construct(ManagerRegistry $registry, ClockInterface $clock)
+    {
+        parent::__construct($registry, SuperApero::class);
+
+        $this->clock = $clock;
+    }
+
+    /**
+     * @return array<SuperApero>
+     */
+    public function getAllSortedByYear(): array
+    {
+        return $this->createQueryBuilder('s')
+            ->orderBy('s.date', 'desc')
+            ->getQuery()
+            ->execute();
+    }
+
+    public function findOneByYear(int $year): ?SuperApero
+    {
+        return $this->createQueryBuilder('s')
+            ->where('s.date >= :yearStart')
+            ->andWhere('s.date <= :yearEnd')
+            ->setParameter('yearStart', new DateTimeImmutable($year . '-01-01'))
+            ->setParameter('yearEnd', new DateTimeImmutable($year . '-12-31'))
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findActive(): ?SuperApero
+    {
+        $now = $this->clock->now();
+
+        return $this->createQueryBuilder('s')
+            // Le prochain Super Apéro doit être aujourd'hui ou dans le futur
+            ->where('s.date >= :now')
+            // Et doit avoir lieu dans l'année courante
+            ->andWhere('s.date >= :yearStart')
+            ->andWhere('s.date <= :yearEnd')
+            // Et doit avoir au moins un meetup associé
+            ->innerJoin('s.meetups', 'm')
+            ->setParameter('now', new DateTimeImmutable($now->format('Y-m-d')))
+            ->setParameter('yearStart', new DateTimeImmutable($now->format('Y') . '-01-01'))
+            ->setParameter('yearEnd', new DateTimeImmutable($now->format('Y') . '-12-31'))
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+}

--- a/sources/AppBundle/SuperApero/Entity/SuperApero.php
+++ b/sources/AppBundle/SuperApero/Entity/SuperApero.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Entity;
+
+use DateTimeImmutable;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Clock\Clock;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'super_apero')]
+class SuperApero
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public ?int $id = null;
+
+    #[ORM\Column(type: 'date_immutable', nullable: false)]
+    public DateTimeImmutable $date;
+
+    /** @var Collection<string, SuperAperoMeetup>&iterable<string, SuperAperoMeetup> */
+    #[ORM\OneToMany(targetEntity: SuperAperoMeetup::class, mappedBy: 'superApero', cascade: ['persist', 'remove'], orphanRemoval: true, indexBy: 'antenne')]
+    public Collection $meetups;
+
+    public function __construct()
+    {
+        $this->meetups = new ArrayCollection();
+    }
+
+    public function annee(): int
+    {
+        return (int) $this->date->format('Y');
+    }
+
+    public function addMeetup(SuperAperoMeetup $meetup): void
+    {
+        if (!$this->meetups->contains($meetup)) {
+            $this->meetups->add($meetup);
+            $meetup->superApero = $this;
+        }
+    }
+
+    public function removeMeetup(SuperAperoMeetup $meetup): void
+    {
+        $this->meetups->removeElement($meetup);
+    }
+
+    public function isActive(): bool
+    {
+        $now = Clock::get()->now();
+
+        return $this->annee() === (int) $now->format('Y')
+            && $this->date >= new DateTimeImmutable($now->format('Y-m-d'))
+            && !$this->meetups->isEmpty();
+    }
+}

--- a/sources/AppBundle/SuperApero/Entity/SuperAperoMeetup.php
+++ b/sources/AppBundle/SuperApero/Entity/SuperAperoMeetup.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'super_apero_meetup')]
+class SuperAperoMeetup
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column]
+    public ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: SuperApero::class, inversedBy: 'meetups')]
+    #[ORM\JoinColumn(nullable: false)]
+    public SuperApero $superApero;
+
+    #[ORM\Column(length: 255, nullable: false)]
+    public string $antenne;
+
+    #[ORM\Column(nullable: true)]
+    public ?int $meetupId = null;
+
+    #[ORM\Column(nullable: true)]
+    public ?string $description = null;
+}

--- a/sources/AppBundle/SuperApero/Form/SuperAperoMeetupFormData.php
+++ b/sources/AppBundle/SuperApero/Form/SuperAperoMeetupFormData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Form;
+
+use AppBundle\SuperApero\Entity\SuperAperoMeetup;
+
+final class SuperAperoMeetupFormData
+{
+    public ?int $meetupId = null;
+    public ?string $description = null;
+
+    public static function fromEntity(SuperAperoMeetup $entity): self
+    {
+        $data = new self();
+        $data->meetupId = $entity->meetupId;
+        $data->description = $entity->description;
+
+        return $data;
+    }
+
+    public function hasValues(): bool
+    {
+        return $this->meetupId !== null
+            || trim((string) $this->description) !== '';
+    }
+}

--- a/sources/AppBundle/SuperApero/Form/SuperAperoMeetupType.php
+++ b/sources/AppBundle/SuperApero/Form/SuperAperoMeetupType.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SuperAperoMeetupType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('meetupId', IntegerType::class, [
+                'label' => 'ID Meetup',
+                'required' => false,
+            ])
+            ->add('description', TextareaType::class, [
+                'label' => 'Description',
+                'required' => false,
+                'attr' => ['rows' => 4],
+            ])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => SuperAperoMeetupFormData::class,
+        ]);
+    }
+}

--- a/sources/AppBundle/SuperApero/Form/SuperAperoType.php
+++ b/sources/AppBundle/SuperApero/Form/SuperAperoType.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SuperApero\Form;
+
+use AppBundle\Antennes\AntenneRepository;
+use AppBundle\SuperApero\Entity\Repository\SuperAperoRepository;
+use AppBundle\SuperApero\Entity\SuperApero;
+use AppBundle\SuperApero\Entity\SuperAperoMeetup;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SuperAperoType extends AbstractType
+{
+    public function __construct(
+        private readonly SuperAperoRepository $superAperoRepository,
+        private readonly AntenneRepository $antenneRepository,
+    ) {}
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $antennes = $this->antenneRepository->getAllSortedByLabels();
+
+        $builder
+            ->add('date', DateType::class, [
+                'label' => 'Date',
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'required' => true,
+            ])
+            ->add($builder->create('meetups', FormType::class, [
+                'mapped' => false,
+                'label' => false,
+            ]));
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($antennes): void {
+            /** @var SuperApero $superApero */
+            $superApero = $event->getData();
+
+            $meetupsForm = $event->getForm()->get('meetups');
+            foreach ($antennes as $antenne) {
+                $existing = $superApero->meetups[$antenne->code] ?? null;
+
+                $meetupsForm->add($antenne->code, SuperAperoMeetupType::class, [
+                    'label' => $antenne->label,
+                    'data' => $existing instanceof SuperAperoMeetup
+                        ? SuperAperoMeetupFormData::fromEntity($existing)
+                        : null,
+                ]);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($antennes): void {
+            /** @var SuperApero $superApero */
+            $superApero = $event->getData();
+            $form = $event->getForm();
+
+            if (isset($superApero->date)) {
+                $year = $superApero->annee();
+                $existing = $this->superAperoRepository->findOneByYear($year);
+
+                if ($existing !== null && $existing->id !== $superApero->id) {
+                    $form->get('date')->addError(
+                        new FormError("Un Super Apéro existe déjà pour l'année {$year}."),
+                    );
+                }
+            }
+
+            $meetupsForm = $form->get('meetups');
+
+            $submittedAntennes = [];
+            foreach ($antennes as $antenne) {
+                /** @var SuperAperoMeetupFormData $data */
+                $data = $meetupsForm->get($antenne->code)->getData();
+
+                if ($data->hasValues()) {
+                    $submittedAntennes[] = $antenne->code;
+
+                    if (isset($superApero->meetups[$antenne->code])) {
+                        $superApero->meetups[$antenne->code]->meetupId = $data->meetupId;
+                        $superApero->meetups[$antenne->code]->description = $data->description;
+                    } else {
+                        $meetup = new SuperAperoMeetup();
+                        $meetup->antenne = $antenne->code;
+                        $meetup->meetupId = $data->meetupId;
+                        $meetup->description = $data->description;
+                        $superApero->addMeetup($meetup);
+                    }
+                }
+            }
+
+            foreach ($superApero->meetups->toArray() as $meetup) {
+                if (!\in_array($meetup->antenne, $submittedAntennes, true)) {
+                    $superApero->removeMeetup($meetup);
+                }
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => SuperApero::class,
+        ]);
+    }
+}

--- a/templates/admin/super_apero/form.html.twig
+++ b/templates/admin/super_apero/form.html.twig
@@ -1,0 +1,72 @@
+{% extends 'admin/base_with_header.html.twig' %}
+
+{% form_theme form 'form_theme_admin.html.twig' %}
+
+{% block content %}
+    <h2>{{ formTitle }}</h2>
+
+    {{ form_start(form) }}
+
+        <div class="ui segment">
+            <div class="ui form">
+                {{ form_row(form.date) }}
+            </div>
+
+            <div class="ui grid">
+                <div class="three wide column"></div>
+                <div class="nine wide column">
+
+                    <h2 class="ui header">Antennes</h2>
+
+                    <div class="ui message">
+                        <p>
+                            Seules les antennes ayant soit un ID meetup, soit une description seront affichées sur le site.
+                        </p>
+                    </div>
+
+                    <table class="ui table compact">
+                        <thead>
+                        <tr>
+                            <th>Antenne</th>
+                            <th style="width: 200px;">ID Meetup</th>
+                            <th>Description</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        {% for meetup in form.meetups %}
+                            <tr>
+                                <td class="top aligned">{{ meetup.vars.label }}</td>
+                                <td class="top aligned">
+                                    <div class="ui form" style="width: 200px;">
+                                        {{ form_widget(meetup.meetupId) }}
+                                    </div>
+                                </td>
+                                <td>
+                                    <div class="ui form">
+                                        {{ form_widget(meetup.description) }}
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <div class="ui segment">
+            <div>
+                <div class="ui form">
+                    <div class="inline fields ui grid">
+                        <div class="three wide column">
+                        </div>
+                        <div class="three wide column">
+                            <input type="submit" value="{{ submitLabel }}" class="ui primary button">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    {{ form_end(form) }}
+{% endblock %}

--- a/templates/admin/super_apero/index.html.twig
+++ b/templates/admin/super_apero/index.html.twig
@@ -1,0 +1,78 @@
+{% extends 'admin/base_with_header.html.twig' %}
+
+{% block content %}
+    <h2>Liste des Super Apéros</h2>
+
+    {% if not hasSuperAperoForCurrentYear %}
+        <div class="ui menu">
+            <a href="{{ path('admin_super_apero_add') }}" class="item">
+                <div data-tooltip="Choisir la date du prochain Super Apéro" data-position="bottom left">
+                    <i class="icon plus square"></i>
+                    Planifier le Super Apéro {{ currentYear }}
+                </div>
+            </a>
+        </div>
+    {% endif %}
+
+    <div class="ui message">
+        <p>
+            Un Super Apéro devient actif lorsque sa date est dans l'année courante, n'est pas encore passée et qu'au
+            moins une des antennes a des informations renseignées.<br />
+            Si un Super Apéro est actif, <a href="{{ url('superapero') }}">la page du site</a> affichera les informations. Sinon, elle redirige vers la page d'accueil.
+        </p>
+    </div>
+
+    <table class="ui table striped compact celled">
+        <thead>
+        <tr>
+            <th>Année</th>
+            <th>Date</th>
+            <th>Antennes</th>
+            <th>État</th>
+            <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for apero in aperos %}
+        <tr>
+            <td>{{ apero.annee }}</td>
+            <td>{{ apero.date|date('d/m/Y') }}</td>
+            <td>
+                {% for meetup in apero.meetups %}
+                    <span class="ui label">{{ office_name(meetup.antenne) }}</span>
+                {% endfor %}
+            </td>
+            <td>
+                {% if apero.isActive %}
+                    <span class="ui green label">Actif</span>
+                {% else %}
+                    <span class="ui grey label">Inactif</span>
+                {% endif %}
+            </td>
+            <td class="single line right aligned">
+                <a id="modifier_{{ apero.id }}"
+                   href="{{ path('admin_super_apero_edit', {'id': apero.id }) }}"
+                   data-position="left center"
+                   data-tooltip="Modifier le Super Apéro {{ apero.annee }}"
+                   class="compact ui icon button"
+                >
+                    <i class="pencil alernate icon"></i>
+                </a>
+
+                <form method="post" action="{{ path('admin_super_apero_delete', {'id': apero.id}) }}" style="display: inline" class="confirmable" data-confirmable-label="Etes-vous sûr de vouloir supprimer le Super Apéro {{ apero.annee }} ?">
+                    <input type="hidden" name="_token" value="{{ csrf_token('super_apero_delete') }}">
+                    <button type="submit"
+                            id="supprimer_{{ apero.id }}"
+                            data-position="left center"
+                            data-tooltip="Supprimer le Super Apéro {{ apero.annee }}"
+                            class="compact ui red icon button"
+                    >
+                        <i class="trash icon"></i>
+                    </button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/templates/site/superapero.html.twig
+++ b/templates/site/superapero.html.twig
@@ -39,10 +39,10 @@
             <h2 style="text-align: center">Des apéros PHP le même jour dans toutes les antennes !</h2>
 
             <blockquote>
-                <p>Bloquez votre soirée du mercredi 11 mars et rendez-vous dans votre antenne locale pour une soirée de conférences et d'échanges, où toute la communauté PHP sera invitée à lever son verre pour célébrer le langage !</p>
+                <p>Bloquez votre soirée du {{ superApero.date|format_date(pattern='EEEE d MMMM', locale='fr') }} et rendez-vous dans votre antenne locale pour une soirée de conférences et d'échanges, où toute la communauté PHP sera invitée à lever son verre pour célébrer le langage !</p>
             </blockquote>
 
-            {% for apero in aperos %}
+            {% for meetup in superApero.meetups %}
                 {% if loop.index is odd %}
                     <div class="container">
                 {% endif %}
@@ -50,19 +50,19 @@
                 <div class="col-md-6">
                     <div class="container">
                         <div class="col-md-2">
-                            <img src="{{ office_logo(apero.code) }}" alt="" />
+                            <img src="{{ office_logo(meetup.antenne) }}" alt="" />
                         </div>
                         <div class="col-md-10">
-                            <h3>{{ office_name(apero.code) }}</h3>
+                            <h3>{{ office_name(meetup.antenne) }}</h3>
                         </div>
                     </div>
                     <div class="container">
-                        <div class="col-md-{% if apero.meetup_id is defined %}8{% else %}12{% endif %}">
-                            {{ apero.content|raw }}
+                        <div class="col-md-{% if meetup.meetupId %}8{% else %}12{% endif %}">
+                            {{ meetup.description|raw }}
                         </div>
-                        {% if apero.meetup_id is defined %}
+                        {% if meetup.meetupId %}
                         <div class="col-md-4">
-                                <a href="https://www.meetup.com/fr-FR/{{ office_meetup_urlname(apero.code) }}/events/{{ apero.meetup_id }}/" class="button">S'inscrire</a>
+                                <a href="https://www.meetup.com/fr-FR/{{ office_meetup_urlname(meetup.antenne) }}/events/{{ meetup.meetupId }}/" class="button">S'inscrire</a>
                         </div>
                         {% endif %}
                     </div>
@@ -73,7 +73,7 @@
                 {% endif %}
             {% endfor %}
 
-            {% if aperos|length is odd %}
+            {% if superApero.meetups|length is odd %}
                 </div>
             {% endif %}
     </div>

--- a/tests/behat/features/Admin/SuperApero/SuperApero.feature
+++ b/tests/behat/features/Admin/SuperApero/SuperApero.feature
@@ -1,0 +1,98 @@
+Feature: Gestion des Super Apéro
+
+  @reloadDbWithTestData
+  Scenario: Ajout d'un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    Then I should see "Liste des Super Apéros"
+    When I follow "Planifier le Super Apéro 2025"
+    Then I should see "Ajouter un Super Apéro"
+    When I fill in "super_apero[date]" with "2025-03-11"
+    And I fill in "super_apero[meetups][lyon][meetupId]" with "12345"
+    And I fill in "super_apero[meetups][paris][description]" with "Super Apéro PHP à Paris"
+    And I fill in "super_apero[meetups][bordeaux][meetupId]" with "67890"
+    And I fill in "super_apero[meetups][bordeaux][description]" with "Super Apéro PHP à Bordeaux"
+    And I press "Ajouter"
+    Then I should see "Le Super Apéro 2025 a été ajouté"
+    And I should see "2025"
+    And I should see "11/03/2025"
+    And I should see "lyon"
+    And I should see "paris"
+    And I should see "bordeaux"
+    And I should see a green label "Actif"
+
+  Scenario: Activation d'un Super Apéro
+    Given the current date is "2025-03-11 23:59:59"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    Then I should see "Liste des Super Apéros"
+    And I should see "2025"
+    And I should see "11/03/2025"
+    And I should see a green label "Actif"
+    When the current date is "2025-03-12 00:00:00"
+    And I am on "/admin/super-apero/"
+    Then I should see "Liste des Super Apéros"
+    And I should see "2025"
+    And I should see "11/03/2025"
+    And I should see a grey label "Inactif"
+
+  Scenario: Un seul Super Apéro possible par année
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/add"
+    When I fill in "super_apero[date]" with "2025-09-20"
+    And I press "Ajouter"
+    Then I should see "Un Super Apéro existe déjà pour l'année 2025."
+
+  Scenario: Modifier la date d'un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    When I follow "modifier_1"
+    Then I should see "Modifier le Super Apéro 2025"
+    When I fill in "super_apero[date]" with "2025-06-15"
+    And I press "Modifier"
+    Then I should see "Le Super Apéro 2025 a été modifié"
+    And I should see "2025"
+    And I should see "15/06/2025"
+
+  Scenario: Ajouter une ville à un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/edit/1"
+    When I fill in "super_apero[meetups][nantes][meetupId]" with "11111"
+    And I fill in "super_apero[meetups][nantes][description]" with "Super Apéro PHP à Nantes"
+    And I press "Modifier"
+    Then I should see "Le Super Apéro 2025 a été modifié"
+    And I should see "nantes"
+
+  Scenario: Modifier une ville d'un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/edit/1"
+    When I fill in "super_apero[meetups][lyon][meetupId]" with "99999"
+    And I fill in "super_apero[meetups][lyon][description]" with "Super Apéro PHP à Lyon modifié"
+    And I fill in "super_apero[meetups][paris][description]" with "Super Apéro PHP à Paris modifié"
+    And I fill in "super_apero[meetups][bordeaux][meetupId]" with "88888"
+    And I fill in "super_apero[meetups][bordeaux][description]" with "Super Apéro PHP à Bordeaux modifié"
+    And I press "Modifier"
+    Then I should see "Le Super Apéro 2025 a été modifié"
+
+  Scenario: Supprimer une ville d'un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/edit/1"
+    When I fill in "super_apero[meetups][nantes][meetupId]" with ""
+    And I fill in "super_apero[meetups][nantes][description]" with ""
+    And I press "Modifier"
+    Then I should see "Le Super Apéro 2025 a été modifié"
+    And I should not see "nantes"
+
+  Scenario: Supprimer un Super Apéro
+    Given the current date is "2025-01-15 10:00:00"
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    When I press "supprimer_1"
+    Then I should see "Le Super Apéro 2025 a été supprimé"
+    And I should not see "15/06/2025"

--- a/tests/behat/features/PublicSite/SuperApero.feature
+++ b/tests/behat/features/PublicSite/SuperApero.feature
@@ -1,9 +1,44 @@
 Feature: Site Public - Super Apéro PHP
 
   @reloadDbWithTestData
-  Scenario: On accède à la page Super Apéro PHP
+  Scenario: Page du Super Apéro désactivée si aucun Super Apéro pour l'année courante
+    Given I am on "/super-apero"
+    Then the current URL should match "#/home#"
+
+  @reloadDbWithTestData
+  Scenario: Page du Super Apéro désactivée si le Super Apéro de l'année est passé
+    Given the current date is "2025-02-12 00:00:00"
+    # Ajout d'un Super Apéro
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    Then I should see "Liste des Super Apéros"
+    When I follow "Planifier le Super Apéro 2025"
+    Then I should see "Ajouter un Super Apéro"
+    When I fill in "super_apero[date]" with "2025-02-11"
+    And I fill in "super_apero[meetups][lyon][meetupId]" with "12345"
+    And I press "Ajouter"
+    # Affichage de la page du Super Apéro
+    Given I am on "/super-apero"
+    Then the current URL should match "#/home#"
+
+  @reloadDbWithTestData
+  Scenario: Page du Super Apéro active si un Super Apéro est actif dans l'année courante
+    Given the current date is "2025-03-11 23:59:59"
+    # Ajout d'un Super Apéro
+    And I am logged in as admin and on the Administration
+    And I am on "/admin/super-apero/"
+    Then I should see "Liste des Super Apéros"
+    When I follow "Planifier le Super Apéro 2025"
+    Then I should see "Ajouter un Super Apéro"
+    When I fill in "super_apero[date]" with "2025-03-11"
+    And I fill in "super_apero[meetups][lyon][meetupId]" with "12345"
+    And I fill in "super_apero[meetups][paris][description]" with "Super Apéro PHP à Paris"
+    And I fill in "super_apero[meetups][bordeaux][meetupId]" with "67890"
+    And I fill in "super_apero[meetups][bordeaux][description]" with "Super Apéro PHP à Bordeaux"
+    And I press "Ajouter"
+    # Affichage de la page du Super Apéro
     Given I am on "/super-apero"
     Then the current URL should match "#/association/super-apero$#"
     And the "#main h1" element should contain "Super-apéro PHP"
-    And the response should contain "Super Apéro PHP – Édition Spéciale"
-    And the response should contain "Super Apéro PHP chez WanadevDigital"
+    And the response should contain "Super Apéro PHP à Paris"
+    And the response should contain "Super Apéro PHP à Bordeaux"


### PR DESCRIPTION
Tous les ans, à peu près en février, Amélie contacte le pôle outils pour qu'elle puisse s'occuper de la page du Super Apéro.

Et, tous les ans, il faut :
- créer une google sheet sur le drive
- modifier une variable d'env avec l'url de cette sheet
- reboot le serveur
- faire une PR pour mettre à jour la date (qui est en dur dans le code)

Cette PR permet de se passer de tout ça et de rendre Amélie 100% autonome pour la gestion de cette page. On ouvre aussi la possibilité de faire un lien automatique avec les meetups récupérés depuis l'api.

L'activation de la page se fait automatiquement. Si un apéro est présent en base pour l'année courante, que sa date est dans le futur (ou le jour-même jusqu'à minuit) et qu'au moins une des antennes a des infos, alors la page est active. Sinon, elle redirige vers la home.

## Le rendu dans le BO

Ici on voit qu'on peut planifier le prochain (un seul est possible par an) :
<img width="1340" height="459" alt="image" src="https://github.com/user-attachments/assets/f9da9abd-4ba5-4a4f-9e2a-10c9acf9d673" />

Et ici la liste avec celui de l'année en court actif :
<img width="1336" height="455" alt="image" src="https://github.com/user-attachments/assets/e59cbde4-e6f2-4298-87ed-60f96cebb644" />

Le formulaire de création/modification :
<img width="1583" height="864" alt="image" src="https://github.com/user-attachments/assets/aea406cd-d9cd-4259-aad2-257bf4d901b7" />

> [!NOTE]
> Le rendu côté site n'a pas changé