### PR TITLE
Éditorialisation du programme

### DIFF
--- a/app/config/packages/backoffice_menu.yaml
+++ b/app/config/packages/backoffice_menu.yaml
@@ -189,6 +189,12 @@ parameters:
                         - admin_event_themes_list
                         - admin_event_themes_add
                         - admin_event_themes_edit
+                admin_event_editorialization:
+                    nom: 'Éditorialisation'
+                    niveau: 'ROLE_FORUM'
+                    url: '/admin/event/editorialization'
+                    extra_routes:
+                        - admin_event_editorialization
                 forum_vote_github:
                     nom: 'Votes visiteurs'
                     niveau: 'ROLE_FORUM'

--- a/app/config/routing/admin_event.yml
+++ b/app/config/routing/admin_event.yml
@@ -206,5 +206,10 @@ admin_event_themes_list:
   defaults:
     _controller: AppBundle\Controller\Admin\Event\EventThemeAction
 
+admin_event_editorialization:
+  path: /editorialization/
+  defaults:
+    _controller: AppBundle\Controller\Admin\Event\EventEditorializationAction
+
 admin_event_ticket:
   resource: "admin_event_ticket.yml"

--- a/db/migrations/20260708090000_add_position_to_talks.php
+++ b/db/migrations/20260708090000_add_position_to_talks.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddPositionToTalks extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this
+            ->table('afup_sessions')
+            ->addColumn('position', 'integer', ['null' => true])
+            ->save()
+        ;
+    }
+}

--- a/sources/AppBundle/Controller/Admin/Event/EventEditorializationAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/EventEditorializationAction.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Controller\Admin\Event;
+
+use AppBundle\Event\AdminEventSelection;
+use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Repository\EventThemeRepository;
+use AppBundle\Event\Model\Repository\TalkRepository;
+use AppBundle\Event\Model\Talk;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EventEditorializationAction extends AbstractController
+{
+    public function __construct(
+        private readonly EventThemeRepository $eventThemeRepository,
+        private readonly TalkRepository $talkRepository,
+    ) {}
+
+    public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
+    {
+        $event = $eventSelection->event;
+
+        if ($request->isXmlHttpRequest()) {
+            return $this->handleAjaxRequest($request, $event);
+        }
+
+        $eventId = $event->getId() ?? 0;
+        $hasThemes = $event->getHasThemes();
+        $themes = $hasThemes ? iterator_to_array($this->eventThemeRepository->getByThemesOrderedByPriority($eventId)) : [];
+        $scheduledTalks = iterator_to_array($this->talkRepository->getScheduledTalksByEvent($eventId));
+
+        $talkGroups = $this->groupTalks($scheduledTalks, $themes, $hasThemes);
+
+        return $this->render('admin/event/editorialization.html.twig', [
+            'event' => $event,
+            'event_select_form' => $eventSelection->selectForm(),
+            'has_themes' => $hasThemes,
+            'themes' => $themes,
+            'talk_groups' => $talkGroups,
+        ]);
+    }
+
+    /**
+     * @param array<Talk> $scheduledTalks
+     * @param array<\AppBundle\Event\Model\EventTheme> $themes
+     * @return array<array{theme: ?\AppBundle\Event\Model\EventTheme, talks: array<Talk>}>
+     */
+    private function groupTalks(array $scheduledTalks, array $themes, bool $hasThemes): array
+    {
+        if (!$hasThemes) {
+            $talks = $scheduledTalks;
+            usort($talks, $this->compareTalks(...));
+
+            return [['theme' => null, 'talks' => $talks]];
+        }
+
+        $talksByThemeId = [];
+        foreach ($themes as $theme) {
+            $talksByThemeId[(int) $theme->getId()] = [];
+        }
+
+        $noThemeTalks = [];
+        foreach ($scheduledTalks as $talk) {
+            $themeId = $talk->getTheme();
+            if ($themeId !== null && isset($talksByThemeId[$themeId])) {
+                $talksByThemeId[$themeId][] = $talk;
+            } else {
+                $noThemeTalks[] = $talk;
+            }
+        }
+
+        usort($noThemeTalks, $this->compareTalks(...));
+        $groups = [['theme' => null, 'talks' => $noThemeTalks]];
+
+        foreach ($themes as $theme) {
+            $talks = $talksByThemeId[(int) $theme->getId()];
+            usort($talks, $this->compareTalks(...));
+            $groups[] = ['theme' => $theme, 'talks' => $talks];
+        }
+
+        return $groups;
+    }
+
+    private function compareTalks(Talk $a, Talk $b): int
+    {
+        $positionA = $a->getPosition();
+        $positionB = $b->getPosition();
+
+        if ($positionA !== $positionB) {
+            if ($positionA === null) {
+                return 1;
+            }
+            if ($positionB === null) {
+                return -1;
+            }
+
+            return $positionA <=> $positionB;
+        }
+
+        return $a->getTitle() <=> $b->getTitle();
+    }
+
+    private function handleAjaxRequest(Request $request, Event $event): JsonResponse
+    {
+        $action = $request->request->get('action');
+
+        return match ($action) {
+            'update_talk_theme' => $this->updateTalkTheme($request),
+            'update_talk_position' => $this->updateTalkPosition($request),
+            default => new JsonResponse(['error' => 'Action non reconnue'], 400),
+        };
+    }
+
+    private function updateTalkTheme(Request $request): JsonResponse
+    {
+        $talkId = $request->request->getInt('talk_id');
+        $themeId = $request->request->get('theme_id');
+
+        $talk = $this->talkRepository->get($talkId);
+        if (!$talk) {
+            return new JsonResponse(['error' => 'Conférence non trouvée'], 404);
+        }
+
+        $talk->setTheme($themeId ? (int) $themeId : null);
+        $this->talkRepository->save($talk);
+
+        return new JsonResponse(['success' => true]);
+    }
+
+    private function updateTalkPosition(Request $request): JsonResponse
+    {
+        $talkId = $request->request->getInt('talk_id');
+        $position = $request->request->get('position');
+
+        $talk = $this->talkRepository->get($talkId);
+        if (!$talk) {
+            return new JsonResponse(['error' => 'Conférence non trouvée'], 404);
+        }
+
+        $talk->setPosition($position === null || $position === '' ? null : (int) $position);
+        $this->talkRepository->save($talk);
+
+        return new JsonResponse(['success' => true]);
+    }
+}

