### PR TITLE
Correction du message de validité d'un cotisation

### DIFF
--- a/sources/AppBundle/MembershipFee/MembershipFeeService.php
+++ b/sources/AppBundle/MembershipFee/MembershipFeeService.php
@@ -93,7 +93,8 @@ class MembershipFeeService
 
     public function getNextSubscriptionExpiration(?MembershipFee $cotisation = null): DateTime
     {
-        $endSubscription = $cotisation ? $cotisation->getEndDate() : new DateTime();
+        $endDate = $cotisation?->getEndDate();
+        $endSubscription = $endDate !== null ? (clone $endDate)->setTime(23, 59, 59) : new DateTime();
         $base = $now = new DateTime();
 
         $year = new DateInterval('P1Y');
@@ -108,9 +109,6 @@ class MembershipFeeService
 
     /**
      * Renvoit la cotisation demandée
-     *
-     * @param $invoiceId Identifiant de la facture
-     * @param $token Token de la facture. Si null, pas de vérification
      */
     public function getByInvoice(string $invoiceId, ?string $token = null): ?MembershipFee
     {


### PR DESCRIPTION
Suite à un échange sur [slack](https://afup.slack.com/archives/C03L64VE9/p1782912679191499) on corrige la mutation involontaire de la date de fin d'une cotisation