### PR TITLE
Amélioration des perfs docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,16 +71,26 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache Docker images.
-        uses: AndreKurait/docker-cache@0.6.0
+      - name: Create .env from .env.dist
+        run: cp .env.dist .env
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build images with GHA cache
+        uses: docker/bake-action@v7
         with:
-          key: |
-            docker-${{ runner.os }}-${{ hashFiles(
-              'compose.yml',
-              'docker/dockerfiles/apachephp/Dockerfile',
-              'docker/dockerfiles/mysql/Dockerfile',
-              'docker/dockerfiles/mysqltest/Dockerfile'
-            ) }}
+          files: |
+            compose.yml
+            compose.override.yml-dist
+          targets: |
+            apachephp
+            apachephptest
+          load: true
+          set: |
+            apachephp.cache-from=type=gha,scope=apachephp-full
+            apachephp.cache-to=type=gha,scope=apachephp-full,mode=max
+            apachephptest.cache-from=type=gha,scope=apachephp-full
+            apachephptest.cache-to=type=gha,scope=apachephp-full,mode=max
 
       - name: Delete symfony cache
         run: rm -rf var/cache/test
@@ -101,20 +111,30 @@ jobs:
   integration:
     name: "Integration tests"
     runs-on: ubuntu-22.04
+    env:
+      APACHEPHPTEST_TARGET: base
 
     steps:
       - uses: actions/checkout@v6
 
-      - name: Cache Docker images.
-        uses: AndreKurait/docker-cache@0.6.0
+      - name: Create .env from .env.dist
+        run: cp .env.dist .env
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Build images with GHA cache
+        uses: docker/bake-action@v7
         with:
-          key: |
-            docker-${{ runner.os }}-${{ hashFiles(
-              'compose.yml',
-              'docker/dockerfiles/apachephp/Dockerfile',
-              'docker/dockerfiles/mysql/Dockerfile',
-              'docker/dockerfiles/mysqltest/Dockerfile'
-            ) }}
+          files: |
+            compose.yml
+            compose.override.yml-dist
+          targets: |
+            apachephptest
+            dbtest
+          load: true
+          set: |
+            apachephptest.cache-from=type=gha,scope=apachephp-base
+            apachephptest.cache-to=type=gha,scope=apachephp-base,mode=max
 
       - name: Delete symfony cache
         run: rm -rf var/cache/test

--- a/compose.yml
+++ b/compose.yml
@@ -27,6 +27,7 @@ services:
   apachephp:
     build:
       context: ./docker/dockerfiles/apachephp
+      target: ${APACHEPHP_TARGET:-full}
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"
@@ -48,6 +49,7 @@ services:
   apachephptest:
     build:
       context: ./docker/dockerfiles/apachephp
+      target: ${APACHEPHPTEST_TARGET:-full}
       args:
         uid: ${CURRENT_UID:-1001}
         gid: "1001"

--- a/docker/dockerfiles/apachephp/Dockerfile
+++ b/docker/dockerfiles/apachephp/Dockerfile
@@ -1,49 +1,35 @@
-FROM php:8.2-apache
+FROM php:8.2-apache AS base
 
 ARG ENABLE_XDEBUG=false
 ARG uid=1008
 ARG gid=1008
 
+# Download PHP extension installer
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+
 ## Update system
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get autoremove --purge -y && \
-    rm -rf /var/lib/apt/lists/* && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
     # Create user for Apache
     groupadd -g ${gid} localUser && \
     useradd -l -u ${uid} -g ${gid} -m -s /bin/bash localUser && \
-    usermod -a -G www-data localUser
+    usermod -a -G www-data localUser && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN if [ "$ENABLE_XDEBUG" = "true" ]; then echo ************ XDEBUG ENABLED **********; \
-else echo ------------ XDEBUG DISABLED ==========; fi
-
-RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
-
-# Install required PHP extensions for AFUP website and other management package
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-        libfreetype6-dev \
-        libjpeg62-turbo-dev \
-        libpng-dev \
-        libzip-dev \
-        libmcrypt4 \
-        libicu-dev \
-        nodejs \
-        chromium \
-    && \
-        docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && \
-    docker-php-ext-install \
+RUN install-php-extensions \
         pdo_mysql \
         mysqli \
         zip \
         gd \
         intl \
-        pcntl \
-    && \
-    if [ "$ENABLE_XDEBUG" = "true" ]; then pecl install xdebug-3.4.2 && docker-php-ext-enable xdebug; fi && \
-    apt-get autoremove --purge -y && \
-    rm -rf /var/lib/apt/lists/*
+        pcntl
+
+RUN if [ "$ENABLE_XDEBUG" = "true" ]; then \
+        echo "************ XDEBUG ENABLED **********" && \
+        install-php-extensions xdebug-3.4.2; \
+    else \
+        echo "------------ XDEBUG DISABLED =========="; \
+    fi
 
 # Configuration of Apache and PHP
 COPY apache.conf /etc/apache2/sites-available/000-default.conf
@@ -57,3 +43,9 @@ RUN sed --in-place "s/User \${APACHE_RUN_USER}/User localUser/" /etc/apache2/apa
 
 # Installing Composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+FROM base AS full
+
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs chromium && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Plusieurs optimisations qui permettent de diviser par 2 le temps moyen des tests behat dans la CI :

- découpage du Dockerfile en stages (pas besoin de node ni chromium pour les test d'intégration)
- utilisation de [mlocati/docker-php-extension-installer](https://github.com/mlocati/docker-php-extension-installer) pour ne plus avoir à installer des packages de compilation
- gestion du cache dans la CI par layers docker (c'est surtout là qu'on gagne du temps)

Tout ça ne change rien en local, on continue à build l'image complète pour le dev.