### PR TITLE
Google Analytics remise en fonctionnement des Events

### DIFF
--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -16,9 +16,9 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     public function __construct(
         private readonly Parsedown $parsedown,
         private readonly Parsedown $emailParsedown,
-        #[Autowire('%google_analytics_enabled%')]
-        private readonly string $googleAnalyticsEnabled,
-        #[Autowire('%google_analytics_id%')]
+        #[Autowire(env: 'bool:GOOGLE_ANALYTICS_ENABLED')]
+        private readonly bool $googleAnalyticsEnabled,
+        #[Autowire(env: 'GOOGLE_ANALYTICS_ID')]
         private readonly string $googleAnalyticsId,
     ) {}
 

--- a/templates/event/ticket/google_analytics_paybox.js.twig
+++ b/templates/event/ticket/google_analytics_paybox.js.twig
@@ -1,0 +1,10 @@
+{% if payboxResponse.successful %}
+window.gtag("event", "purchase", {
+    transaction_id: "{{ payboxResponse.cmd }}",
+    value: {{ payboxResponse.total/100 }},
+    tax: 0,
+    shipping: 0,
+    currency: "EUR",
+    items: {{ items|json_encode()|raw }}
+});
+{% endif %}

--- a/templates/event/ticket/google_analytics_tickets.js.twig
+++ b/templates/event/ticket/google_analytics_tickets.js.twig
@@ -1,0 +1,18 @@
+window.gtag("event", "purchase", {
+    transaction_id: "{{ invoice.reference }}",
+    value: {{ invoice.amount }},
+    tax: 0,
+    shipping: 0,
+    currency: "EUR",
+    items: [
+    {% for ticket in invoice.tickets %}
+        {
+            item_id: "{{ ticket.id }}",
+            item_name: "{{ ticket.ticketEventType.ticketType.prettyName }}",
+            item_category: "ticket",
+            price: {{ ticket.amount }},
+            quantity: 1
+        }{{ not loop.last ? ',' : '' }}
+    {% endfor %}
+    ]
+});

--- a/templates/event/ticket/paybox_redirect.html.twig
+++ b/templates/event/ticket/paybox_redirect.html.twig
@@ -8,17 +8,28 @@
     <link rel="stylesheet" href="{{ asset('/css/tickets.css') }}" />
 {% endblock %}
 
+{% block google_analytics %}
+    {% embed 'google_analytics.html.twig' %}
+        {% block google_analytics_gtag %}
+            {% include 'event/ticket/google_analytics_paybox.js.twig' with {'payboxResponse': payboxResponse, 'items': [
+                {
+                    item_id: event.id,
+                    item_name: "Tickets "~event.title
+                }
+            ]} only %}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
 {% block content %}
     <div class="col-md-8">
         <h1>Paiement de vos billets</h1>
         <div>
-            <p>
-                {% if payboxResponse.successful %}
-                    Le paiement de votre commande s'est bien passé, merci.
-                {% else %}
-                    Il y a eu une erreur lors de l'enregistrement de votre commande. Pour essayer à nouveau, <a href="{{ url('ticket_payment', {eventSlug: event.path, invoiceRef: invoice.reference}) }}">cliquez-ici</a>
-                {% endif %}
-            </p>
+            {% if payboxResponse.successful %}
+                <p>Le paiement de votre commande s'est bien passé, merci.</p>
+            {% else %}
+                    <p>Il y a eu une erreur lors de l'enregistrement de votre commande. Pour essayer à nouveau, <a href="{{ url('ticket_payment', {eventSlug: event.path, invoiceRef: invoice.reference}) }}">cliquez-ici</a></p>
+            {% endif %}
             <p>
                 Si vous avez la moindre question, n'hésitez pas à contacter <a href="mailto:bonjour@afup.org">bonjour@afup.org</a>.
             </p>

--- a/templates/event/ticket/payment.html.twig
+++ b/templates/event/ticket/payment.html.twig
@@ -9,7 +9,13 @@
 {% endblock %}
 
 {% block google_analytics %}
-    {% include 'google_analytics.html.twig' %}
+    {% embed 'google_analytics.html.twig' %}
+        {% block google_analytics_gtag %}
+            {% if invoice.isFree %}
+                {% include 'event/ticket/google_analytics_tickets.js.twig' with {'invoice': invoice, 'tickets': tickets} only %}
+            {% endif %}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}
 
 {% block content %}
