### PR TITLE
Meilleure gestion de la date d'expiration d'une cotisation

### DIFF
--- a/sources/AppBundle/MembershipFee/MembershipFeeService.php
+++ b/sources/AppBundle/MembershipFee/MembershipFeeService.php
@@ -10,10 +10,14 @@ use AppBundle\MembershipFee\Model\MembershipFee;
 use AppBundle\MembershipFee\Model\Repository\MembershipFeeRepository;
 use DateInterval;
 use DateTime;
+use Psr\Clock\ClockInterface;
 
-class MembershipFeeService
+readonly class MembershipFeeService
 {
-    public function __construct(private readonly MembershipFeeRepository $membershipFeeRepository) {}
+    public function __construct(
+        private MembershipFeeRepository $membershipFeeRepository,
+        private ClockInterface $clock,
+    ) {}
 
     public function ajouter(
         MemberType $typePersonne,
@@ -93,18 +97,26 @@ class MembershipFeeService
 
     public function getNextSubscriptionExpiration(?MembershipFee $cotisation = null): DateTime
     {
+        $now = $this->clock->now();
+        $base = clone $now;
         $endDate = $cotisation?->getEndDate();
-        $endSubscription = $endDate !== null ? (clone $endDate)->setTime(23, 59, 59) : new DateTime();
-        $base = $now = new DateTime();
 
-        $year = new DateInterval('P1Y');
+        if ($endDate !== null) {
+            // La date de fin est stockée en UTC.
+            // On la ramène dans le bon fuseau horaire avant de la modifier.
+            $endSubscription = (clone $endDate)
+                ->setTimezone($now->getTimezone())
+                ->setTime(23, 59, 59);
 
-        if ($endSubscription > $now) {
-            $base = $endSubscription;
+            if ($endSubscription > $now) {
+                $base = $endSubscription;
+            }
         }
 
-        $base->add($year);
-        return $base;
+        $result = $base->add(new DateInterval('P1Y'));
+
+        return new \DateTime(timezone: $result->getTimezone())
+            ->setTimestamp($result->getTimestamp());
     }
 
     /**

--- a/tests/unit/AppBundle/MembershipFee/MembershipFeeServiceTest.php
+++ b/tests/unit/AppBundle/MembershipFee/MembershipFeeServiceTest.php
@@ -11,6 +11,7 @@ use AppBundle\MembershipFee\Model\Repository\MembershipFeeRepository;
 use AppBundle\MembershipFee\OnlinePaymentHandler;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
 
 final class MembershipFeeServiceTest extends TestCase
 {
@@ -33,15 +34,25 @@ final class MembershipFeeServiceTest extends TestCase
                 'dateFin' => new \DateTimeImmutable('+1 month')->setTime(14, 0),
                 'expected' => new \DateTimeImmutable('+1 month')->setTime(14, 0)->add(new \DateInterval('P1Y')),
             ],
+            'Date d\'expiration pendant les heures d\'été' => [
+                'dateFin' => (new \DateTime('2026-08-13 00:45:00')),
+                'expected' => new \DateTime('2027-08-13 00:45:00'),
+                'now' => new \DateTimeImmutable('2026-08-13 00:45:00'),
+            ],
+            'Date d\'expiration pendant les heures d\'hiver' => [
+                'dateFin' => (new \DateTime('2026-02-13 00:45:00')),
+                'expected' => new \DateTime('2027-02-13 00:45:00'),
+                'now' => new \DateTimeImmutable('2026-02-13 00:45:00'),
+            ],
         ];
     }
 
     #[DataProvider('generateCotisationProvider')]
-    public function testFinProchaineCotisation(\DateTimeInterface $dateFin, \DateTimeInterface $expected): void
+    public function testFinProchaineCotisation(\DateTimeInterface $dateFin, \DateTimeInterface $expected, ?\DateTimeImmutable $now = null): void
     {
         $membershipFeeRepository = $this->createMock(MembershipFeeRepository::class);
 
-        $membershipFeeService = new MembershipFeeService($membershipFeeRepository);
+        $membershipFeeService = new MembershipFeeService($membershipFeeRepository, new MockClock($now ?? new \DateTimeImmutable()));
 
         $membershipFee = new MembershipFee();
         $membershipFee->setEndDate(new \DateTime('@' . $dateFin->format('U')));
@@ -70,7 +81,7 @@ final class MembershipFeeServiceTest extends TestCase
     {
         $membershipFeeRepository = $this->createMock(MembershipFeeRepository::class);
 
-        $membershipFeeService = new MembershipFeeService($membershipFeeRepository);
+        $membershipFeeService = new MembershipFeeService($membershipFeeRepository, new MockClock());
 
         $actual = new OnlinePaymentHandler(
             $membershipFeeService,


### PR DESCRIPTION
Il pouvait arriver que la date de d'expiration soit décalée d'un jour pour une cotisation prise entre minuit et 1h59 du matin ou minuit et 1h du matin selon l'heure d'été ou d'hiver.