### PR TITLE
Refonte des stats d'inscription Slack en instrument de pilotage des ventes

### DIFF
--- a/sources/AppBundle/Command/TicketStatsNotificationCommand.php
+++ b/sources/AppBundle/Command/TicketStatsNotificationCommand.php
@@ -34,6 +34,7 @@ class TicketStatsNotificationCommand extends Command
         $this
             ->setName('ticket-stats-notification')
             ->addOption('display-diff', null, InputOption::VALUE_NONE)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, "Affiche les messages sans les envoyer à Slack")
         ;
     }
 
@@ -49,6 +50,8 @@ class TicketStatsNotificationCommand extends Command
             $date->modify('- 1 day');
         }
 
+        $dryRun = (bool) $input->getOption('dry-run');
+
         /** @var Event $event */
         foreach ($this->eventRepository->getNextEvents() as $event) {
             $message = $this->messageFactory->createMessageForTicketStats(
@@ -57,6 +60,17 @@ class TicketStatsNotificationCommand extends Command
                 $this->ticketTypeRepository,
                 $date,
             );
+
+            if ($dryRun) {
+                $output->writeln(sprintf('<info>[%s] %s</info>', $message->getChannel(), $message->getUsername()));
+                foreach ($message->getAttachments() as $attachment) {
+                    $output->writeln(sprintf('  %s', $attachment->getTitle()));
+                    foreach ($attachment->getFields() as $field) {
+                        $output->writeln(sprintf('    - %s : %s', $field->getTitle(), $field->getValue()));
+                    }
+                }
+                continue;
+            }
 
             $this->slackNotifier->sendMessage($message);
         }

--- a/sources/AppBundle/Event/Model/EventStats/SalesPilotage.php
+++ b/sources/AppBundle/Event/Model/EventStats/SalesPilotage.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Event\Model\EventStats;
+
+final readonly class SalesPilotage
+{
+    public function __construct(
+        /** Billets payants (type tarifaire payant) effectivement payés à ce jour */
+        public int $paidTickets,
+        /** Capacité de l'événement (nb_places) */
+        public ?int $seats,
+        /** Nombre de jours de vente restants avant la clôture des ventes */
+        public int $daysToEndOfSales,
+        /** Billets payants vendus par l'édition N-1 au même stade du cycle de vente */
+        public ?int $previousPaidTicketsAtSameStage,
+        /** Billets payants vendus par l'édition N-1 au total (en fin de vente) */
+        public ?int $previousPaidTicketsTotal,
+        /** Titre de l'édition N-1 utilisée pour la comparaison */
+        public ?string $previousEditionTitle,
+    ) {}
+
+    public function getFillRate(): ?int
+    {
+        if ($this->seats === null || $this->seats === 0) {
+            return null;
+        }
+
+        return (int) floor($this->paidTickets * 100 / $this->seats);
+    }
+
+    public function getEvolutionRate(): ?int
+    {
+        if (empty($this->previousPaidTicketsAtSameStage)) {
+            return null;
+        }
+
+        return (int) round(($this->paidTickets - $this->previousPaidTicketsAtSameStage) * 100 / $this->previousPaidTicketsAtSameStage);
+    }
+}

--- a/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/EventStatsRepository.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace AppBundle\Event\Model\Repository;
 
+use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\EventStats\CFPStats;
+use AppBundle\Event\Model\EventStats\SalesPilotage;
 use AppBundle\Event\Model\EventStats\TicketTypeStats;
 use AppBundle\Event\Model\EventStats;
 use AppBundle\Event\Model\EventStats\DailyStats;
@@ -214,6 +216,72 @@ class EventStatsRepository
             'max' => $i,
             'daysToEndOfSales' => $daysToEndOfSales,
         ];
