### PR TITLE
Intégration des posts Bluesky sur les pages de talks

### DIFF
--- a/app/config/packages/http_client.yaml
+++ b/app/config/packages/http_client.yaml
@@ -11,3 +11,5 @@ framework:
                     Content-Type: 'application/json'
             http_client.bluesky:
                 base_uri: 'https://bsky.social'
+            http_client.bluesky_embed:
+                base_uri: 'https://embed.bsky.app'

--- a/db/migrations/20260421000000_talk_bluesky_posts.php
+++ b/db/migrations/20260421000000_talk_bluesky_posts.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+class TalkBlueskyPosts extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->execute("ALTER TABLE `afup_sessions` ADD `bluesky_posts` text DEFAULT NULL AFTER `tweets`");
+    }
+}

--- a/db/seeds/Session.php
+++ b/db/seeds/Session.php
@@ -79,6 +79,7 @@ il souffre aussi de d&eacute;fauts souvent sous-estim&eacute;s parmi lesquels l&
                 'joindin' => 24138,
                 'date_publication' => (new \DateTime())->modify('-1 days')->format('Y-m-d H:i:s'),
                 'has_allowed_to_sharing_with_local_offices' => 1,
+                'bluesky_posts' => 'https://bsky.app/profile/us.theguardian.com/post/3mjxal5k3rs2t',
             ],
             [
                 'session_id' => 3,

--- a/db/seeds/Session.php
+++ b/db/seeds/Session.php
@@ -79,7 +79,7 @@ il souffre aussi de d&eacute;fauts souvent sous-estim&eacute;s parmi lesquels l&
                 'joindin' => 24138,
                 'date_publication' => (new \DateTime())->modify('-1 days')->format('Y-m-d H:i:s'),
                 'has_allowed_to_sharing_with_local_offices' => 1,
-                'bluesky_posts' => 'https://bsky.app/profile/us.theguardian.com/post/3mjxal5k3rs2t',
+                'bluesky_posts' => 'https://bsky.app/profile/afup.org/post/3mjk3hmqxxe2d',
             ],
             [
                 'session_id' => 3,

--- a/sources/AppBundle/Event/Form/TalkAdminType.php
+++ b/sources/AppBundle/Event/Form/TalkAdminType.php
@@ -77,6 +77,10 @@ class TalkAdminType extends TalkType
                 'label' => 'Tweets',
                 'required' => false,
             ])
+            ->add('blueskyPosts', TextareaType::class, [
+                'label' => 'Posts Bluesky',
+                'required' => false,
+            ])
             ->add('submittedOn', DateTimeType::class, [
                 'label' => 'Date de soumission',
             ])

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -568,6 +568,11 @@ SQL;
                 'type' => 'string',
             ])
             ->addField([
+                'columnName' => 'bluesky_posts',
+                'fieldName' => 'blueskyPosts',
+                'type' => 'string',
+            ])
+            ->addField([
                 'columnName' => 'transcript',
                 'fieldName' => 'transcript',
                 'type' => 'string',

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -83,6 +83,8 @@ class Talk implements NotifyPropertyInterface
 
     private ?string $tweets = null;
 
+    private ?string $blueskyPosts = null;
+
     private ?string $transcript = null;
 
     private ?string $verbatim = null;
@@ -613,6 +615,40 @@ class Talk implements NotifyPropertyInterface
         }
 
         return $returnedTweets;
+    }
+
+    public function getBlueskyPosts(): ?string
+    {
+        return $this->blueskyPosts;
+    }
+
+    public function setBlueskyPosts(?string $blueskyPosts): self
+    {
+        $this->propertyChanged('blueskyPosts', $this->blueskyPosts, $blueskyPosts);
+        $this->blueskyPosts = $blueskyPosts;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string>
+     */
+    public function getBlueskyPostsAsArray(): array
+    {
+        if (!$this->getBlueskyPosts()) {
+            return [];
+        }
+        $returnedPosts = [];
+        foreach (explode(PHP_EOL, $this->getBlueskyPosts()) as $post) {
+            $post = trim($post);
+            if ($post === '' || $post === '0') {
+                continue;
+            }
+
+            $returnedPosts[] = $post;
+        }
+
+        return $returnedPosts;
     }
 
     public function getHasAllowedToSharingWithLocalOffices(): bool

--- a/sources/AppBundle/SocialNetwork/Bluesky/BlueskyOembedClient.php
+++ b/sources/AppBundle/SocialNetwork/Bluesky/BlueskyOembedClient.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\SocialNetwork\Bluesky;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final readonly class BlueskyOembedClient
+{
+    public function __construct(
+        #[Autowire('@http_client.bluesky_embed')]
+        private HttpClientInterface $httpClient,
+        #[Autowire('@cache.system')]
+        private CacheItemPoolInterface $cache,
+    ) {}
+
+    public function getEmbedHtml(string $url): string
+    {
+        $cacheItem = $this->cache->getItem('bluesky_oembed_' . md5($url));
+
+        if (!$cacheItem->isHit()) {
+            try {
+                $response = $this->httpClient->request('GET', '/oembed', [
+                    'query' => ['url' => $url, 'format' => 'json'],
+                ]);
+                $data = $response->toArray();
+                // Strip the embed.js <script> tag — we output it once in the template
+                $html = preg_replace('/<script\b[^>]*embed\.bsky\.app[^>]*><\/script>/', '', $data['html'] ?? '');
+            } catch (\Throwable) {
+                $html = '';
+            }
+
+            $cacheItem->set($html);
+            $this->cache->save($cacheItem);
+        }
+
+        return (string) $cacheItem->get();
+    }
+}

--- a/sources/AppBundle/Twig/TwigExtension.php
+++ b/sources/AppBundle/Twig/TwigExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Twig;
 
+use AppBundle\SocialNetwork\Bluesky\BlueskyOembedClient;
 use Parsedown;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Twig\Extension\AbstractExtension;
@@ -16,6 +17,7 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
     public function __construct(
         private readonly Parsedown $parsedown,
         private readonly Parsedown $emailParsedown,
+        private readonly BlueskyOembedClient $blueskyOembedClient,
         #[Autowire(env: 'bool:GOOGLE_ANALYTICS_ENABLED')]
         private readonly bool $googleAnalyticsEnabled,
         #[Autowire(env: 'GOOGLE_ANALYTICS_ID')]
@@ -34,6 +36,10 @@ class TwigExtension extends AbstractExtension implements GlobalsInterface
                     return $response;
                 }
                 return '';
+            }, ['is_safe' => ['html']]),
+            new TwigFunction('bluesky_oembed', function (string $url): string {
+                $html = $this->blueskyOembedClient->getEmbedHtml($url);
+                return $html ?: '<a href="' . htmlspecialchars($url) . '">' . htmlspecialchars($url) . '</a>';
             }, ['is_safe' => ['html']]),
         ];
     }

