### PR TITLE
CFP: Ajout d'une case à cocher validation la lecture du precessus de selection des talks #2173

### DIFF
--- a/sources/AppBundle/Event/Form/TalkType.php
+++ b/sources/AppBundle/Event/Form/TalkType.php
@@ -16,6 +16,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class TalkType extends AbstractType
 {
     public const OPT_COC_CHECKED = 'codeOfConductChecked';
+    public const OPT_SELECTION_ACKNOWLEDGEMENT_CHECKED = 'selectionAcknowledgementChecked';
     public const IS_AFUP_DAY = 'isAfupDay';
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
@@ -65,10 +66,16 @@ class TalkType extends AbstractType
             'required' => false,
         ])
         ->add('codeOfConduct', CheckboxType::class, [
-            'label' => 'J\'accepte le code de conduite et les conditions générales de participation (1)',
+            'label' => 'J\'accepte le code de conduite et les conditions générales de participation (2)',
             'mapped' => false,
             'required' => true,
             'data' => $options[self::OPT_COC_CHECKED],
+        ])
+        ->add('selectionAcknowledgement', CheckboxType::class, [
+            'label' => 'J\'ai bien pris connaissance du processus de sélection des conférences (3)',
+            'mapped' => false,
+            'required' => true,
+            'data' => $options[self::OPT_SELECTION_ACKNOWLEDGEMENT_CHECKED],
         ])
         ->add('hasAllowedToSharingWithLocalOffices', ChoiceType::class, [
             'choices' => [
@@ -89,6 +96,7 @@ class TalkType extends AbstractType
     {
         $resolver->setDefaults([
             self::OPT_COC_CHECKED => false,
+            self::OPT_SELECTION_ACKNOWLEDGEMENT_CHECKED => false,
             self::IS_AFUP_DAY => false,
         ]);
     }

--- a/templates/event/cfp/form.html.twig
+++ b/templates/event/cfp/form.html.twig
@@ -18,6 +18,7 @@
 
     {{ form_row(form.needsMentoring) }}
     {{ form_row(form.codeOfConduct) }}
+    {{ form_row(form.selectionAcknowledgement) }}
     <div class="row">
         <div class="col-sm-12">
             {{ form_label(form.hasAllowedToSharingWithLocalOffices) }}

--- a/templates/event/cfp/propose.html.twig
+++ b/templates/event/cfp/propose.html.twig
@@ -18,8 +18,9 @@
 
         {% include 'event/cfp/form.html.twig' with {'form': form} %}
 
-        <p>(1) {{ 'code_of_conduct_warning'|trans|raw }}</p>
-        <p>(2) {{ 'Ces notes facultatives peuvent contenir des informations sur votre conférence que vous ne voudriez pas voir apparaitre sur le système de vote et dans le programme'|trans }}.</p>
+        <p>(1) {{ 'Ces notes facultatives peuvent contenir des informations sur votre conférence que vous ne voudriez pas voir apparaitre sur le système de vote et dans le programme'|trans }}.</p>
+        <p>(2) {{ 'code_of_conduct_warning'|trans|raw }}</p>
+        <p>(3) {{ 'talks_selection_acknowledgement'|trans|raw }}</p>
     </div>
     {{ sidebar|raw }}
 {% endblock %}

--- a/tests/behat/features/EventPages/Cfp.feature
+++ b/tests/behat/features/EventPages/Cfp.feature
@@ -55,6 +55,7 @@ Feature: Event pages - CFP
     And I fill in "talk[abstract]" with "L'histoire des poissons rouges à travers les ages"
     And I fill in "talk[hasAllowedToSharingWithLocalOffices]" with "1"
     And I check "talk[codeOfConduct]"
+    And I check "talk[selectionAcknowledgement]"
     # Proposition d'atelier présent
     And I should see "Je propose de faire un atelier"
     And I should see "nous souhaitons proposer des ateliers"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -14,7 +14,8 @@
 'Notes aux organisateurs (2)': 'Notes to organizers (2)'
 'Je propose de faire un atelier': 'I propose a workshop'
 'Je souhaite profiter du programme d''accompagnement des jeunes speakers': 'I''d like to take advantage of the support program for young speakers'
-'J''accepte le code de conduite et les conditions générales de participation (1)': 'I accept the code of conduct and the general conditions of participation (1)'
+'J''accepte le code de conduite et les conditions générales de participation (2)': 'I accept the code of conduct and the general conditions of participation (2)'
+'J''ai bien pris connaissance du processus de sélection des conférences (3)': 'I have carefully reviewed the talks selection process (3)'
 'Autoriser l’AFUP à transmettre ma proposition de conférence à ses antennes locales ?': 'Authorize AFUP to forward my conference proposal to its local branches?'
 'J''autorise': 'I authorize'
 'Je refuse': 'I refuse'
@@ -98,6 +99,8 @@ type.3: '20 mn'
 code_of_conduct_warning: |
   The code of conduct is <a href="https://afup.org/p/985-code-of-conduct" target="_blank">available online</a>.<br />
   As a speaker, I agree to be filmed and photographed free of charge for the exclusive benefit of AFUP, for distribution on the Internet or on any other communication medium distributed in particular in Europe, for a period of 10 years after my conference.
+talks_selection_acknowledgement: |
+  The selection process is <a href="https://event.afup.org/processus-de-selection-eventsafup/" target="_blank">available online</a>.
 Phone: Phone
 Position: Position
 Language: Language

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -226,6 +226,8 @@ cfp_propose_workshop: |
   Lors de l’événement, nous souhaitons proposer des ateliers d’une durée de 2 heures avec une vingtaine de participant(e)s
   qui se seront inscrit(e)s préalablement. Seulement les speakers sélectionné(e)s effectueraient un atelier.
   Cochez cette case et renseignez la zone de texte ci-dessous si vous souhaitez proposer un atelier.
+talks_selection_acknowledgement: |
+  Le processus de sélection est <a href="https://event.afup.org/processus-de-selection-eventsafup/" target="_blank">consultable en ligne</a>.
 cfp_authorize_forward: |
   Les équipes des antennes AFUP peuvent être intéressées par votre sujet en vue d’un événement local
   (meetup, Super Apéro PHP, soirée d’élection dans l’antenne...) et pourrait aimer vous inviter dans leur ville.


### PR DESCRIPTION
**Français**

Avant :
<img width="1255" height="554" alt="CFP_before_fr" src="https://github.com/user-attachments/assets/9e009ac5-eb52-4256-b2e3-598ae1c525c9" />
Après :
<img width="1255" height="625" alt="CFP_after_fr" src="https://github.com/user-attachments/assets/1bfadf8f-7411-40d5-a8df-8996b46cc486" />


**Anglais**
Avant :
<img width="1255" height="554" alt="CFP_before_en" src="https://github.com/user-attachments/assets/513df946-ab3a-457d-b831-3db8267e8bc3" />

après :
<img width="1255" height="625" alt="CFP_after_en" src="https://github.com/user-attachments/assets/17742ff6-fb72-43ab-9be9-9c2d25485073" />



J'ai aussi réordonné les notes en pied de pages pour plus de cohérence.

resolves #2173 