### PR TITLE
on affiche un bandeau avec un message d'alerte sur la situation de l'AFUP

### DIFF
--- a/templates/site/base.html.twig
+++ b/templates/site/base.html.twig
@@ -20,6 +20,12 @@
 
 {% block header %}
     {% autoescape false %}
+
+    <div style="background-color: #ed0678;color: white;text-align: center;padding: 3px 0;font-size: 1.2em;font-weight: bold;">
+        L'AFUP est en difficulté,
+        <a href="/news/1256-des-nouvelles-situation-afup-mai2026" tabindex="-1" style="color: white;">découvrez comment aider l'association</a>.
+    </div>
+
     <header>
         <div class="mw1400p center">
             <div id="espace-membre" class="w33 tablet-hidden">


### PR DESCRIPTION
On affiche temporairement un bandeau (c'est donc hardcodé de façon un peu moche), cela permet de bien mettre en avant l'article et les moyens d'aider l'AFUP.

<img width="1854" height="1083" alt="Screenshot 2026-07-14 at 15-20-25 Afup - Association française des utilisateurs de PHP" src="https://github.com/user-attachments/assets/d8047111-2108-4558-8649-8b37fdce1b3b" />

