### PR TITLE
Page speakers - correction requête SQL pour récupérer le profil linkedin

### DIFF
--- a/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/SpeakerRepository.php
@@ -56,7 +56,7 @@ class SpeakerRepository extends Repository implements MetadataInitializer
         }
 
         $query = $this->getPreparedQuery('SELECT speaker.conferencier_id, speaker.id_forum, speaker.genre, speaker.nom, speaker.prenom, speaker.email, speaker.societe,
-        speaker.biographie, speaker.twitter, speaker.mastodon, speaker.bluesky, speaker.user_github, speaker.photo, talk.titre, talk.session_id,
+        speaker.biographie, speaker.twitter, speaker.mastodon, speaker.bluesky, speaker.linkedin, speaker.user_github, speaker.photo, talk.titre, talk.session_id,
         speaker.will_attend_speakers_diner,
         speaker.has_special_diet,
         speaker.referent_person,


### PR DESCRIPTION
Le lien vers le profil linkedin ne s'affiche pas sur la page speaker.
cf. https://afup.slack.com/archives/C03L64VE9/p1783430771244019