### PR TITLE
Amélioration gestion d'erreur des devis

### DIFF
--- a/sources/AppBundle/Accounting/Model/Invoicing.php
+++ b/sources/AppBundle/Accounting/Model/Invoicing.php
@@ -10,6 +10,7 @@ use AppBundle\Accounting\InvoicingPaymentStatus;
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
 use DateTime;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class Invoicing implements NotifyPropertyInterface
 {
@@ -39,6 +40,7 @@ class Invoicing implements NotifyPropertyInterface
     private ?DateTime $paymentDate = null;
     private ?InvoicingCurrency $currency = null;
     /** @var InvoicingDetail[] */
+    #[Assert\Valid]
     private array $details = [];
 
     private ?float $price = null;

--- a/sources/AppBundle/Accounting/Model/InvoicingDetail.php
+++ b/sources/AppBundle/Accounting/Model/InvoicingDetail.php
@@ -6,6 +6,7 @@ namespace AppBundle\Accounting\Model;
 
 use CCMBenchmark\Ting\Entity\NotifyProperty;
 use CCMBenchmark\Ting\Entity\NotifyPropertyInterface;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class InvoicingDetail implements NotifyPropertyInterface
 {
@@ -13,10 +14,22 @@ class InvoicingDetail implements NotifyPropertyInterface
 
     private ?int $id = null;
     private ?int $invoicingId = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 20)]
     private ?string $reference = null;
+
+    #[Assert\NotBlank]
+    #[Assert\Length(max: 100)]
     private ?string $designation = null;
+
+    #[Assert\NotBlank]
     private ?float $quantity = null;
+
+    #[Assert\NotBlank]
     private ?float $unitPrice = null;
+
+    #[Assert\NotBlank]
     private ?float $tva = null;
 
     public function getId(): ?int

--- a/sources/AppBundle/Controller/Admin/Accounting/Quotation/AddQuotationAction.php
+++ b/sources/AppBundle/Controller/Admin/Accounting/Quotation/AddQuotationAction.php
@@ -11,6 +11,7 @@ use AppBundle\Accounting\Model\Invoicing;
 use AppBundle\Accounting\Model\InvoicingDetail;
 use AppBundle\Accounting\Model\Repository\InvoicingDetailRepository;
 use AppBundle\Accounting\Model\Repository\InvoicingRepository;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,6 +23,7 @@ class AddQuotationAction extends AbstractController
         private readonly InvoicingNumberGenerator $numberGenerator,
         private readonly InvoicingDetailRepository $invoicingDetailRepository,
         private readonly ProduitRepository $produitRepository,
+        private readonly LoggerInterface $logger,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -41,8 +43,9 @@ class AddQuotationAction extends AbstractController
                 $this->invoicingRepository->commit();
                 $this->addFlash('success',  'L\'écriture a été ajoutée');
                 return $this->redirectToRoute('admin_accounting_quotations_list');
-            } catch (\Exception) {
+            } catch (\Exception $e) {
                 $this->invoicingRepository->rollback();
+                $this->logger->error('Échec de l\'ajout d\'un devis : ' . $e->getMessage(), ['exception' => $e]);
                 $this->addFlash('error',  'L\'écriture n\'a pas pu être enregistrée');
             }
         }

--- a/sources/AppBundle/Controller/Admin/Accounting/Quotation/EditQuotationAction.php
+++ b/sources/AppBundle/Controller/Admin/Accounting/Quotation/EditQuotationAction.php
@@ -8,6 +8,7 @@ use AppBundle\Accounting\Entity\Repository\ProduitRepository;
 use AppBundle\Accounting\Form\QuotationType;
 use AppBundle\Accounting\Model\Repository\InvoicingDetailRepository;
 use AppBundle\Accounting\Model\Repository\InvoicingRepository;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -18,6 +19,7 @@ class EditQuotationAction extends AbstractController
         private readonly InvoicingRepository $invoicingRepository,
         private readonly InvoicingDetailRepository $invoicingDetailRepository,
         private readonly ProduitRepository $produitRepository,
+        private readonly LoggerInterface $logger,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -51,8 +53,9 @@ class EditQuotationAction extends AbstractController
                 $this->invoicingRepository->commit();
                 $this->addFlash('success',  'L\'écriture a été modifiée');
                 return $this->redirectToRoute('admin_accounting_quotations_list');
-            } catch (\Exception) {
+            } catch (\Exception $e) {
                 $this->invoicingRepository->rollback();
+                $this->logger->error('Échec de la modification d\'un devis : ' . $e->getMessage(), ['exception' => $e]);
                 $this->addFlash('error',  'L\'écriture n\'a pas pu être enregistrée');
             }
         }

--- a/templates/admin/accounting/quotation/_form_theme.html.twig
+++ b/templates/admin/accounting/quotation/_form_theme.html.twig
@@ -1,0 +1,28 @@
+{% use 'form_theme_admin.html.twig' %}
+
+{%- block form_row -%}
+    <div class="inline fields ui grid">
+        {{ form_label(form) }}
+        <div class="field nine wide column" style="flex-wrap: wrap;">
+            <div class="ui input" style="max-width: none; width: 100%;">
+                {{ form_widget(form) }}
+            </div>
+            {{ form_errors(form) }}
+            {% if help is not empty %}
+                <div style="flex-basis: 100%;">
+                    <i>{{ form_help(form) }}</i>
+                </div>
+            {% endif %}
+        </div>
+    </div>
+{%- endblock form_row -%}
+
+{%- block form_errors -%}
+    {%- if errors|length > 0 -%}
+        <div class="ui pointing red basic label" style="flex-basis: 100%; margin-top: 0.5em;">
+            {%- for error in errors -%}
+                {{ error.message }}{% if not loop.last %}<br>{% endif %}
+            {%- endfor -%}
+        </div>
+    {%- endif -%}
+{%- endblock form_errors -%}

--- a/templates/admin/accounting/quotation/form.html.twig
+++ b/templates/admin/accounting/quotation/form.html.twig
@@ -1,4 +1,4 @@
-{% form_theme form 'form_theme_admin.html.twig' %}
+{% form_theme form 'admin/accounting/quotation/_form_theme.html.twig' %}
 
 {{ form_start(form) }}
 {{ form_errors(form) }}


### PR DESCRIPTION
La création d'un devis avec une ligne dont la référence dépasse 20 caractères  échouait avec un message générique et inexploitable :  *"L'écriture n'a pas pu être enregistrée"*.

Le formulaire des devis embarque un CollectionType avec l'option `keep_as_list: true`. Pendant la soumission, Symfony remplace les sous-formulaires de chaque ligne par de nouveaux formulaires jamais soumis, ce qui empêche la validation (`NotBlank`, `Length`, etc.) de s'exécuter sur les lignes. 

On déplace les contraintes de validation les les entités (`InvoicingDetail`, `Invoicing` avec `#[Assert\Valid]`), qui sont validées indépendamment de ce contournement du formulaire.