+    }
+
+    /**
+     * Instrument de pilotage des ventes : billets payants vendus, jours de vente
+     * restants, taux de remplissage et comparaison avec l'édition N-1 prise au
+     * même stade de son cycle de vente.
+     */
+    public function getSalesPilotage(Event $event): SalesPilotage
+    {
+        $eventId = (int) $event->getId();
+
+        $now = new DateTimeImmutable();
+        $endOfSales = DateTimeImmutable::createFromInterface($event->getDateEndSales());
+        $daysToEndOfSales = $endOfSales >= $now ? (int) $now->diff($endOfSales)->format('%a') : 0;
+
+        $paidTickets = $this->countPaidTickets($eventId);
+
+        $previousAtSameStage = null;
+        $previousTotal = null;
+        $previousTitle = null;
+
+        $previousEvent = $this->eventRepository->getLastYearEvent($event);
+        if ((int) $previousEvent->getId() !== $eventId) {
+            $previousEventId = (int) $previousEvent->getId();
+            $previousTitle = $previousEvent->getTitle();
+            // On compte les billets de l'édition N-1 vendus alors qu'il lui restait
+            // au moins autant de jours de vente qu'aujourd'hui (même stade du cycle).
+            $previousAtSameStage = $this->countPaidTickets($previousEventId, -$daysToEndOfSales);
+            $previousTotal = $this->countPaidTickets($previousEventId);
+        }
+
+        return new SalesPilotage(
+            $paidTickets,
+            $event->getSeats(),
+            $daysToEndOfSales,
+            $previousAtSameStage,
+            $previousTotal,
+            $previousTitle,
+        );
+    }
+
+    /**
+     * Nombre de billets payés (etat = PAID) sur un type de tarif payant
+     * (default_price > 0). Si $maxDayOffset est fourni, seuls les billets vendus
+     * alors qu'il restait au moins ce nombre de jours avant la fin des ventes sont
+     * comptés (offset négatif, relatif à la date de fin de vente de l'événement).
+     */
+    private function countPaidTickets(int $eventId, ?int $maxDayOffset = null): int
+    {
+        $queryBuilder = $this->connection->createQueryBuilder()
+            ->select('COUNT(*)')
+            ->from('afup_inscription_forum', 'i')
+            ->innerJoin('i', 'afup_forum_tarif', 'aft', 'aft.id = i.type_inscription AND aft.default_price > 0')
+            ->where('i.id_forum = :eventId')
+            ->andWhere('i.etat = :paid')
+            ->setParameter('eventId', $eventId)
+            ->setParameter('paid', Ticket::STATUS_PAID);
+
+        if ($maxDayOffset !== null) {
+            $queryBuilder
+                ->innerJoin('i', 'afup_forum', 'af', 'af.id = i.id_forum')
+                ->andWhere("DATEDIFF(FROM_UNIXTIME(i.date), FROM_UNIXTIME(af.date_fin_vente)) <= :maxDayOffset")
+                ->setParameter('maxDayOffset', $maxDayOffset);
+        }
+
+        return (int) $queryBuilder->executeQuery()->fetchOne();
     }
 
     public function getCFPStats(int $eventId): CFPStats

--- a/sources/AppBundle/Slack/MessageFactory.php
+++ b/sources/AppBundle/Slack/MessageFactory.php
@@ -6,6 +6,7 @@ namespace AppBundle\Slack;
 
 use AppBundle\Association\Model\Repository\UserRepository;
 use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\EventStats\SalesPilotage;
 use AppBundle\Event\Model\Repository\EventStatsRepository;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Repository\TalkToSpeakersRepository;
@@ -180,7 +181,6 @@ class MessageFactory
 
     public function createMessageForTicketStats(Event $event, EventStatsRepository $eventStatsRepository, TicketTypeRepository $ticketRepository, ?\DateTime $date = null): Message
     {
-        $eventStats = $eventStatsRepository->getStats((int) $event->getId());
         $message = new Message();
         $message
             ->setChannel($event->isAfupDay() ? 'afupday' : 'pole-forum')
@@ -205,33 +205,60 @@ class MessageFactory
             $message->addAttachment($attachment);
         }
 
+        $pilotage = $eventStatsRepository->getSalesPilotage($event);
+
         $attachment = new Attachment();
         $attachment
-            ->setTitle('Total des inscriptions')
-            ->setTitleLink($this->urlGenerator->generate('admin_event_ticket_list', ['id' => $event->getId()],UrlGeneratorInterface::ABSOLUTE_URL))
+            ->setTitle('Pilotage des ventes')
+            ->setTitleLink($this->urlGenerator->generate('admin_event_ticket_list', ['id' => $event->getId()], UrlGeneratorInterface::ABSOLUTE_URL))
+            ->addField((new Field())->setShort(true)->setTitle('Billets vendus (payants)')
+                ->setValue((string) $pilotage->paidTickets))
+            ->addField((new Field())->setShort(true)->setTitle('Jours de vente restants')
+                ->setValue((string) $pilotage->daysToEndOfSales))
+            ->addField((new Field())->setShort(true)->setTitle('Taux de remplissage')
+                ->setValue($this->formatFillRate($pilotage)))
+            ->addField((new Field())->setShort(true)->setTitle('Comparaison N-1')
+                ->setValue($this->formatPilotageComparison($pilotage)))
         ;
