### PR TITLE
Ajout de la liste des meetups d'une antenne

### DIFF
--- a/sources/AppBundle/Controller/Api/Antennes/GetOneAction.php
+++ b/sources/AppBundle/Controller/Api/Antennes/GetOneAction.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Api\Antennes;
 
+use AppBundle\Antennes\Antenne;
 use AppBundle\Antennes\AntenneRepository;
+use AppBundle\Event\Model\Meetup;
 use AppBundle\Event\Model\Repository\MeetupRepository;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -43,15 +45,15 @@ final readonly class GetOneAction
 
         $nextMeetup = $this->meetupRepository->findNextForAntenne($antenne);
         if ($nextMeetup) {
-            $response['next_meetup'] = [
-                'title' => $nextMeetup->getTitle(),
-                'date' => $nextMeetup->getDate()->format('Y-m-d H:i:s'),
-                'location' => $nextMeetup->getLocation(),
-                'description' => $nextMeetup->getDescription(),
-                'url' => 'https://www.meetup.com/fr-FR/' . $antenne->meetup->urlName . '/events/' . $nextMeetup->getId(),
-                'photo' => $nextMeetup->getPhotoUrl(),
-            ];
+            $response['next_meetup'] = $this->transformMeetup($antenne, $nextMeetup);
         }
+
+        $allMeetups = $this->meetupRepository->findAllForAntenne($antenne);
+
+        $response['meetups'] = array_map(
+            fn(Meetup $meetup) => $this->transformMeetup($antenne, $meetup),
+            iterator_to_array($allMeetups->getIterator()),
+        );
 
         return new JsonResponse($response);
     }
@@ -63,5 +65,17 @@ final readonly class GetOneAction
         }
 
         return $prefix . $suffix;
+    }
+
+    private function transformMeetup(Antenne $antenne, Meetup $meetup): array
+    {
+        return [
+            'title' => $meetup->getTitle(),
+            'date' => $meetup->getDate()->format('Y-m-d H:i:s'),
+            'location' => $meetup->getLocation(),
+            'description' => $meetup->getDescription(),
+            'url' => 'https://www.meetup.com/fr-FR/' . $antenne->meetup->urlName . '/events/' . $meetup->getId(),
+            'photo' => $meetup->getPhotoUrl(),
+        ];
     }
 }

--- a/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/MeetupRepository.php
@@ -7,6 +7,7 @@ namespace AppBundle\Event\Model\Repository;
 use AppBundle\Antennes\Antenne;
 use AppBundle\Event\Model\Meetup;
 use Aura\SqlQuery\Common\SelectInterface;
+use CCMBenchmark\Ting\Repository\CollectionInterface;
 use CCMBenchmark\Ting\Repository\HydratorSingleObject;
 use CCMBenchmark\Ting\Repository\Metadata;
 use CCMBenchmark\Ting\Repository\MetadataInitializer;
@@ -41,6 +42,23 @@ class MeetupRepository extends Repository implements MetadataInitializer
             ])
             ->query($this->getCollection(new HydratorSingleObject()))
             ->first();
+    }
+
+    public function findAllForAntenne(Antenne $antenne): ?CollectionInterface
+    {
+        /** @var SelectInterface $qb */
+        $qb = $this->getQueryBuilder(self::QUERY_SELECT);
+        $qb
+            ->from('afup_meetup m')
+            ->cols(['m.*'])
+            ->where('m.antenne_name = :name')
+        ;
+
+        return $this->getPreparedQuery($qb->getStatement())
+            ->setParams([
+                'name' => $antenne->code,
+            ])
+            ->query($this->getCollection(new HydratorSingleObject()));
     }
 
     /**


### PR DESCRIPTION
Pour pouvoir afficher un historique sur les mini-sites.

Plus tard j'aimerais enlever `next_meetup` de la réponse vu que ça fait doublon avec la liste mais je dois le faire dans une autre PR pour pas tout casser sur les mini-sites.