### PR TITLE
Séparation des tests behat avec et sans javascript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
       - name: PHPStan
         run: php ./bin/phpstan
 
-  functional:
-    name: "Functional tests"
+  functional-no-js:
+    name: "Functional tests (no JS)"
     runs-on: ubuntu-22.04
 
     steps:
@@ -95,17 +95,55 @@ jobs:
       - name: Delete symfony cache
         run: rm -rf var/cache/test
 
-      - name: Tests - Functional
-        run: make test-functional
+      - name: Tests - Functional (no JS)
+        run: make test-functional-no-js
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Functional tests - deprecated log - full
+          name: Functional tests (no JS) - deprecated log - full
           path: var/logs/test.deprecations.log
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Functional tests - deprecated log - report
+          name: Functional tests (no JS) - deprecated log - report
+          path: var/logs/test.deprecations_grouped.log
+
+  functional-js:
+    name: "Functional tests (JS)"
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Cache Docker images.
+        uses: AndreKurait/docker-cache@0.6.0
+        with:
+          key: |
+            docker-${{ runner.os }}-${{ hashFiles(
+              'compose.yml',
+              'docker/dockerfiles/apachephp/Dockerfile',
+              'docker/dockerfiles/mysql/Dockerfile',
+              'docker/dockerfiles/mysqltest/Dockerfile'
+            ) }}
+
+      - name: Delete symfony cache
+        run: rm -rf var/cache/test
+
+      - name: Tests - Functional (JS)
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: make test-functional-js
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Functional tests (JS) - deprecated log - full
+          path: var/logs/test.deprecations.log
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Functional tests (JS) - deprecated log - report
           path: var/logs/test.deprecations_grouped.log
 
   integration:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ help:
 	} \
 	{ lastLine = $$0 }' $(MAKEFILE_LIST)
 
-.PHONY: install docker-up docker-stop docker-down test hooks vendors db-seed db-migrations reset-db init console phpstan assets
+.PHONY: install docker-up docker-stop docker-down test test-functional test-functional-no-js test-functional-js hooks vendors db-seed db-migrations reset-db init console phpstan assets
 
 ##@ Setup
 
@@ -108,6 +108,26 @@ test-functional: data config htdocs/uploads tmp
 	make clean-test-deprecated-log
 	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/bdi detect drivers
 	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/behat
+	make var/logs/test.deprecations_grouped.log
+	$(DOCKER_COMP) stop dbtest apachephptest mailcatcher
+
+### Tests fonctionnels (scénarios sans JS)
+test-functional-no-js: data config htdocs/uploads tmp
+	$(DOCKER_COMP) stop dbtest apachephptest mailcatcher
+	$(DOCKER_COMP) up -d dbtest apachephptest mailcatcher
+	make clean-test-deprecated-log
+	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/bdi detect drivers
+	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/behat --suite=web_features_no_js
+	make var/logs/test.deprecations_grouped.log
+	$(DOCKER_COMP) stop dbtest apachephptest mailcatcher
+
+### Tests fonctionnels (scénarios JS via Panther)
+test-functional-js: data config htdocs/uploads tmp
+	$(DOCKER_COMP) stop dbtest apachephptest mailcatcher
+	$(DOCKER_COMP) up -d dbtest apachephptest mailcatcher
+	make clean-test-deprecated-log
+	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/bdi detect drivers
+	$(DOCKER_COMP) run --no-deps --rm -u localUser apachephptest ./bin/behat --suite=web_features_js
 	make var/logs/test.deprecations_grouped.log
 	$(DOCKER_COMP) stop dbtest apachephptest mailcatcher
 

--- a/behat.php
+++ b/behat.php
@@ -3,6 +3,7 @@
 use Afup\Tests\Behat\Bootstrap\FeatureContext;
 use Behat\Config\Config;
 use Behat\Config\Extension;
+use Behat\Config\Filter\TagFilter;
 use Behat\Config\Profile;
 use Behat\Config\Suite;
 use Behat\MinkExtension\Context\MinkContext;
@@ -59,11 +60,21 @@ return (new Config())
                 ],
             ]))
             ->withSuite(
-                (new Suite('web_features'))
+                (new Suite('web_features_no_js'))
                     ->withContexts(
                         FeatureContext::class,
                         MinkContext::class
                     )
                     ->withPaths('%paths.base%/tests/behat')
+                    ->withFilter(new TagFilter('~@javascript-group&&~@javascript'))
+            )
+            ->withSuite(
+                (new Suite('web_features_js'))
+                    ->withContexts(
+                        FeatureContext::class,
+                        MinkContext::class
+                    )
+                    ->withPaths('%paths.base%/tests/behat')
+                    ->withFilter(new TagFilter('@javascript-group,@javascript'))
             )
     );

--- a/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
+++ b/tests/behat/features/Admin/Tresorerie/DevisFactures.feature
@@ -137,6 +137,7 @@ Feature: Administration - Trésorerie - Devis/Facture
     Then I should see "Télécharger la facture en PDF"
 
   # On n'utilise pas @reloadDbWithTestData pour conserver les données
+  @javascript-group
   Scenario: Téléchargement d'un devis et d'une facture
     Given I am logged in as admin and on the Administration
     When I follow "Devis"


### PR DESCRIPTION
Cela permet d'avoir du retry auto des tests avec js qui peuvent être un
peu flaky de temps en temps.

Un tag `@javascript-group` permet d'inclure un scénario dans la suite js
mais qui sera exécuté avec le moteur classique (sans javascript donc).

Cela permet par exemple d'avoir un scénario dépendant d'un autre qui
fait du javascript, tout en pouvant utiliser certaines assertions qui ne
fonctionnent qu'avec le moteur classique (les headers HTTP notamment).