### PR TITLE
Configuration de l'object manager Doctrine pour PHPStan

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -11654,12 +11654,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findAllPublishedArticles\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Article\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findArticleBySlug\\(\\) should return AppBundle\\\\Site\\\\Entity\\\\Article\\|null but returns mixed\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
@@ -11667,12 +11661,6 @@ $ignoreErrors[] = [
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findBySlug\\(\\) should return AppBundle\\\\Site\\\\Entity\\\\Article\\|null but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findListForHome\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Article\\> but returns mixed\\.$#',
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
@@ -11692,12 +11680,6 @@ $ignoreErrors[] = [
 $ignoreErrors[] = [
 	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findPublishedArticles\\(\\) has parameter \\$filtres with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\ArticleRepository\\:\\:findPublishedArticles\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Article\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/ArticleRepository.php',
 ];
@@ -11724,24 +11706,6 @@ $ignoreErrors[] = [
 	'identifier' => 'return.type',
 	'count' => 1,
 	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/CountryRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\FeuilleRepository\\:\\:getAllFeuilles\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Feuille\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/FeuilleRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\FeuilleRepository\\:\\:getFeuillesEnfant\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Feuille\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/FeuilleRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Site\\\\Entity\\\\Repository\\\\RubriqueRepository\\:\\:getAllRubriques\\(\\) should return array\\<AppBundle\\\\Site\\\\Entity\\\\Rubrique\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Site/Entity/Repository/RubriqueRepository.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Class AppBundle\\\\Site\\\\Form\\\\ArticleType extends generic class Symfony\\\\Component\\\\Form\\\\AbstractType but does not specify its types\\: TData$#',
@@ -12594,18 +12558,6 @@ $ignoreErrors[] = [
 	'identifier' => 'argument.templateType',
 	'count' => 1,
 	'path' => __DIR__ . '/sources/AppBundle/Validator/Constraints/UniqueEntityValidator.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Veille\\\\Entity\\\\Repository\\\\EnvoiRepository\\:\\:getAllOrderedByDateDesc\\(\\) should return list\\<AppBundle\\\\Veille\\\\Entity\\\\Envoi\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Veille/Entity/Repository/EnvoiRepository.php',
-];
-$ignoreErrors[] = [
-	'message' => '#^Method AppBundle\\\\Veille\\\\Entity\\\\Repository\\\\EnvoiRepository\\:\\:getAllPreviouslySent\\(\\) should return list\\<AppBundle\\\\Veille\\\\Entity\\\\Envoi\\> but returns mixed\\.$#',
-	'identifier' => 'return.type',
-	'count' => 1,
-	'path' => __DIR__ . '/sources/AppBundle/Veille/Entity/Repository/EnvoiRepository.php',
 ];
 $ignoreErrors[] = [
 	'message' => '#^Method AppBundle\\\\Veille\\\\Entity\\\\Repository\\\\NewsletterDesinscriptionRepository\\:\\:createFromWebhookData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -19,6 +19,8 @@ parameters:
       property: 45
       constant: 100
     doctrine:
+        objectManagerLoader: tests/object-manager.php
+        reportDynamicQueryBuilders: true
         ormRepositoryClass: AppBundle\Doctrine\EntityRepository
 
 rules:

--- a/tests/object-manager.php
+++ b/tests/object-manager.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use AppBundle\AppKernel;
+
+$kernel = new AppKernel($_SERVER['APP_ENV'] ?? 'test', (bool) ($_SERVER['APP_DEBUG']) ?? true);
+$kernel->boot();
+
+return $kernel->getContainer()->get('doctrine')->getManager();


### PR DESCRIPTION
Cela permet à PHPStan de mieux comprendre les types retournés par les repositories d'entités.