### PR TITLE
Commande de migration des articles html en markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
     "jms/serializer-bundle": "5.*",
     "knpuniversity/oauth2-client-bundle": "^2.17",
     "laminas/laminas-feed": "^2.18",
+    "league/html-to-markdown": "^5.0",
     "league/iso3166": "^4.0",
     "league/oauth2-github": "^3.1",
     "nyholm/psr7": "^1.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec65f0461422bc2982aef8751a114221",
+    "content-hash": "0abe633c257e6f34143e1b0750214067",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -3603,6 +3603,95 @@
                 }
             ],
             "time": "2026-03-19T18:52:39+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "reference": "0b4066eede55c48f38bcee4fb8f0aa85654390fd",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": "^7.2.5 || ^8.0"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "^1.1.0",
+                "phpstan/phpstan": "^1.8.8",
+                "phpunit/phpunit": "^8.5 || ^9.2",
+                "scrutinizer/ocular": "^1.6",
+                "unleashedtech/php-coding-standard": "^2.7 || ^3.0",
+                "vimeo/psalm": "^4.22 || ^5.0"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "support": {
+                "issues": "https://github.com/thephpleague/html-to-markdown/issues",
+                "source": "https://github.com/thephpleague/html-to-markdown/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/html-to-markdown",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-12T21:21:09+00:00"
         },
         {
             "name": "league/iso3166",

--- a/sources/AppBundle/Command/MigrateArticlesHtmlToMarkdownCommand.php
+++ b/sources/AppBundle/Command/MigrateArticlesHtmlToMarkdownCommand.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Command;
+
+use AppBundle\Site\Enum\ArticleContentType;
+use AppBundle\Site\Model\Repository\ArticleRepository;
+use League\HTMLToMarkdown\HtmlConverter;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class MigrateArticlesHtmlToMarkdownCommand extends Command
+{
+    public function __construct(private readonly ArticleRepository $articleRepository)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('app:articles:migrate-html-to-markdown')
+            ->setDescription('Converts HTML articles to Markdown and updates their contentType field.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Preview changes without saving to database')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of articles to process (0 = all)', 0)
+            ->addOption('article-id', null, InputOption::VALUE_REQUIRED, 'Process a single article by its ID')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Migration des articles HTML vers Markdown');
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit = (int) $input->getOption('limit');
+        $articleId = (int) $input->getOption('article-id');
+
+        if ($dryRun) {
+            $io->note('Mode dry-run activé : aucune modification ne sera sauvegardée.');
+        }
+
+        $converter = new HtmlConverter([
+            'strip_tags' => false,
+            'remove_nodes' => 'script style',
+            'hard_break' => true,
+            'use_autolinks' => false,
+            'preserve_comments' => false,
+        ]);
+
+        if ($articleId !== 0) {
+            $article = $this->articleRepository->findOneHtmlArticleById($articleId);
+            if ($article === null) {
+                $io->warning(sprintf('Article #%d introuvable ou déjà en Markdown.', $articleId));
+                return Command::SUCCESS;
+            }
+            $articles = [$article];
+        } else {
+            $articles = $this->articleRepository->findAllHtmlArticles($limit);
+        }
+
+        $processed = 0;
+        $errors = 0;
+
+        foreach ($articles as $article) {
+            try {
+                $convertedContent = $this->convertField($converter, (string) $article->getContent());
+                $convertedLead = $this->convertLeadParagraph($converter, $article->getLeadParagraph());
+
+                if ($output->isVerbose()) {
+                    $io->section(sprintf('Article #%d — %s', $article->getId(), $article->getTitle()));
+                    $io->text('Aperçu contenu : ' . substr($convertedContent, 0, 200));
+                }
+
+                $article->setContent($convertedContent);
+                $article->setLeadParagraph($convertedLead);
+                $article->setContentType(ArticleContentType::Markdown->value);
+
+                if (!$dryRun) {
+                    $this->articleRepository->save($article);
+                }
+
+                $processed++;
+            } catch (\Throwable $e) {
+                $io->error(sprintf(
+                    'Erreur lors de la conversion de l\'article #%d (%s) : %s',
+                    $article->getId(),
+                    $article->getTitle(),
+                    $e->getMessage(),
+                ));
+                $errors++;
+            }
+        }
+
+        $io->definitionList(
+            ['Articles convertis' => $processed],
+            ['Erreurs' => $errors],
+        );
+
+        if ($errors > 0) {
+            $io->warning(sprintf('%d article(s) n\'ont pas pu être convertis.', $errors));
+        }
+
+        if ($dryRun) {
+            $io->note('Aucune modification n\'a été sauvegardée (dry-run).');
+        } else {
+            $io->success(sprintf('%d article(s) migrés avec succès.', $processed));
+        }
+
+        return $errors > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function convertField(HtmlConverter $converter, string $html): string
+    {
+        $html = trim($html);
+        if ($html === '') {
+            return '';
+        }
+
+        return trim($converter->convert($html));
+    }
+
+    private function convertLeadParagraph(HtmlConverter $converter, mixed $leadParagraph): string
+    {
+        if ($leadParagraph === null || trim((string) $leadParagraph) === '') {
+            return '';
+        }
+
+        return trim($converter->convert((string) $leadParagraph));
+    }
+}

--- a/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
+++ b/sources/AppBundle/Site/Model/Repository/ArticleRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Site\Model\Repository;
 
+use AppBundle\Site\Enum\ArticleContentType;
 use AppBundle\Site\Model\Article;
 use AppBundle\Site\Model\Rubrique;
 use Aura\SqlQuery\Common\SelectInterface;
@@ -311,6 +312,34 @@ class ArticleRepository extends Repository implements MetadataInitializer
         ;
 
         return $this->getQuery($builder->getStatement())->query($this->getCollection(new HydratorSingleObject()));
+    }
+
+    /**
+     * @return CollectionInterface<Article>
+     */
+    public function findAllHtmlArticles(int $limit = 0): CollectionInterface
+    {
+        $sql = 'SELECT * FROM afup_site_article WHERE type_contenu = :contentType ORDER BY id ASC';
+        $params = ['contentType' => ArticleContentType::Html->value];
+        if ($limit > 0) {
+            $sql .= ' LIMIT :limit';
+            $params['limit'] = $limit;
+        }
+
+        return $this->getPreparedQuery($sql)
+            ->setParams($params)
+            ->query($this->getCollection(new HydratorSingleObject()));
+    }
+
+    public function findOneHtmlArticleById(int $id): ?Article
+    {
+        $collection = $this->getPreparedQuery(
+            'SELECT * FROM afup_site_article WHERE id = :id AND type_contenu = :contentType',
+        )
+            ->setParams(['id' => $id, 'contentType' => ArticleContentType::Html->value])
+            ->query($this->getCollection(new HydratorSingleObject()));
+
+        return $collection->count() === 0 ? null : $collection->first();
     }
 
     /**


### PR DESCRIPTION
resolves https://github.com/afup/web/issues/2221

<img width="1289" height="337" alt="Screenshot from 2026-05-10 15-44-35" src="https://github.com/user-attachments/assets/8a688137-df08-4a93-ab9c-08e625959c2a" />

```
$> php bin/console app:articles:migrate-html-to-markdown --dry-run

$> php bin/console app:articles:migrate-html-to-markdown --limit=<limit>

$> php bin/console app:articles:migrate-html-to-markdown --article-id=<article-id>

```