### PR TITLE
Correction(billeterie): affichage de l'étape contenant une errueur après validation du formulaire par le serveur

### DIFF
--- a/htdocs/js/tickets.js
+++ b/htdocs/js/tickets.js
@@ -551,6 +551,17 @@ $(document).ready(function() {
         cloneTransport();
         updateSummary();
 
+        // After a server-side validation failure the page re-renders at step 1, hiding field
+        // errors that live in step 2 or step 3. Detect those errors and jump to the right step
+        // so the user can see what needs to be corrected.
+        if ($('.tickets--errors p').length > 0) {
+            if ($('#ticket-step-2 .tickets--errors li').length > 0) {
+                goToStep(2);
+            } else if ($('#ticket-step-3 .tickets--errors li').length > 0) {
+                goToStep(3);
+            }
+        }
+
         // Handle form submission
         $('#formulaire').on('submit', function(e) {
             // Validate final step for payment and billing info


### PR DESCRIPTION
**Problème**

Lors de l'achat de billets, certains utilisateurs voyaient le bandeau générique "Une ou plusieurs erreurs sont survenues" sans aucun message d'erreur visible dans le formulaire. L'erreur existait bien, mais dans une étape masquée par le JavaScript.

Le formulaire se réinitialise toujours à l'étape 1 au rechargement de page. Quand Symfony retourne une erreur de validation sur un champ de l'étape 2 ou 3, cette erreur est rendue dans un div caché — invisible pour l'utilisateur.

**Correctif**

Au chargement, si le bandeau d'erreur générique est présent (signe d'un retour serveur en erreur), le JS cherche des erreurs de champ dans les étapes 2 et 3 et navigue directement vers la première étape concernée.