### PR TITLE
Add ld+json organization on homepage

### DIFF
--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -1,5 +1,28 @@
 {% extends 'site/base.html.twig' %}
 
+{% block metas %}
+    {{ parent() }}
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "AFUP",
+        "alternateName": "Association Française des Utilisateurs de PHP",
+        "url": "https://afup.org",
+        "logo": "https://afup.org/templates/site/img/logo-afup.svg",
+        "description": "L'AFUP, Association Française des Utilisateurs de PHP, est au cœur de la communauté PHP depuis 2000. Elle vise à favoriser l'échange d'expertises et la diffusion des connaissances.",
+        "foundingDate": "2000",
+        "sameAs": [
+            "https://www.linkedin.com/company/afup",
+            "https://mastodon.online/@afup",
+            "https://bsky.app/profile/afup.org",
+            "https://www.instagram.com/afup_php/",
+            "https://www.youtube.com/c/afupPHP"
+        ]
+    }
+    </script>
+{% endblock %}
+
 {% import _self as home_macros %}
 
 {% macro home_feuille(feuille) %}


### PR DESCRIPTION
**Objectif:** Améliorer la reconnaissance de l'organisation afup à travers sa présence sur le web

**Moyen:** On ajoute un schema ld+json organisation sur la home du domaine principal, permettant de reconnecter l'afup et ses réseaux sociaux. Cela peut aider à améliorer le SEO de l'afup mais également renforcer son autorité dans les LLM grâce à sa présence historique.

Note: je n'ai pas pu le tester en local, si quelqu'un peut valider je lui en serai très reconnaissant 🙇 