@@ -56,52 +62,4 @@
         </div>
         {% endif %}
     </div>
-
-    {% autoescape 'js' %}
-        <!-- Google Code for Inscription evenement Conversion Page -->
-        <script type="text/javascript">
-            /* <![CDATA[ */
-            var google_conversion_id = 878368884;
-            var google_conversion_language = "fr";
-            var google_conversion_format = "3";
-            var google_conversion_color = "ffffff";
-            var google_conversion_label = "HBjSCKivn2oQ9LDrogM";
-            var google_conversion_value = {{ invoice.amount }};
-            var google_conversion_currency = "EUR";
-            var google_remarketing_only = false;
-            /* ]]> */
-        </script>
-        <script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-        </script>
-        <noscript>
-            <div style="display:inline;">
-                <img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/878368884/?value={{ invoice.amount }}&amp;currency_code=EUR&amp;label=HBjSCKivn2oQ9LDrogM&amp;guid=ON&amp;script=0"/>
-            </div>
-        </noscript>
-
-        <script>
-            // This purchase event uses a different transaction ID
-            // from the previous purchase event so Analytics
-            // doesn't deduplicate the events.
-            // Learn more: https://support.google.com/analytics/answer/12313109
-            gtag("event", "purchase", {
-                transaction_id: "{{ invoice.reference }}",
-                value: {{ invoice.amount }},
-                tax: 0,
-                shipping: 0,
-                currency: "EUR",
-                items: [
-                    {% for ticket in tickets %}
-                    {
-                        item_id: "{{ invoice.reference }}",
-                        item_name: "{{ ticket.ticketEventType.ticketType.prettyName }}",
-                        index: {{ loop.index }},
-                        price: {{ ticket.amount }},
-                        quantity: 1
-                    },
-                    {% endfor %}
-                ]
-            });
-        </script>
-    {% endautoescape %}
 {% endblock %}

--- a/templates/google_analytics.html.twig
+++ b/templates/google_analytics.html.twig
@@ -1,9 +1,12 @@
-<script src="{{ asset('/assets/tarteaucitron/tarteaucitron.js') }}"></script>
-<script src="{{ asset('/js/tarteaucitron.js') }}"></script>
+{% if google_analytics_enabled %}
+    <script src="{{ asset('/assets/tarteaucitron/tarteaucitron.js') }}"></script>
+    <script src="{{ asset('/js/tarteaucitron.js') }}"></script>
 
-<script type="text/javascript">
-    tarteaucitron.user.gtagUa = '{{ google_analytics_id }}';
-    // tarteaucitron.user.gtagCrossdomain = ['example.com', 'example2.com'];
-    tarteaucitron.user.gtagMore = function () { /* add here your optionnal gtag() */ };
-    (tarteaucitron.job = tarteaucitron.job || []).push('gtag');
-</script>
+    <script type="text/javascript">
+        tarteaucitron.user.gtagUa = '{{ google_analytics_id }}';
+        tarteaucitron.user.gtagMore = function () {
+            {% block google_analytics_gtag %}{% endblock %}
+        };
+        (tarteaucitron.job = tarteaucitron.job || []).push('gtag');
+    </script>
+{% endif %}

--- a/templates/site/company_membership/paybox_redirect.html.twig
+++ b/templates/site/company_membership/paybox_redirect.html.twig
@@ -1,4 +1,18 @@
 {% extends 'site/base.html.twig' %}
+
+{% block google_analytics %}
+    {% embed 'google_analytics.html.twig' %}
+        {% block google_analytics_gtag %}
+            {% include 'event/ticket/google_analytics_paybox.js.twig' with {'payboxResponse': payboxResponse, 'items': [
+                {
+                    item_id: "001",
+                    item_name: "Cotisation"
+                }
+            ]} only %}
+        {% endblock %}
+    {% endembed %}
+{% endblock %}
+
 {% block inner_content %}
     <div class="col-md-8">
         <h2>Paiement de votre cotisation</h2>


### PR DESCRIPTION
Remise en fonctionnement du tracking des achats pour Google Analytics via l'envoi d'un Event purchase.

Ces évènements doivent être envoyés dans la fonction `gtagMore` de `tarteaucitron.js`.