--- a/sources/AppBundle/Controller/Admin/Event/EventThemeAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/EventThemeAction.php
@@ -7,7 +7,6 @@ namespace AppBundle\Controller\Admin\Event;
 use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventThemeRepository;
-use AppBundle\Event\Model\Repository\TalkRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -15,10 +14,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EventThemeAction extends AbstractController
 {
-    public function __construct(
-        private readonly EventThemeRepository $eventThemeRepository,
-        private readonly TalkRepository $talkRepository,
-    ) {}
+    public function __construct(private readonly EventThemeRepository $eventThemeRepository) {}
 
     public function __invoke(Request $request, AdminEventSelection $eventSelection): Response
     {
@@ -42,11 +38,9 @@ class EventThemeAction extends AbstractController
 
         $eventId = $event->getId() ?? 0;
         $themes = $this->eventThemeRepository->getByThemesOrderedByPriority($eventId);
-        $scheduledTalks = $this->talkRepository->getScheduledTalksByEvent($eventId);
 
         return $this->render('admin/event/theme_list.html.twig', [
             'themes' => $themes,
-            'scheduled_talks' => $scheduledTalks,
             'event' => $event,
             'event_select_form' => $eventSelection->selectForm(),
         ]);
@@ -58,7 +52,6 @@ class EventThemeAction extends AbstractController
 
         return match ($action) {
             'update_theme_priority' => $this->updateThemePriority($request),
-            'update_talk_theme' => $this->updateTalkTheme($request),
             default => new JsonResponse(['error' => 'Action non reconnue'], 400),
         };
     }
@@ -75,22 +68,6 @@ class EventThemeAction extends AbstractController
 
         $theme->setPriority($priority);
         $this->eventThemeRepository->save($theme);
-
-        return new JsonResponse(['success' => true]);
-    }
-
-    private function updateTalkTheme(Request $request): JsonResponse
-    {
-        $talkId = $request->request->getInt('talk_id');
-        $themeId = $request->request->get('theme_id');
-
-        $talk = $this->talkRepository->get($talkId);
-        if (!$talk) {
-            return new JsonResponse(['error' => 'Conférence non trouvée'], 404);
-        }
-
-        $talk->setTheme($themeId ? (int) $themeId : null);
-        $this->talkRepository->save($talk);
 
         return new JsonResponse(['success' => true]);
     }

