### PR TITLE
fix: le click sur se connecter fonctionne

### DIFF
--- a/sources/Afup/Corporate/Page.php
+++ b/sources/Afup/Corporate/Page.php
@@ -32,7 +32,6 @@ final readonly class Page
             $feuilleLogin->nom = 'Espace membre';
             $feuilleLogin->patterns = "#/admin/company#";
         } else {
-            $feuilleLogin = new FeuilleEntity();
             $feuilleLogin->id = PHP_INT_MAX - 1;
             $feuilleLogin->nom = 'Se connecter';
             $cssClasses[PHP_INT_MAX - 1] = 'desktop-hidden';


### PR DESCRIPTION
### Description
Il semblerait qu'il y ait eu un new FeuilleEntity qui soit apparu alors que ce n'était pas necessaire.
Maintenant en mode mobile le click sur "se connecter"  fonctionne en mode mobile.

### Avant la correction

https://github.com/user-attachments/assets/074850fb-1888-45ae-ae34-7eb63ed37949

### Après correction

https://github.com/user-attachments/assets/5fc8a09b-beb1-485f-b2ca-d098be69127d





### Issue associé
Closes #2206 

 