### PR TITLE
correction sur la création d'une interview

### DIFF
--- a/sources/AppBundle/Event/Form/InterviewQuestionType.php
+++ b/sources/AppBundle/Event/Form/InterviewQuestionType.php
@@ -36,7 +36,7 @@ class InterviewQuestionType extends AbstractType
                     'rows' => 10,
                     'class' => 'easymde',
                 ],
-                'required' => true,
+                'required' => false,
                 'empty_data' => '',
                 'constraints' => [
                     new Assert\NotBlank(),

--- a/templates/admin/base_with_header.html.twig
+++ b/templates/admin/base_with_header.html.twig
@@ -197,13 +197,19 @@
                     });
                 });
 
+                window.initEasyMDE = function(element) {
+                    if (element && !element.easymde) {
+                        element.easymde = new EasyMDE({
+                            element: element,
+                            spellChecker: false,
+                            hideIcons: ['side-by-side', 'fullscreen', 'check-list']
+                        });
+                    }
+                };
+
                 var easyMdeList = document.getElementsByClassName('easymde');
                 for (var i = 0; i < easyMdeList.length; i++) {
-                    var easymde = new EasyMDE({
-                        element:easyMdeList[i],
-                        spellChecker: false,
-                        hideIcons: ['side-by-side', 'fullscreen', 'check-list']
-                    });
+                    window.initEasyMDE(easyMdeList[i]);
                 }
 
             </script>

--- a/templates/admin/event/interview/_javascript.html.twig
+++ b/templates/admin/event/interview/_javascript.html.twig
@@ -17,6 +17,11 @@
 
       collectionHolder.appendChild(item);
 
+      const textarea = item.querySelector('.easymde');
+      if (textarea) {
+        window.initEasyMDE(textarea);
+      }
+
       addDeletionButton(item, collectionHolder.dataset.index);
       collectionHolder.dataset.index++;
     }


### PR DESCRIPTION
La soumission du formulaire de création d'interview ne fonctionnait pas, on avait l'erreur "Le contrôle de formulaire avec name='interview[questions][0][reponse]'" car le champ requis était caché avec easymde, pour cela on désactive le required, où de toute façon on la validation coté serveur avec le NotBlank.

De plus EasyMde était affiché seulement sur la première question (où plutôt sur les questions déjà affichées au chargement de la page, pas quand on ajoutait une question, on fait en sorte de le charger quand on ajoute une question.