### PR TITLE
Remplacement de SimpleMDE avec EasyMDE

### DIFF
--- a/sources/AppBundle/Event/Form/EventCFPTextType.php
+++ b/sources/AppBundle/Event/Form/EventCFPTextType.php
@@ -15,42 +15,42 @@ class EventCFPTextType extends AbstractType
         $builder
             ->add('fr', TextareaType::class, [
                 'label' => 'CFP (fr)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('en', TextareaType::class, [
                 'label' => 'CFP (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('speaker_management_fr', TextareaType::class, [
                 'label' => 'Infos speakers (fr)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('speaker_management_en', TextareaType::class, [
                 'label' => 'Infos speakers (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('sponsor_management_fr', TextareaType::class, [
                 'label' => 'Infos sponsors (fr)',
-                'attr' => ['rows' => 5,'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5,'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('sponsor_management_en', TextareaType::class, [
                 'label' => 'Infos sponsors (en)',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('mail_inscription_content', TextareaType::class, [
                 'label' => 'Contenu mail inscription',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ])
             ->add('become_sponsor_description', TextareaType::class, [
                 'label' => 'Contenu page devenir sponsor',
-                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'simplemde'],
+                'attr' => ['rows' => 5, 'cols' => 50, 'class' => 'easymde'],
                 'required' => false,
             ]);
     }

--- a/sources/AppBundle/GeneralMeeting/PrepareFormType.php
+++ b/sources/AppBundle/GeneralMeeting/PrepareFormType.php
@@ -29,7 +29,7 @@ class PrepareFormType extends AbstractType
                 'attr' => [
                     'rows' => 5,
                     'cols' => 50,
-                    'class' => 'simplemde',
+                    'class' => 'easymde',
                 ],
             ])
             ->add('submit', SubmitType::class, [

--- a/sources/AppBundle/Site/Form/ArticleType.php
+++ b/sources/AppBundle/Site/Form/ArticleType.php
@@ -43,7 +43,7 @@ class ArticleType extends AbstractType
 
         /** @var \AppBundle\Site\Model\Article|null $article */
         $article = $builder->getData();
-        $textareaCssClass = 'simplemde';
+        $textareaCssClass = 'easymde';
 
 
         $builder

--- a/sources/AppBundle/Site/Form/RubriqueType.php
+++ b/sources/AppBundle/Site/Form/RubriqueType.php
@@ -67,7 +67,7 @@ class RubriqueType extends AbstractType
                     'maxlength' => 255,
                     'cols' => 42,
                     'rows' => 10,
-                    'class' => 'simplemde',
+                    'class' => 'easymde',
                 ],
                 'constraints' => [
                     new Assert\Length(max: 255),
@@ -80,7 +80,7 @@ class RubriqueType extends AbstractType
                 'attr' => [
                     'cols' => 42,
                     'rows' => 20,
-                    'class' => 'simplemde',
+                    'class' => 'easymde',
                 ],
                 'constraints' => [
                     new Assert\NotBlank(),

--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -172,8 +172,8 @@
             <script src="https://code.jquery.com/jquery-3.1.1.min.js" crossorigin="anonymous"></script>
                 <script src="{{ asset('vendor/semantic-ui/dist/semantic.min.js') }}"></script>
 
-            <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
-            <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.css">
+            <script src="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.js"></script>
 
                 <script type="text/javascript" src="/javascript/dropzone/dropzone.min.js"></script>
 
@@ -201,12 +201,12 @@
                     });
                 });
 
-                var simpleMdeList = document.getElementsByClassName('simplemde');
-                for (var i = 0; i < simpleMdeList.length; i++) {
-                    var simplemde = new SimpleMDE({
-                        element:simpleMdeList[i],
+                var easyMdeList = document.getElementsByClassName('easymde');
+                for (var i = 0; i < easyMdeList.length; i++) {
+                    var easymde = new EasyMDE({
+                        element:easyMdeList[i],
                         spellChecker: false,
-                        hideIcons: ['side-by-side', 'fullscreen']
+                        hideIcons: ['side-by-side', 'fullscreen', 'check-list']
                     });
                 }
 

--- a/templates/admin/talk/form.html.twig
+++ b/templates/admin/talk/form.html.twig
@@ -3,7 +3,7 @@
     <div class="ui segment">
         <h3 class="ui header">Présentation</h3>
         {{ form_row(form.title) }}
-        {{ form_row(form.abstract, {attr: {class: 'simplemde'}}) }}
+        {{ form_row(form.abstract, {attr: {class: 'easymde'}}) }}
         {{ form_row(form.staffNotes) }}
         {{ form_row(form.type) }}
         {{ form_row(form.skill) }}
@@ -31,7 +31,7 @@
         {{ form_row(form.languageCode) }}
         {{ form_row(form.tweets) }}
         {{ form_row(form.blueskyPosts) }}
-        {{ form_row(form.verbatim, {attr: {class: 'simplemde'}}) }}
+        {{ form_row(form.verbatim, {attr: {class: 'easymde'}}) }}
     </div>
     <div class="ui segment">
         <div class="inline fields ui grid">

--- a/templates/event/cfp/base.html.twig
+++ b/templates/event/cfp/base.html.twig
@@ -25,6 +25,6 @@
 {% block javascripts %}
     {{ parent() }}
     <script src="{{ asset('/js/vote.js') }}"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
-    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.js"></script>
 {% endblock %}

--- a/templates/event/cfp/edit.html.twig
+++ b/templates/event/cfp/edit.html.twig
@@ -37,9 +37,9 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-		var simplemde = new SimpleMDE({
+		var easymde = new EasyMDE({
 			spellChecker: false,
-			hideIcons: ['side-by-side', 'fullscreen']
+			hideIcons: ['side-by-side', 'fullscreen', 'check-list']
 		});
     </script>
 {% endblock %}

--- a/templates/event/cfp/propose.html.twig
+++ b/templates/event/cfp/propose.html.twig
@@ -28,9 +28,9 @@
 {% block javascripts %}
     {{ parent() }}
     <script>
-		var simplemde = new SimpleMDE({
+		var easymde = new EasyMDE({
 			spellChecker: false,
-			hideIcons: ['side-by-side', 'fullscreen']
+			hideIcons: ['side-by-side', 'fullscreen', 'check-list']
 		});
     </script>
 {% endblock %}


### PR DESCRIPTION
[SimpleMDE](https://github.com/sparksuite/simplemde-markdown-editor/) n'est plus maintenu depuis une dizaine d'année, je propose de le remplacer par [EasyMDE](https://github.com/ionaru/easy-markdown-editor), un fork maintenu, pour réduire au maximum l'impact pour les utilisateurs.