### PR TITLE
Correction incohérence entre produits et devis/facture

### DIFF
--- a/db/migrations/20260810120000_increase_quotation_reference_length.php
+++ b/db/migrations/20260810120000_increase_quotation_reference_length.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class IncreaseQuotationReferenceLength extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('afup_compta_facture_details')
+            ->changeColumn('ref', 'string', [
+                'limit' => 50,
+                'null' => false,
+            ])
+            ->update();
+    }
+}

--- a/db/migrations/20260810120100_reduce_produit_reference_length.php
+++ b/db/migrations/20260810120100_reduce_produit_reference_length.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class ReduceProduitReferenceLength extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('compta_produit')
+            ->changeColumn('reference', 'string', [
+                'limit' => 50,
+                'null' => false,
+            ])
+            ->update();
+    }
+}

--- a/sources/AppBundle/Accounting/Entity/Produit.php
+++ b/sources/AppBundle/Accounting/Entity/Produit.php
@@ -16,7 +16,7 @@ class Produit
     #[ORM\Column]
     public ?int $id = null;
 
-    #[ORM\Column(length: 255, nullable: false)]
+    #[ORM\Column(length: 50, nullable: false)]
     public string $reference;
 
     #[ORM\Column(length: 255, nullable: false)]

--- a/sources/AppBundle/Accounting/Form/InvoicingRowType.php
+++ b/sources/AppBundle/Accounting/Form/InvoicingRowType.php
@@ -24,7 +24,7 @@ class InvoicingRowType extends AbstractType
             'constraints' => [
                 new Assert\NotBlank(),
                 new Assert\Type(type: 'string'),
-                new Assert\Length(max: 20),
+                new Assert\Length(max: 50),
             ],
         ])->add('designation', TextareaType::class, [
             'label' => 'Désignation',

--- a/sources/AppBundle/Accounting/Form/ProduitType.php
+++ b/sources/AppBundle/Accounting/Form/ProduitType.php
@@ -24,7 +24,7 @@ class ProduitType extends AbstractType
             'constraints' => [
                 new Assert\NotBlank(),
                 new Assert\Type('string'),
-                new Assert\Length(max: 20),
+                new Assert\Length(max: 50),
             ],
         ])->add('designation', TextareaType::class, [
             'label' => 'Désignation',


### PR DESCRIPTION
Les produits utilisent une reférence de maximum 255 caractères alors que la colonne ref de la table afup_compta_facture_details n'en accepte que 20.

La limite à 20 caractères est l'origine des bug recontré par Benjamin (cf. https://afup.slack.com/archives/C03L64VE9/p1785505576263349)

