### PR TITLE
New Relic - changement de dépendance

### DIFF
--- a/app/config/bundles.php
+++ b/app/config/bundles.php
@@ -14,7 +14,7 @@ return [
     JMS\SerializerBundle\JMSSerializerBundle::class => ['all' => true],
     Presta\SitemapBundle\PrestaSitemapBundle::class => ['all' => true],
     EWZ\Bundle\RecaptchaBundle\EWZRecaptchaBundle::class => ['all' => true],
-    Ekino\NewRelicBundle\EkinoNewRelicBundle::class => ['all' => true],
+    Tiime\NewRelicBundle\TiimeNewRelicBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true, 'test' => true],
     Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
     CuyZ\ValinorBundle\ValinorBundle::class => ['all' => true],

--- a/app/config/packages/tiime_new_relic.yaml
+++ b/app/config/packages/tiime_new_relic.yaml
@@ -1,3 +1,3 @@
-ekino_new_relic:
+tiime_new_relic:
     exceptions: true
     deprecations: false

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "doctrine/doctrine-bundle": "^2.18",
     "doctrine/orm": "^3.6",
     "drewm/mailchimp-api": "^2.5",
-    "ekino/newrelic-bundle": "dev-patch-1#2cd9951c163bda2d18a1515b43ee574e51aac871",
     "erusev/parsedown": "^1.6",
     "excelwebzone/recaptcha-bundle": "^1.5",
     "friendsofpear/pear_exception": "0.0.*",
@@ -68,6 +67,7 @@
     "twig/intl-extra": "^3.21",
     "twig/string-extra": "^3.21",
     "twig/twig": "^3.21",
+    "webgriffe/newrelic-bundle": "^2.5.0",
     "webmozart/assert": "^2.1",
     "znk3r/html_common": "*",
     "znk3r/html_quickform": "4.0.2"

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "twig/intl-extra": "^3.21",
     "twig/string-extra": "^3.21",
     "twig/twig": "^3.21",
-    "webgriffe/newrelic-bundle": "^2.5.0",
+    "tiime/newrelic-bundle": "^1.0",
     "webmozart/assert": "^2.1",
     "znk3r/html_common": "*",
     "znk3r/html_quickform": "4.0.2"
@@ -213,10 +213,6 @@
           ]
         }
       }
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/webgriffe/EkinoNewRelicBundle"
     }
   ],
   "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "41949cc47d80cc04d34f176a9d248edf",
+    "content-hash": "0b6692e824bb408f2dcd4fcaddaf326b",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2194,80 +2194,6 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
-        },
-        {
-            "name": "ekino/newrelic-bundle",
-            "version": "dev-patch-1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webgriffe/EkinoNewRelicBundle.git",
-                "reference": "2cd9951c163bda2d18a1515b43ee574e51aac871"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webgriffe/EkinoNewRelicBundle/zipball/2cd9951c163bda2d18a1515b43ee574e51aac871",
-                "reference": "2cd9951c163bda2d18a1515b43ee574e51aac871",
-                "shasum": ""
-            },
-            "require": {
-                "monolog/monolog": "^3.0",
-                "php": "^8.1",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0"
-            },
-            "require-dev": {
-                "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.1",
-                "symfony/framework-bundle": "^6.4|^7.0",
-                "symfony/monolog-bundle": "^3.10",
-                "symfony/phpunit-bridge": "^5.3|^6.0|^7.0",
-                "twig/twig": "^1.32|^2.4|^3.0"
-            },
-            "suggest": {
-                "symfony/monolog-bundle": "^3.10"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Ekino\\NewRelicBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Ekino\\NewRelicBundle\\Tests\\": "Tests/"
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Thomas Rabaix",
-                    "email": "thomas.rabaix@ekino.com",
-                    "homepage": "http://ekino.com"
-                }
-            ],
-            "description": "Integrate New Relic into Symfony2",
-            "homepage": "https://github.com/ekino/EkinoNewRelicBundle",
-            "keywords": [
-                "metric",
-                "monitoring",
-                "performance"
-            ],
-            "support": {
-                "source": "https://github.com/webgriffe/EkinoNewRelicBundle/tree/patch-1"
-            },
-            "time": "2024-05-06T12:52:23+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -10611,6 +10537,71 @@
             "time": "2025-08-27T11:34:33+00:00"
         },
         {
+            "name": "tiime/newrelic-bundle",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Tiime-Software/TiimeNewRelicBundle.git",
+                "reference": "5cb2119b3b12cb23c8bd6ad60e4a9ae02924e2b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Tiime-Software/TiimeNewRelicBundle/zipball/5cb2119b3b12cb23c8bd6ad60e4a9ae02924e2b2",
+                "reference": "5cb2119b3b12cb23c8bd6ad60e4a9ae02924e2b2",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2",
+                "symfony/config": "^5.4|^6.4|^7.0",
+                "symfony/console": "^5.4|^6.4|^7.0",
+                "symfony/dependency-injection": "^5.4|^6.4|^7.0",
+                "symfony/event-dispatcher": "^5.4|^6.4|^7.0",
+                "symfony/http-kernel": "^5.4|^6.4|^7.0"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^5.1",
+                "monolog/monolog": "^3.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/framework-bundle": "^5.4|^6.4|^7.0",
+                "symfony/phpunit-bridge": "^7.1",
+                "twig/twig": "^3.10"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Tiime\\NewRelicBundle\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@ekino.com",
+                    "homepage": "http://ekino.com"
+                },
+                {
+                    "name": "Olivier Dolbeau",
+                    "email": "olivier@bbnt.me"
+                }
+            ],
+            "description": "Integrate New Relic into Symfony",
+            "homepage": "https://github.com/Tiime-Software/TiimeNewRelicBundle",
+            "keywords": [
+                "metric",
+                "monitoring",
+                "newrelic",
+                "performance"
+            ],
+            "support": {
+                "issues": "https://github.com/Tiime-Software/TiimeNewRelicBundle/issues",
+                "source": "https://github.com/Tiime-Software/TiimeNewRelicBundle/tree/v1.0.2"
+            },
+            "time": "2026-03-03T14:50:04+00:00"
+        },
+        {
             "name": "twig/extra-bundle",
             "version": "v3.21.0",
             "source": {
@@ -10893,85 +10884,6 @@
                 }
             ],
             "time": "2025-05-03T07:21:55+00:00"