-
-        if ($event->lastsOneDay()) {
-            $tickets = $eventStats->firstDay->paid;
-            if ($event->getSeats()) {
-                $percentage = floor(($tickets * 100) / $event->getSeats());
-                $tickets = $tickets . ' / ' . $event->getSeats() . " ($percentage%)";
-            }
-
-            $attachment->addField((new Field())->setShort(true)->setTitle('Journée unique')
-                ->setValue($tickets));
-        } else {
-            $attachment
-                ->addField((new Field())->setShort(true)->setTitle('Premier jour')
-                    ->setValue($eventStats->firstDay->paid))
-                ->addField((new Field())->setShort(true)->setTitle('Deuxième jour')
-                    ->setValue($eventStats->secondDay->paid))
-            ;
-        }
 
         $message->addAttachment($attachment);
 
         return $message;
+    }
+
+    private function formatFillRate(SalesPilotage $pilotage): string
+    {
+        $fillRate = $pilotage->getFillRate();
+        if ($fillRate === null) {
+            return '—';
+        }
+
+        return sprintf('%d %% (%d / %d)', $fillRate, $pilotage->paidTickets, $pilotage->seats);
+    }
+
+    private function formatPilotageComparison(SalesPilotage $pilotage): string
+    {
+        if ($pilotage->previousPaidTicketsAtSameStage === null) {
+            return '—';
+        }
+
+        $detail = sprintf(
+            '%d à ce stade · %d au total',
+            $pilotage->previousPaidTicketsAtSameStage,
+            $pilotage->previousPaidTicketsTotal,
+        );
+        if ($pilotage->previousEditionTitle !== null) {
+            $detail .= sprintf(' (%s)', $pilotage->previousEditionTitle);
+        }
+
+        $evolution = $pilotage->getEvolutionRate();
+        if ($evolution === null) {
+            return $detail;
+        }
+
+        $trend = $evolution > 0 ? ':chart_with_upwards_trend:' : ($evolution < 0 ? ':chart_with_downwards_trend:' : ':arrow_right:');
+
+        return sprintf('%s %+d %% — %s', $trend, $evolution, $detail);
     }
 
 


### PR DESCRIPTION
## Contexte

Le batch `ticket-stats-notification` (cron mardi/jeudi 19h) postait sur Slack une attache « Total des inscriptions » avec **Premier jour / Deuxième jour**. Depuis qu'on ne vend plus de billets à la journée, ces deux chiffres sont identiques et n'apportent plus rien pour piloter les ventes.

## Changements

Remplacement de cette attache par **« Pilotage des ventes »**, avec 4 indicateurs orientés décision :

- **Billets vendus (payants)** — inscriptions `PAID` sur un tarif payant (`default_price > 0`), comptées une seule fois
- **Jours de vente restants** — jours avant `date_fin_vente` (clampé à 0, jamais négatif)
- **Taux de remplissage** — `payants / nb_places`, ex. `68 % (342 / 500)`
- **Comparaison N-1** — édition précédente (`getLastYearEvent`) prise **au même stade de son cycle de vente** (même nombre de jours avant *sa* clôture), avec son total final et le % d'évolution

Exemple de rendu du champ N-1 :
> 📈 +12 % — 305 à ce stade · 480 au total (Forum PHP 2024)

## Détails techniques

- Nouveau DTO `EventStats\SalesPilotage` (métriques + calcul taux de remplissage / évolution)
- `EventStatsRepository::getSalesPilotage()` + helper `countPaidTickets()`
- Formatage déporté dans `MessageFactory`
- Option **`--dry-run`** sur la commande : affiche les messages (canal, attaches, champs) en clair dans le terminal au lieu de les envoyer à Slack

## Vérifications

- ✅ PHPStan
- ✅ PHP-CS-Fixer
- ⏳ Rendu à valider via `php bin/console ticket-stats-notification --dry-run`