### PR TITLE
Déplacement appel importmap

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -58,6 +58,6 @@
 
         {% block footer '' %}
         {% block javascripts '' %}
-        {% block importmap %}{{ importmap('app') }}{% endblock %}
+        {% block importmap '' %}
     </body>
 </html>

--- a/templates/site/base.html.twig
+++ b/templates/site/base.html.twig
@@ -122,3 +122,7 @@
         </footer>
     {% endautoescape %}
 {% endblock %}
+
+{% block importmap %}
+    {{ importmap('app') }}
+{% endblock %}


### PR DESCRIPTION
Je déplace l'appel du css de l'asset-mapper sur le `templates/site/base.html.twig` du site et non le fichier de base de tous les différents layouts.

Le background de la partie cfp / speaker redevient blanc.