--- a/templates/admin/talk/form.html.twig
+++ b/templates/admin/talk/form.html.twig
@@ -30,6 +30,7 @@
         {{ form_row(form.interviewUrl) }}
         {{ form_row(form.languageCode) }}
         {{ form_row(form.tweets) }}
+        {{ form_row(form.blueskyPosts) }}
         {{ form_row(form.verbatim, {attr: {class: 'simplemde'}}) }}
     </div>
     <div class="ui segment">

--- a/templates/site/talks/show.html.twig
+++ b/templates/site/talks/show.html.twig
@@ -217,6 +217,30 @@
         </div>
         {% endif %}
 
+        {% if talk.getBlueskyPostsAsArray|length > 0 %}
+        <div class="container">
+            <div class="col-md-12">
+                <div class="container comments-title-container">
+                    <div class="col-md-12">
+                        <h2>Posts Bluesky</h2>
+                    </div>
+                </div>
+
+                {% for posts_batch in talk.getBlueskyPostsAsArray|batch(4) %}
+                    <div class="container">
+                        {% for post in posts_batch %}
+                            <div class="col-md-3">
+                                {{ bluesky_oembed(post) }}
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+
+            </div>
+            <script async src="https://embed.bsky.app/static/embed.js" charset="utf-8"></script>
+        </div>
+        {% endif %}
+
         {% if comments|length > 0 %}
             {% include 'common/star.html.twig' %}
             <div class="container">

--- a/tests/behat/features/Admin/Events/Conferences.feature
+++ b/tests/behat/features/Admin/Events/Conferences.feature
@@ -37,6 +37,18 @@ Feature: Administration - Évènements - Conférences
     And I should see "Adrien Gallou"
 
   @reloadDbWithTestData
+  Scenario: Ajout de posts Bluesky à une conférence
+    Given I am logged in as admin and on the Administration
+    And I follow "Conférences"
+    When I follow the button of tooltip "Modifier la conférence Jouons tous ensemble à un petit jeu"
+    Then I fill in "talk_admin[blueskyPosts]" with "https://bsky.app/profile/afup.bsky.social/post/3lnuwy2cces2g"
+    And I press "Soumettre"
+    Then I should see "La conférence a été modifiée"
+    When I go to "/talks/1-jouons-tous-ensemble-a-un-petit-jeu"
+    Then I should see "Posts Bluesky"
+    And the response should contain "https://bsky.app/profile/afup.bsky.social/post/3lnuwy2cces2g"
+
+  @reloadDbWithTestData
   Scenario: Modification d'une conférence
     Given I am logged in as admin and on the Administration
     And I follow "Conférences"

