### PR TITLE
Revert du chargement de semantic UI via CDN

### DIFF
--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
         <title>Administration AFUP</title>
-        <link rel="stylesheet" href="{{ asset('vendor/semantic-ui/dist/semantic.min.css') }}">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
         <link rel="icon" type="image/png" href="/templates/administration/images/favicon-96x96.png" sizes="96x96" />
         <link rel="icon" type="image/svg+xml" href="/templates/administration/images/favicon.svg" />
         <link rel="shortcut icon" href="/templates/administration/images/favicon.ico" />
@@ -170,7 +170,7 @@
 
             {% block javascript %}
             <script src="https://code.jquery.com/jquery-3.1.1.min.js" crossorigin="anonymous"></script>
-                <script src="{{ asset('vendor/semantic-ui/dist/semantic.min.js') }}"></script>
+            <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
 
             <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.css">
             <script src="https://cdn.jsdelivr.net/npm/easymde@2.21.0/dist/easymde.min.js"></script>


### PR DESCRIPTION
Le chargement via l'asset mapper ne fonctionne pas, et ça ne s'est pas vu tout de suite à cause du cache. On remet le CDN en attendant une meilleure correction.