--- a/sources/AppBundle/Event/Model/Repository/TalkRepository.php
+++ b/sources/AppBundle/Event/Model/Repository/TalkRepository.php
@@ -283,7 +283,7 @@ class TalkRepository extends Repository implements MetadataInitializer
 
         $query = $this->getPreparedQuery(
             sprintf('SELECT talk.id_forum, talk.session_id, titre, skill, talk.genre, abstract, talk.plannifie, talk.language_code,
-            talk.joindin, talk.theme,
+            talk.joindin, talk.theme, talk.position,
             speaker.conferencier_id, speaker.nom, speaker.prenom, speaker.id_forum, speaker.photo, speaker.societe,
             planning.id, planning.debut, planning.fin, room.id, room.nom
             FROM afup_sessions AS talk
@@ -293,7 +293,7 @@ class TalkRepository extends Repository implements MetadataInitializer
             LEFT JOIN afup_forum_salle room ON planning.id_salle = room.id
             LEFT JOIN afup_conference_theme ON afup_conference_theme.id = talk.theme
             WHERE talk.id_forum IN(%s) AND plannifie = 1 %s %s
-            ORDER BY %s ', $inEvents, $publicationdateFilters, $themeFilters, $orderByTheme ? 'afup_conference_theme.priority ASC, afup_conference_theme.name ASC' : 'planning.debut ASC, room.id ASC, talk.date_publication DESC, talk.session_id ASC '),
+            ORDER BY %s ', $inEvents, $publicationdateFilters, $themeFilters, $orderByTheme ? 'afup_conference_theme.priority ASC, afup_conference_theme.name ASC, talk.position IS NULL, talk.position ASC, talk.date_publication DESC, talk.session_id ASC' : 'talk.position IS NULL, talk.position ASC, planning.debut ASC, room.id ASC, talk.date_publication DESC, talk.session_id ASC '),
         )->setParams($params);
 
         $result = $query->query($this->getCollection($hydrator));
@@ -623,6 +623,11 @@ SQL;
             ->addField([
                 'columnName' => 'theme',
                 'fieldName' => 'theme',
+                'type' => 'int',
+            ])
+            ->addField([
+                'columnName' => 'position',
+                'fieldName' => 'position',
                 'type' => 'int',
             ])
         ;

--- a/sources/AppBundle/Event/Model/Talk.php
+++ b/sources/AppBundle/Event/Model/Talk.php
@@ -101,6 +101,8 @@ class Talk implements NotifyPropertyInterface
 
     private ?int $theme = null;
 
+    private ?int $position = null;
+
     public function __construct()
     {
         $this->submittedOn = new \DateTime();
@@ -686,5 +688,16 @@ class Talk implements NotifyPropertyInterface
     {
         $this->propertyChanged('theme', $this->theme, $theme);
         $this->theme = $theme;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(?int $position): void
+    {
+        $this->propertyChanged('position', $this->position, $position);
+        $this->position = $position;
     }
 }

--- a/templates/admin/event/editorialization.html.twig
+++ b/templates/admin/event/editorialization.html.twig
@@ -1,0 +1,188 @@
+{% extends 'admin/base_with_header.html.twig' %}
+
+{% block content %}
+    <h2>Éditorialisation du programme</h2>
+
+    {% include 'admin/event/change_event.html.twig' with {form: event_select_form} only %}
+
+    <div class="ui menu">
+        <div class="item">
+            <button id="save-positions" class="ui green button">
+                <i class="save icon"></i>
+                Sauvegarder les positions
+            </button>
+        </div>
+    </div>
+
+    <h3>Position des conférences <span id="editorialization-success-message" class="ui green label" style="display: none;"><i class="check icon"></i>Sauvegardé</span></h3>
+
+    {% for group in talk_groups %}
+        <h4>{{ group.theme ? group.theme.name : 'Sans thème' }}</h4>
+        {% if group.talks|length %}
+            <table class="ui table striped celled form">
+                <thead>
+                <tr>
+                    <th style="width: 20%;">Conférence</th>
+                    <th style="width: {% if has_themes %}50%{% else %}70%{% endif %};">Résumé</th>
+                    {% if has_themes %}
+                        <th>Thème</th>
+                    {% endif %}
+                    <th>Position</th>
+                </tr>
+                </thead>
+                <tbody>
+                {% for talk in group.talks %}
+                    <tr data-talk-id="{{ talk.id }}">
+                        <td>
+                            <strong>{{ talk.title }}</strong>
+                        </td>
+                        <td>
+                            {% set abstract = talk.abstract %}
+                            {% if abstract|length > 400 %}
+                                <div class="abstract-content">
+                                    <span class="abstract-short">{{ abstract|slice(0, 400) }}...</span>
+                                    <span class="abstract-full" style="display: none;">{{ abstract|raw|markdown }}</span>
+                                    <br>
+                                    <a href="#" class="toggle-abstract">Voir plus</a>
+                                </div>
+                            {% else %}
+                                <div class="abstract-content">
+                                    <span class="abstract-full">{{ abstract|raw|markdown }}</span>
+                                </div>
+                            {% endif %}
+                        </td>
+                        {% if has_themes %}
+                            <td>
+                                <div class="inline fields">
+                                    <select class="theme-select ui" data-talk-id="{{ talk.id }}">
+                                        <option value="">Aucun thème</option>
+                                        {% for theme in themes %}
+                                            <option value="{{ theme.id }}"
+                                                    {% if talk.theme == theme.id %}selected{% endif %}>
+                                                {{ theme.name }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            </td>
+                        {% endif %}
+                        <td>
+                            <input type="number"
+                                   class="position-input"
+                                   value="{{ talk.position }}"
+                                   min="0"
+                                   step="1"
+                                   data-talk-id="{{ talk.id }}"
+                                   style="width: 80px;">
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <div class="ui icon header">
+                <i class="meh outline icon"></i>
+                Aucune conférence.
+            </div>
+        {% endif %}
+    {% else %}
+        <div class="ui icon header">
+            <i class="meh outline icon"></i>
+            Aucune conférence planifiée pour cet événement.
+        </div>
+    {% endfor %}
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Wait for jQuery to be available
+        function waitForJQuery(callback) {
+            if (typeof $ !== 'undefined') {
+                callback();
+            } else {
+                setTimeout(function() { waitForJQuery(callback); }, 100);
+            }
+        }
+
+        waitForJQuery(function() {
+            // Handle theme selection for talks with native selects
+            $('.theme-select').on('change', function() {
+                var talkId = $(this).data('talk-id');
+                var themeId = $(this).val();
+
+                $.ajax({
+                    url: '{{ path('admin_event_editorialization', {'id': event.id}) }}',
+                    method: 'POST',
+                    data: {
+                        action: 'update_talk_theme',
+                        talk_id: talkId,
+                        theme_id: themeId
+                    },
+                    headers: {
+                        'X-Requested-With': 'XMLHttpRequest'
+                    },
+                    success: function(response) {
+                        if (response.success) {
+                            location.reload();
+                        }
+                    },
+                    error: function() {
+                        alert('Erreur lors de la mise à jour du thème');
+                    }
+                });
+            });
+
+            // Handle position updates
+            $('#save-positions').click(function() {
+                var positions = [];
+                $('.position-input').each(function() {
+                    positions.push({
+                        talk_id: $(this).data('talk-id'),
+                        position: $(this).val()
+                    });
+                });
+
+                var promises = positions.map(function(item) {
+                    return $.ajax({
+                        url: '{{ path('admin_event_editorialization', {'id': event.id}) }}',
+                        method: 'POST',
+                        data: {
+                            action: 'update_talk_position',
+                            talk_id: item.talk_id,
+                            position: item.position
+                        },
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest'
+                        }
+                    });
+                });
+
+                Promise.all(promises).then(function() {
+                    alert('Positions sauvegardées avec succès');
+                    location.reload();
+                }).catch(function() {
+                    alert('Erreur lors de la sauvegarde');
+                });
+            });
+
+            // Handle abstract toggle
+            $('.toggle-abstract').click(function(e) {
+                e.preventDefault();
+                var container = $(this).closest('.abstract-content');
+                var shortVersion = container.find('.abstract-short');
+                var fullVersion = container.find('.abstract-full');
+
+                if (fullVersion.is(':visible')) {
+                    fullVersion.hide();
+                    shortVersion.show();
+                    $(this).text('Voir plus');
+                } else {
+                    shortVersion.hide();
+                    fullVersion.show();
+                    $(this).text('Voir moins');
+                }
+            });
+        });
+    });
+    </script>
+
+{% endblock %}

