### PR TITLE
Récupération de l'url de la photo des meetups

### DIFF
--- a/db/migrations/20260302194613_add_photo_url_to_meetup_table.php
+++ b/db/migrations/20260302194613_add_photo_url_to_meetup_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddPhotoUrlToMeetupTable extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_meetup')
+            ->addColumn('photo_url', 'string', [
+                'null' => true,
+            ])
+            ->update();
+    }
+}

--- a/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
+++ b/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
@@ -59,6 +59,7 @@ class ScrappingMeetupEventsCommand extends Command
                     $existingMeetup->setDescription($meetup->getDescription());
                     $existingMeetup->setLocation($meetup->getLocation());
                     $existingMeetup->setDate($meetup->getDate());
+                    $existingMeetup->setPhotoUrl($meetup->getPhotoUrl());
 
                     // On doit remplacer la variable, car l'ORM a une référence vers l'instance récupérée
                     // via le get et pas celle de la boucle.

--- a/sources/AppBundle/Controller/Api/Antennes/GetOneAction.php
+++ b/sources/AppBundle/Controller/Api/Antennes/GetOneAction.php
@@ -49,6 +49,7 @@ final readonly class GetOneAction
                 'location' => $nextMeetup->getLocation(),
                 'description' => $nextMeetup->getDescription(),
                 'url' => 'https://www.meetup.com/fr-FR/' . $antenne->meetup->urlName . '/events/' . $nextMeetup->getId(),
+                'photo' => $nextMeetup->getPhotoUrl(),
             ];
         }
 

--- a/sources/AppBundle/Event/Model/Meetup.php
+++ b/sources/AppBundle/Event/Model/Meetup.php
@@ -42,6 +42,8 @@ class Meetup implements NotifyPropertyInterface
      */
     private $antenneName;
 
+    private ?string $photoUrl = null;
+
     /**
      * @return int
      */
@@ -154,5 +156,16 @@ class Meetup implements NotifyPropertyInterface
         $this->antenneName = $antenneName;
 
         return $this;
+    }
+
+    public function getPhotoUrl(): ?string
+    {
+        return $this->photoUrl;
+    }
+
+    public function setPhotoUrl(?string $photoUrl): void
+    {
+        $this->propertyChanged('photoUrl', $this->photoUrl, $photoUrl);
+        $this->photoUrl = $photoUrl;
     }
 }

--- a/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
@@ -89,6 +89,11 @@ class MeetupRepository extends Repository implements MetadataInitializer
                 'columnName' => 'antenne_name',
                 'fieldName' => 'antenneName',
                 'type' => 'string',
+            ])
+            ->addField([
+                'columnName' => 'photo_url',
+                'fieldName' => 'photoUrl',
+                'type' => 'string',
             ]);
 
         return $metadata;

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Node.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Node.php
@@ -8,14 +8,12 @@ use DateTime;
 
 final readonly class Node
 {
-    /**
-     * @param array<Venue> $venues
-     */
     public function __construct(
         public string $id,
         public string $title,
         public string $description,
         public DateTime $dateTime,
-        public array $venues,
+        public Venue $venue,
+        public Photo $displayPhoto,
     ) {}
 }

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Photo.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Photo.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Indexation\Meetups\GraphQL;
+
+final readonly class Photo
+{
+    public function __construct(public string $standardUrl) {}
+}

--- a/sources/AppBundle/Indexation/Meetups/GraphQL/Venue.php
+++ b/sources/AppBundle/Indexation/Meetups/GraphQL/Venue.php
@@ -6,5 +6,5 @@ namespace AppBundle\Indexation\Meetups\GraphQL;
 
 final readonly class Venue
 {
-    public function __construct(public string $name) {}
+    public function __construct(public ?string $name) {}
 }

--- a/sources/AppBundle/Indexation/Meetups/MeetupClient.php
+++ b/sources/AppBundle/Indexation/Meetups/MeetupClient.php
@@ -56,10 +56,8 @@ final readonly class MeetupClient
                 $meetup->setDescription($edge->node->description);
                 $meetup->setDate($edge->node->dateTime);
                 $meetup->setAntenneName($nameAntenne);
-
-                if (($edge->node->venues[0] ?? null) !== null) {
-                    $meetup->setLocation($edge->node->venues[0]->name);
-                }
+                $meetup->setLocation($edge->node->venue->name);
+                $meetup->setPhotoUrl($edge->node->displayPhoto->standardUrl);
 
                 $meetups[] = $meetup;
             }
