### PR TITLE
correction sur l'import du journal

### DIFF
--- a/sources/AppBundle/Compta/Importer/AutoQualifier.php
+++ b/sources/AppBundle/Compta/Importer/AutoQualifier.php
@@ -32,7 +32,7 @@ class AutoQualifier
         $operationQualified['categorie'] = self::DEFAULT_CATEGORIE;
         $operationQualified['evenement'] = self::DEFAULT_EVENEMENT;
         $operationQualified['idModeReglement'] = self::DEFAULT_REGLEMENT;
-        $operationQualified['attachmentRequired'] = self::DEFAULT_ATTACHMENT;
+        $operationQualified['attachmentRequired'] = (bool) self::DEFAULT_ATTACHMENT;
 
         $firstPartDescription = strtoupper(explode(' ', $operationQualified['description'])[0]);
         switch ($firstPartDescription) {
@@ -66,7 +66,7 @@ class AutoQualifier
                     $operationQualified['categorie'] = $rule->category->id;
                 }
                 if (null !== $rule->attachmentRequired) {
-                    $operationQualified['attachmentRequired'] = $rule->attachmentRequired;
+                    $operationQualified['attachmentRequired'] = (bool) $rule->attachmentRequired;
                 }
                 if (null !== $rule->paymentTypeId) {
                     $operationQualified['idModeReglement'] = $rule->paymentTypeId;


### PR DESCRIPTION
```
2026-05-24T06:01:22.490Z request.CRITICAL: Uncaught PHP Exception TypeError: "AppBundle\Accounting\Model\Transaction::setAttachmentRequired(): Argument #1 ($attachmentRequired) must be of type bool, int given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Compta/CsvExtractor.php on line 50" at Transaction.php line 207 {"exception":"[object] (TypeError(code: 0): AppBundle\\Accounting\\Model\\Transaction::setAttachmentRequired(): Argument #1 ($attachmentRequired) must be of type bool, int given, called in /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Compta/CsvExtractor.php on line 50 at /home/bas/app_ee619ef6-05d2-4b4c-978f-d8f85e5a49da/sources/AppBundle/Accounting/Model/Transaction.php:207)"} []
```

on avait cette erreur, on s'assure donc bien de passer un booléen au setAttachementRequired