### PR TITLE
on passe le hook de post build dans le dépot

### DIFF
--- a/clevercloud/scripts/cc_post_build_hook.sh
+++ b/clevercloud/scripts/cc_post_build_hook.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+./node_modules/.bin/webpack -p
+php bin/phinx migrate


### PR DESCRIPTION
Au lieu de mettre les commandes dans la variable d'environnement on les met dans un fichier dans le dépot, et indiquera le fichier dans la variable d'environnement.

Cela permettra de versionner cela, et de rajouter le `asset-map:compile` dans cette PR : https://github.com/afup/web/pull/2141

fixes #2156