### PR TITLE
Ajout d'une option pour mettre à jour les anciens meetups

### DIFF
--- a/app/config/packages/valinor.yaml
+++ b/app/config/packages/valinor.yaml
@@ -1,0 +1,7 @@
+valinor:
+    console:
+        # When a mapping error occurs during a console command, the output will
+        # automatically be enhanced to show information about errors. The
+        # maximum number of errors that will be displayed can be configured
+        # below, or set to 0 to disable this feature entirely.
+        mapping_errors_to_output: 15

--- a/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
+++ b/sources/AppBundle/Command/ScrappingMeetupEventsCommand.php
@@ -6,6 +6,7 @@ namespace AppBundle\Command;
 
 use AppBundle\Event\Model\Repository\MeetupRepository;
 use AppBundle\Indexation\Meetups\MeetupClient;
+use CuyZ\Valinor\Mapper\MappingError;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,11 +30,16 @@ class ScrappingMeetupEventsCommand extends Command
             ->setName('scrapping-meetup-event')
             ->setAliases(['s-m-e'])
             ->setDescription('Récupère les évènements meetup AFUP sur meetup.com pour les afficher sur le site de l\'afup.')
+            ->addOption('refresh-old-meetups', description: 'Mettre à jour les anciens meetups')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($input->getOption('refresh-old-meetups') === true) {
+            $quantityOfPastEvents = 100;
+        }
+
         $io = new SymfonyStyle($input, $output);
         $io->title('Import des events meetups via scrapping de meetup.com');
 
@@ -44,7 +50,7 @@ class ScrappingMeetupEventsCommand extends Command
         }
 
         try {
-            $meetups = $this->meetupClient->getEvents();
+            $meetups = $this->meetupClient->getEvents($quantityOfPastEvents ?? null);
 
             $io->progressStart(count($meetups));
             foreach ($meetups as $meetup) {
@@ -73,6 +79,11 @@ class ScrappingMeetupEventsCommand extends Command
 
             return Command::SUCCESS;
         } catch (\Exception $e) {
+            if ($e instanceof MappingError) {
+                // Le bundle Valinor affiche automatiquement des détails en cas d'erreur
+                throw $e;
+            }
+
             throw new \Exception('Problème lors du scraping ou de la sauvegarde des évènements Meetup', $e->getCode(), $e);
         }
     }

--- a/sources/AppBundle/Indexation/Meetups/MeetupClient.php
+++ b/sources/AppBundle/Indexation/Meetups/MeetupClient.php
@@ -25,14 +25,14 @@ final readonly class MeetupClient
     /**
      * @return Meetup[]
      */
-    public function getEvents(): array
+    public function getEvents(?int $quantityOfPastEvents = null): array
     {
         $response = $this->httpClient->request('POST', '/gql-ext', [
             'body' => json_encode([
                 'query' => $this->getEventsQuery(),
                 'variables' => [
                     'quantityUpcoming' => self::QUANTITY_UPCOMING_EVENTS,
-                    'quantityPast' => self::QUANTITY_PAST_EVENTS,
+                    'quantityPast' => $quantityOfPastEvents ?? self::QUANTITY_PAST_EVENTS,
                 ],
             ]),
         ]);


### PR DESCRIPTION
C'est utile quand on veut récupérer une donnée de plus qu'on ne sauvegardait pas encore.

En l’occurrence ça va servir pour la PR #2153 pour refresh les urls de photos.