### PR TITLE
fix(compta): Correction de la liste des évènements dans l'édition du journal bancaire

### DIFF
--- a/sources/AppBundle/Accounting/Form/TransactionType.php
+++ b/sources/AppBundle/Accounting/Form/TransactionType.php
@@ -226,7 +226,7 @@ class TransactionType extends AbstractType
     {
         $choices = [];
         /** @var Event $event */
-        foreach ($this->eventRepository->getAllSortedByName(true) as $event) {
+        foreach ($this->eventRepository->getAllSortedByName() as $event) {
             $choices[$event->name] = $event->id;
         }
 


### PR DESCRIPTION
Bug remonté sur [Slack](https://afup.slack.com/archives/C03L64VE9/p1771840759980139).

On peut voir dans le commit de refonte, le legacy utilisait la methode `Afup\Site\Comptabilite\Comptabilite::obtenirListEvenements()` (cf. [compta_journal.php:104](https://github.com/afup/web/commit/4b6d3262a135d97a2b1b18810e10661c0a1616ad#diff-76bd932433fab4f90224549069d0de5b421e984b9832367e31fcc7e1a7da595cL104)).