### PR TITLE
URL slack en erreur

### DIFF
--- a/sources/AppBundle/Slack/LegacyClient.php
+++ b/sources/AppBundle/Slack/LegacyClient.php
@@ -10,7 +10,11 @@ class LegacyClient
 
     public function invite($email): void
     {
-        $return = file_get_contents(sprintf("https://slack.com/api/users.admin.invite?token=%s&email=%s", $this->token, $email));
+        $url = 'https://slack.com/api/users.admin.invite?' . http_build_query([
+            'token' => $this->token,
+            'email' => $email,
+        ]);
+        $return = file_get_contents($url);
 
         if (false === $return) {
             throw new \RuntimeException("Erreur lors de l'appel à l'API slack");


### PR DESCRIPTION
L'URL pour l'invitation Slack tombe en erreur à cause de l'encodage de l'email passé en paramètre.

On utilise donc `http_build_query()` qui s'occupe d'encoder comme il faut l'URL.


Close #2192