### PR TITLE
Setup du mailer Symfony

### DIFF
--- a/app/config/packages/mailer.yaml
+++ b/app/config/packages/mailer.yaml
@@ -1,0 +1,8 @@
+framework:
+    mailer:
+        dsn: 'smtp://%env(SMTP_USERNAME)%:%env(SMTP_PASSWORD)%@%env(SMTP_HOST)%:%env(SMTP_PORT)%'
+
+when@test:
+    framework:
+        mailer:
+            dsn: 'smtp://mailcatcher:1025'

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -122,10 +122,22 @@ services:
             $mailchimp: '@app.mailchimp_api'
             $listId: "%mailchimp_members_list%"
 
-    AppBundle\Email\Mailer\Adapter\MailerAdapter:
+    mailer.adapter.php:
       class: AppBundle\Email\Mailer\Adapter\PhpMailerAdapter
       factory: [AppBundle\Email\Mailer\Adapter\PhpMailerAdapter, createFromConfiguration]
       arguments: ['@Afup\Site\Utils\Configuration']
+
+    mailer.adapter.symfony:
+        class: AppBundle\Email\Mailer\Adapter\SymfonyMailerAdapter
+        autowire: true
+
+    AppBundle\Email\Mailer\Adapter\MailerAdapter: '@mailer.adapter.php'
+
+    mailer.client.symfony:
+        class: AppBundle\Email\Mailer\Mailer
+        autowire: true
+        arguments:
+            $adapter: '@mailer.adapter.symfony'
 
     AppBundle\Mailchimp\EventEventSubscriber:
         arguments:

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,7 @@
     "symfony/http-kernel": "7.3.*",
     "symfony/intl": "7.3.*",
     "symfony/lock": "7.3.*",
+    "symfony/mailer": "^7.4",
     "symfony/mime": "7.3.*",
     "symfony/monolog-bundle": "^3.1",
     "symfony/runtime": "7.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71c83613c2238e2b9357bdcf349e2c11",
+    "content-hash": "feb027f02b839fbccd7700dade0d5585",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2127,6 +2127,73 @@
                 "source": "https://github.com/drewm/mailchimp-api/tree/master"
             },
             "time": "2019-08-06T09:24:58+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
         },
         {
             "name": "ekino/newrelic-bundle",
@@ -7603,6 +7670,90 @@
                 }
             ],
             "time": "2025-09-11T10:12:26+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "reference": "f6ea532250b476bfc1b56699b388a1bdbf168f62",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.2",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
+                "symfony/mime": "^7.2|^8.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/twig-bridge": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/messenger": "^6.4|^7.0|^8.0",
+                "symfony/twig-bridge": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/mime",

--- a/sources/AppBundle/Controller/Admin/Accounting/MembershipFee/SendMembershipFeeInvoiceAction.php
+++ b/sources/AppBundle/Controller/Admin/Accounting/MembershipFee/SendMembershipFeeInvoiceAction.php
@@ -10,11 +10,13 @@ use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\AuditLog\Audit;
 use AppBundle\Email\Mailer\Mailer;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 
 class SendMembershipFeeInvoiceAction extends AbstractController
 {
     public function __construct(
+        #[Autowire('@mailer.client.symfony')]
         private readonly Mailer $mailer,
         private readonly UserRepository $userRepository,
         private readonly Cotisations $cotisations,

--- a/sources/AppBundle/Email/Mailer/Adapter/SymfonyMailerAdapter.php
+++ b/sources/AppBundle/Email/Mailer/Adapter/SymfonyMailerAdapter.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Email\Mailer\Adapter;
+
+use AppBundle\Email\Mailer\MailUser;
+use AppBundle\Email\Mailer\Message;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use UnexpectedValueException;
+
+final readonly class SymfonyMailerAdapter implements MailerAdapter
+{
+    public function __construct(
+        private MailerInterface $mailer,
+    ) {}
+
+    public function send(Message $message): void
+    {
+        $from = $message->getFrom();
+        if (!$from instanceof MailUser) {
+            throw new UnexpectedValueException('Trying to send a mail with no sender');
+        }
+
+        $email = (new Email())
+            ->from(new Address($from->getEmail(), $from->getName()))
+            ->subject($message->getSubject());
+
+        if ($message->isHtml()) {
+            $email->html($message->getContent());
+        } else {
+            $email->text($message->getContent());
+        }
+
+        foreach ($message->getRecipients() as $mailUser) {
+            $email->addTo(new Address($mailUser->getEmail(), $mailUser->getName()));
+        }
+
+        foreach ($message->getCc() as $mailUser) {
+            $email->addCc(new Address($mailUser->getEmail(), $mailUser->getName()));
+        }
+
+        foreach ($message->getBcc() as $mailUser) {
+            $email->addBcc(new Address($mailUser->getEmail(), $mailUser->getName()));
+        }
+
+        foreach ($message->getAttachments() as $attachment) {
+            $email->attachFromPath(
+                $attachment->getPath(),
+                $attachment->getName(),
+                $attachment->getType(),
+            );
+        }
+
+        $this->mailer->send($email);
+    }
+}


### PR DESCRIPTION
Cette PR permet de mettre en place le mailer de Symfony, pour amener à remplacer l'implémentation actuelle à terme.

L'idée finale étant d'ouvrir la porte à divers choses :
- utiliser un package bien à jour
- envoyer les emails en asynchrone avec messenger
- switcher plus facilement de service d'envoi d'emails

Pour éviter la PR big bang risquée, j'ai configurée le container pour ne remplacer l'envoi que d'un seul email pour le moment. Il s'agit d'un email déclenchable depuis le BO pour envoyer à quelqu'un une facture d'une de ses cotisations.

Si tout va bien, je ferais une autre PR pour basculer les autres envois.