-        },
-        {
-            "name": "webgriffe/newrelic-bundle",
-            "version": "2.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webgriffe/EkinoNewRelicBundle.git",
-                "reference": "94650b2a457cc058e51870f257256f7814ee6337"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webgriffe/EkinoNewRelicBundle/zipball/94650b2a457cc058e51870f257256f7814ee6337",
-                "reference": "94650b2a457cc058e51870f257256f7814ee6337",
-                "shasum": ""
-            },
-            "require": {
-                "monolog/monolog": "^3.0",
-                "php": "^8.1",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/console": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0"
-            },
-            "require-dev": {
-                "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.1",
-                "symfony/framework-bundle": "^6.4|^7.0",
-                "symfony/monolog-bundle": "^3.10",
-                "symfony/phpunit-bridge": "^5.3|^6.0|^7.0",
-                "twig/twig": "^1.32|^2.4|^3.0"
-            },
-            "suggest": {
-                "symfony/monolog-bundle": "^3.10"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Ekino\\NewRelicBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "Ekino\\NewRelicBundle\\Tests\\": "Tests/"
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Thomas Rabaix",
-                    "email": "thomas.rabaix@ekino.com",
-                    "homepage": "http://ekino.com"
-                },
-                {
-                    "name": "Webgriffe SRL",
-                    "email": "support@webgriffe.com",
-                    "homepage": "https://www.webgriffe.com"
-                }
-            ],
-            "description": "Integrate New Relic into Symfony2",
-            "homepage": "https://github.com/webgriffe/EkinoNewRelicBundle",
-            "keywords": [
-                "metric",
-                "monitoring",
-                "performance"
-            ],
-            "support": {
-                "source": "https://github.com/webgriffe/EkinoNewRelicBundle/tree/2.5.0"
-            },
-            "time": "2025-07-15T08:48:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "feb027f02b839fbccd7700dade0d5585",
+    "content-hash": "41949cc47d80cc04d34f176a9d248edf",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -10895,6 +10895,85 @@
             "time": "2025-05-03T07:21:55+00:00"
         },
         {
+            "name": "webgriffe/newrelic-bundle",
+            "version": "2.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webgriffe/EkinoNewRelicBundle.git",
+                "reference": "94650b2a457cc058e51870f257256f7814ee6337"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webgriffe/EkinoNewRelicBundle/zipball/94650b2a457cc058e51870f257256f7814ee6337",
+                "reference": "94650b2a457cc058e51870f257256f7814ee6337",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^3.0",
+                "php": "^8.1",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "matthiasnoback/symfony-dependency-injection-test": "^4.3|^5.1",
+                "symfony/framework-bundle": "^6.4|^7.0",
+                "symfony/monolog-bundle": "^3.10",
+                "symfony/phpunit-bridge": "^5.3|^6.0|^7.0",
+                "twig/twig": "^1.32|^2.4|^3.0"
+            },
+            "suggest": {
+                "symfony/monolog-bundle": "^3.10"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ekino\\NewRelicBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Ekino\\NewRelicBundle\\Tests\\": "Tests/"
+                }
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Thomas Rabaix",
+                    "email": "thomas.rabaix@ekino.com",
+                    "homepage": "http://ekino.com"
+                },
+                {
+                    "name": "Webgriffe SRL",
+                    "email": "support@webgriffe.com",
+                    "homepage": "https://www.webgriffe.com"
+                }
+            ],
+            "description": "Integrate New Relic into Symfony2",
+            "homepage": "https://github.com/webgriffe/EkinoNewRelicBundle",
+            "keywords": [
+                "metric",
+                "monitoring",
+                "performance"
+            ],
+            "support": {
+                "source": "https://github.com/webgriffe/EkinoNewRelicBundle/tree/2.5.0"
+            },
+            "time": "2025-07-15T08:48:27+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "2.1.2",
             "source": {
@@ -15459,9 +15538,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ekino/newrelic-bundle": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
[ekino/newrelic-bundle](https://github.com/ekino/EkinoNewRelicBundle) n'est plus maintenu, le fork webgriffe a release une version 2.5.0 qui contient le [commit](https://github.com/webgriffe/EkinoNewRelicBundle/commit/2cd9951c163bda2d18a1515b43ee574e51aac871) précédemment ciblé.

Le diff entre le ekino/newrelic-bundle:2.4.0 et webgriffe/newrelic-bundle est [ici](https://github.com/ekino/EkinoNewRelicBundle/compare/2.4.0...webgriffe:EkinoNewRelicBundle:2.5.0).

⚠️ le CHANGELOG du fork webgriffe, n'est pas à jour par rapport au tag/releases, ce qui complique la compréhension des changements qu'apporte chaque version.

Êtes vous d'accord pour passer sur ce fork ? On pourrait le valider sur la preprod par exemple.