--- a/tests/behat/features/Admin/Events/Conferences.feature
+++ b/tests/behat/features/Admin/Events/Conferences.feature
@@ -46,7 +46,7 @@ Feature: Administration - Évènements - Conférences
     Then I should see "La conférence a été modifiée"
     When I go to "/talks/1-jouons-tous-ensemble-a-un-petit-jeu"
     Then I should see "Posts Bluesky"
-    And the response should contain "https://bsky.app/profile/afup.bsky.social/post/3lnuwy2cces2g"
+    And the response should contain "3lnuwy2cces2g"
 
   @reloadDbWithTestData
   Scenario: Modification d'une conférence

--- a/tests/behat/features/Admin/Events/Conferences.feature
+++ b/tests/behat/features/Admin/Events/Conferences.feature
@@ -41,12 +41,12 @@ Feature: Administration - Évènements - Conférences
     Given I am logged in as admin and on the Administration
     And I follow "Conférences"
     When I follow the button of tooltip "Modifier la conférence Jouons tous ensemble à un petit jeu"
-    Then I fill in "talk_admin[blueskyPosts]" with "https://bsky.app/profile/afup.bsky.social/post/3lnuwy2cces2g"
+    Then I fill in "talk_admin[blueskyPosts]" with "https://bsky.app/profile/afup.org/post/3mjmmwpp34f2r"
     And I press "Soumettre"
     Then I should see "La conférence a été modifiée"
     When I go to "/talks/1-jouons-tous-ensemble-a-un-petit-jeu"
     Then I should see "Posts Bluesky"
-    And the response should contain "3lnuwy2cces2g"
+    And the response should contain "3mjmmwpp34f2r"
 
   @reloadDbWithTestData
   Scenario: Modification d'une conférence

--- a/tests/behat/features/PublicSite/Talks.feature
+++ b/tests/behat/features/PublicSite/Talks.feature
@@ -22,6 +22,12 @@ Feature: Site Public - Talks
 
 
   @reloadDbWithTestData
+  Scenario: Affichage des posts Bluesky sur la page d'un talk
+    When I go to "/talks/2-rest-ou-graphql-exemples-illustres-avec-symfony-et-api-platform"
+    Then I should see "Posts Bluesky"
+    And the response should contain "bsky.app/profile/us.theguardian.com/post/3mjxal5k3rs2t"
+
+  @reloadDbWithTestData
   Scenario: Accès à la liste des vidéos d'un speaker
     When I go to "/talks/?fR[speakers.label][0]=Un Speaker"
     Then I should see "Les vidéos de Un Speaker"

--- a/tests/behat/features/PublicSite/Talks.feature
+++ b/tests/behat/features/PublicSite/Talks.feature
@@ -25,7 +25,7 @@ Feature: Site Public - Talks
   Scenario: Affichage des posts Bluesky sur la page d'un talk
     When I go to "/talks/2-rest-ou-graphql-exemples-illustres-avec-symfony-et-api-platform"
     Then I should see "Posts Bluesky"
-    And the response should contain "3mjxal5k3rs2t"
+    And the response should contain "3mjk3hmqxxe2d"
 
   @reloadDbWithTestData
   Scenario: Accès à la liste des vidéos d'un speaker

--- a/tests/behat/features/PublicSite/Talks.feature
+++ b/tests/behat/features/PublicSite/Talks.feature
@@ -25,7 +25,7 @@ Feature: Site Public - Talks
   Scenario: Affichage des posts Bluesky sur la page d'un talk
     When I go to "/talks/2-rest-ou-graphql-exemples-illustres-avec-symfony-et-api-platform"
     Then I should see "Posts Bluesky"
-    And the response should contain "bsky.app/profile/us.theguardian.com/post/3mjxal5k3rs2t"
+    And the response should contain "3mjxal5k3rs2t"
 
   @reloadDbWithTestData
   Scenario: Accès à la liste des vidéos d'un speaker


### PR DESCRIPTION
## Description

Ajout de l'affichage des posts Bluesky sur les pages de talks, en miroir du système existant pour les tweets.

- Nouveau champ `bluesky_posts` en base de données (migration Phinx)
- Champ texte dans le formulaire d'administration (une URL par ligne)
- Affichage côté public via l'API oEmbed de Bluesky (`embed.bsky.app/oembed`), avec mise en cache serveur
- Fallback vers un lien simple si l'API oEmbed est inaccessible

## Issue

Ferme #2103

## Tests

- Scénario Behat : ajout de posts Bluesky via l'admin et vérification de l'affichage sur la page publique
- Scénario Behat : affichage des posts Bluesky sur la page d'un talk

## Screenshots

<img width="665" height="521" alt="Capture d’écran 2026-04-21 à 17 29 34" src="https://github.com/user-attachments/assets/1ae68999-7d83-4002-9866-5d15b0c6456d" />