### PR TITLE
Gestion des messages d'aide des champs de formulaire du BO

### DIFF
--- a/templates/admin/accounting/invoice/edit.html.twig
+++ b/templates/admin/accounting/invoice/edit.html.twig
@@ -140,10 +140,6 @@
                         <div class="four wide column action_container"></div>
                     </div>
                     {{ form_row(detail.reference) }}
-                    <div class="inline fields ui grid">
-                        <div class="three wide column"></div>
-                        <div class="field seven wide column">Rappel : sponsoring 20%, place supplémentaire 10%.</div>
-                    </div>
                     {{ form_row(detail.tva) }}
                     {{ form_row(detail.designation) }}
                     {{ form_row(detail.quantity) }}

--- a/templates/admin/accounting/quotation/_prototype.html.twig
+++ b/templates/admin/accounting/quotation/_prototype.html.twig
@@ -5,10 +5,6 @@
     <div class="four wide column action_container"></div>
 </div>
 {{ form_row(form.details.vars.prototype.reference) }}
-<div class="inline fields ui grid">
-    <div class="three wide column"> </div>
-    <div class="field seven wide column right aligned">Rappel : sponsoring 20%, place supplémentaire 10%.</div>
-</div>
 {{ form_row(form.details.vars.prototype.tva) }}
 {{ form_row(form.details.vars.prototype.designation) }}
 {{ form_row(form.details.vars.prototype.quantity) }}

--- a/templates/admin/accounting/quotation/form.html.twig
+++ b/templates/admin/accounting/quotation/form.html.twig
@@ -132,10 +132,6 @@
                 <div class="four wide column action_container"></div>
             </div>
             {{ form_row(detail.reference) }}
-            <div class="inline fields ui grid">
-                <div class="three wide column"></div>
-                <div class="field seven wide column">Rappel : sponsoring 20%, place supplémentaire 10%.</div>
-            </div>
             {{ form_row(detail.tva) }}
             {{ form_row(detail.designation) }}
             {{ form_row(detail.quantity) }}

--- a/templates/admin/event/form.html.twig
+++ b/templates/admin/event/form.html.twig
@@ -36,15 +36,6 @@
             {{ form_row(form.path) }}
         </div>
         <div class="ui form">
-            <div class="inline fields ui grid">
-                <label class="three wide column">
-                </label>
-                <div class="field seven wide column">
-                    <i>Le path sert également à déterminer le nom du template de mail à utiliser sur mandrill, sous la forme confirmation-inscription-{PATH}</i>
-                </div>
-            </div>
-        </div>
-        <div class="ui form">
             {{ form_row(form.logoUrl) }}
             {{ form_row(form.seats) }}
             {{ form_row(form.placeName) }}

--- a/templates/form_theme_admin.html.twig
+++ b/templates/form_theme_admin.html.twig
@@ -10,11 +10,16 @@
 {%- block form_row -%}
     <div class="inline fields ui grid">
         {{ form_label(form) }}
-        <div class="field nine wide column">
+        <div class="field nine wide column"{% if help is not empty %} style="flex-wrap: wrap;"{% endif %}>
             <div class="ui input">
                 {{ form_widget(form) }}
                 {{ form_errors(form) }}
             </div>
+            {% if help is not empty %}
+                <div style="flex-basis: 100%;">
+                    <i>{{ form_help(form) }}</i>
+                </div>
+            {% endif %}
         </div>
     </div>
 {%- endblock form_row -%}


### PR DESCRIPTION
Cela permet d'utiliser l'option `help` dans un form builder pour afficher du texte sous un champ.

Certains champs utilisaient déjà l'option mais qui ne s'affichait pas, et qui était du coup mise en dur dans le html, d'où les suppressions dans certains templates (pour éviter un affichage double).