@@ -93,7 +91,8 @@ fragment EventFragment on Event {
     title
     description
     dateTime
-    venues { name }
+    venue { name }
+    displayPhoto { standardUrl }
 }
 
 fragment GroupFragment on Group {

--- a/tests/unit/AppBundle/Indexation/Meetups/MeetupClientTest.php
+++ b/tests/unit/AppBundle/Indexation/Meetups/MeetupClientTest.php
@@ -57,10 +57,11 @@ final class MeetupClientTest extends TestCase
                                             'title' => 'Upcoming 1',
                                             'description' => 'Desc 1',
                                             'dateTime' => '2025-02-11T18:30:00+01:00',
-                                            'venues' => [
-                                                [
-                                                    'name' => 'Lieu 1',
-                                                ],
+                                            'venue' => [
+                                                'name' => 'Lieu 1',
+                                            ],
+                                            'displayPhoto' => [
+                                                'standardUrl' => 'https://example.com/1',
                                             ],
                                         ],
                                     ],
@@ -70,7 +71,11 @@ final class MeetupClientTest extends TestCase
                                             'title' => 'Upcoming 2',
                                             'description' => 'Desc 2',
                                             'dateTime' => '2025-03-20T18:30:00+01:00',
-                                            'venues' => [
+                                            'venue' => [
+                                                'name' => null,
+                                            ],
+                                            'displayPhoto' => [
+                                                'standardUrl' => 'https://example.com/2',
                                             ],
                                         ],
                                     ],
@@ -84,7 +89,11 @@ final class MeetupClientTest extends TestCase
                                             'title' => 'Past 1',
                                             'description' => 'Desc 3',
                                             'dateTime' => '2019-04-08T18:30:00+01:00',
-                                            'venues' => [
+                                            'venue' => [
+                                                'name' => null,
+                                            ],
+                                            'displayPhoto' => [
+                                                'standardUrl' => 'https://example.com/3',
                                             ],
                                         ],
                                     ],
@@ -94,10 +103,11 @@ final class MeetupClientTest extends TestCase
                                             'title' => 'Past 2',
                                             'description' => 'Desc 4',
                                             'dateTime' => '2020-10-17T18:30:00+01:00',
-                                            'venues' => [
-                                                [
-                                                    'name' => 'Lieu 2',
-                                                ],
+                                            'venue' => [
+                                                'name' => 'Lieu 2',
+                                            ],
+                                            'displayPhoto' => [
+                                                'standardUrl' => 'https://example.com/4',
                                             ],
                                         ],
                                     ],
@@ -121,6 +131,7 @@ final class MeetupClientTest extends TestCase
         self::assertEquals(new \DateTime('2025-02-11T18:30:00+01:00'), $antennes[0]->getDate());
         self::assertEquals('lyon', $antennes[0]->getAntenneName());
         self::assertEquals('Lieu 1', $antennes[0]->getLocation());
+        self::assertEquals('https://example.com/1', $antennes[0]->getPhotoUrl());
 
         self::assertEquals(34, $antennes[1]->getId());
         self::assertEquals('Upcoming 2', $antennes[1]->getTitle());
@@ -128,6 +139,7 @@ final class MeetupClientTest extends TestCase
         self::assertEquals(new \DateTime('2025-03-20T18:30:00+01:00'), $antennes[1]->getDate());
         self::assertEquals('lyon', $antennes[1]->getAntenneName());
         self::assertNull($antennes[1]->getLocation());
+        self::assertEquals('https://example.com/2', $antennes[1]->getPhotoUrl());
 
         self::assertEquals(56, $antennes[2]->getId());
         self::assertEquals('Past 1', $antennes[2]->getTitle());
@@ -135,6 +147,7 @@ final class MeetupClientTest extends TestCase
         self::assertEquals(new \DateTime('2019-04-08T18:30:00+01:00'), $antennes[2]->getDate());
         self::assertEquals('lyon', $antennes[2]->getAntenneName());
         self::assertNull($antennes[2]->getLocation());
+        self::assertEquals('https://example.com/3', $antennes[2]->getPhotoUrl());
 
         self::assertEquals(78, $antennes[3]->getId());
         self::assertEquals('Past 2', $antennes[3]->getTitle());
@@ -142,6 +155,7 @@ final class MeetupClientTest extends TestCase
         self::assertEquals(new \DateTime('2020-10-17T18:30:00+01:00'), $antennes[3]->getDate());
         self::assertEquals('lyon', $antennes[3]->getAntenneName());
         self::assertEquals('Lieu 2', $antennes[3]->getLocation());
+        self::assertEquals('https://example.com/4', $antennes[3]->getPhotoUrl());
     }
 
     private function makeGuzzleMockClient(ResponseInterface $response): HttpClientInterface


### PR DESCRIPTION
Cette PR permet de récupérer l'url de la photo principale d'un meetup, ce qui va servir à l'affichage d'un historique des anciens meetups sur les mini-sites des antennes.