--- a/templates/admin/event/theme_list.html.twig
+++ b/templates/admin/event/theme_list.html.twig
@@ -72,63 +72,6 @@
         </tbody>
     </table>
 
-    <h3>Association des conférences aux thèmes <span id="theme-success-message" class="ui green label" style="display: none;"><i class="check icon"></i>Sauvegardé</span></h3>
-    <div id="talks-section">
-        {% if scheduled_talks %}
-            <table class="ui table striped celled form">
-                <thead>
-                <tr>
-                    <th style="width: 20%;">Conférence</th>
-                    <th style="width: 70%;">Résumé</th>
-                    <th style="">Thème</th>
-                </tr>
-                </thead>
-                <tbody>
-                {% for talk in scheduled_talks %}
-                    <tr data-talk-id="{{ talk.id }}">
-                        <td>
-                            <strong>{{ talk.title }}</strong>
-                        </td>
-                        <td>
-                            {% set abstract = talk.abstract %}
-                            {% if abstract|length > 400 %}
-                                <div class="abstract-content">
-                                    <span class="abstract-short">{{ abstract|slice(0, 400) }}...</span>
-                                    <span class="abstract-full" style="display: none;">{{ abstract|raw|markdown }}</span>
-                                    <br>
-                                    <a href="#" class="toggle-abstract">Voir plus</a>
-                                </div>
-                            {% else %}
-                                <div class="abstract-content">
-                                    <span class="abstract-full">{{ abstract|raw|markdown }}</span>
-                                </div>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <div class="inline fields">
-                                <select class="theme-select ui " data-talk-id="{{ talk.id }}">
-                                    <option value="">Aucun thème</option>
-                                    {% for theme in themes %}
-                                        <option value="{{ theme.id }}"
-                                                {% if talk.theme == theme.id %}selected{% endif %}>
-                                            {{ theme.name }}
-                                        </option>
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        </td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-            </table>
-        {% else %}
-            <div class="ui icon header">
-                <i class="meh outline icon"></i>
-                Aucune conférence planifiée pour cet événement.
-            </div>
-        {% endif %}
-    </div>
-
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Wait for jQuery to be available
@@ -141,37 +84,6 @@
         }
 
         waitForJQuery(function() {
-            // Handle theme selection for talks with native selects
-            $('.theme-select').on('change', function() {
-                var talkId = $(this).data('talk-id');
-                var themeId = $(this).val();
-
-                $.ajax({
-                    url: '{{ path('admin_event_themes_list', {'id': event.id}) }}',
-                    method: 'POST',
-                    data: {
-                        action: 'update_talk_theme',
-                        talk_id: talkId,
-                        theme_id: themeId
-                    },
-                    headers: {
-                        'X-Requested-With': 'XMLHttpRequest'
-                    },
-                    success: function(response) {
-                        if (response.success) {
-                            // Show success message
-                            $('#theme-success-message').show();
-                            setTimeout(function() {
-                                $('#theme-success-message').fadeOut();
-                            }, 2000);
-                        }
-                    },
-                    error: function() {
-                        alert('Erreur lors de la mise à jour du thème');
-                    }
-                });
-            });
-
             // Handle priority updates
             $('#save-priorities').click(function() {
                 var priorities = [];
@@ -204,24 +116,6 @@
                 }).catch(function() {
                     alert('Erreur lors de la sauvegarde');
                 });
-            });
-
-            // Handle abstract toggle
-            $('.toggle-abstract').click(function(e) {
-                e.preventDefault();
-                var container = $(this).closest('.abstract-content');
-                var shortVersion = container.find('.abstract-short');
-                var fullVersion = container.find('.abstract-full');
-
-                if (fullVersion.is(':visible')) {
-                    fullVersion.hide();
-                    shortVersion.show();
-                    $(this).text('Voir plus');
-                } else {
-                    shortVersion.hide();
-                    fullVersion.show();
-                    $(this).text('Voir moins');
-                }
             });
         });
     });


### PR DESCRIPTION
Suite à l'ajout des programmes, il peut être intéressant de pouvoir editorialiser l'ordre des conférences dans le programme.

La MR introduit une nouvelle page "Éditorialisation" qui gère 2 cas d'usage :
* Si les thèmes sont actifs, l'ordre s'applique entre les talks d'un même thème
* Sinon l'ordre est global

<img width="1854" height="934" alt="image" src="https://github.com/user-attachments/assets/e8ae0c6e-7eb8-463a-8bdc-2a95fd3d5cc8" />
