### PR TITLE
Améliorer l'ajout d'interviews dans le back-office

### DIFF
--- a/sources/AppBundle/Controller/Admin/Event/Interview/ListAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Interview/ListAction.php
@@ -50,7 +50,8 @@ class ListAction extends AbstractController
 
         usort(
             $interviewsWithSpeakers,
-            fn(array $a, array $b) => $this->firstSpeakerLabel($a['speakers']) <=> $this->firstSpeakerLabel($b['speakers']),
+            fn(array $a, array $b): int => $a['interview']->datePublication <=> $b['interview']->datePublication
+                ?: $this->firstSpeakerLabel($a['speakers']) <=> $this->firstSpeakerLabel($b['speakers']),
         );
 
         $speakersWithoutInterview = array_values(array_filter(

--- a/sources/AppBundle/Event/Form/InterviewConfigType.php
+++ b/sources/AppBundle/Event/Form/InterviewConfigType.php
@@ -39,7 +39,7 @@ final class InterviewConfigType extends AbstractType
                 'required' => true,
                 'choices' => $choices,
                 'placeholder' => '-- Choisir --',
-                'help' => 'La catégorie doit être créée <a href="' . $this->wordpressBaseUri . '/wp-admin/edit-tags.php?taxonomy=category">côté WordPress</a>',
+                'help' => 'La liste ci-dessous correspond aux catégories déjà existantes sur WordPress : si votre catégorie y figure, sélectionnez-la. Sinon, <a href="' . $this->wordpressBaseUri . '/wp-admin/edit-tags.php?taxonomy=category">créez-la d\'abord dans WordPress</a>.',
                 'help_html' => true,
             ])
             ->add('interviewsIntro', TextareaType::class, [

--- a/tests/behat/bootstrap/FeatureContext.php
+++ b/tests/behat/bootstrap/FeatureContext.php
@@ -110,6 +110,30 @@ class FeatureContext implements Context
         $link->click();
     }
 
+    #[Then('/^the rows of table "(?P<selector>[^"]+)" should be in the following order:$/')]
+    public function assertTableRowsInOrder(string $selector, PyStringNode $expectedRows): void
+    {
+        $expected = array_values(array_filter(array_map('trim', $expectedRows->getStrings())));
+        $rows = $this->minkContext->getSession()->getPage()->findAll('css', $selector . ' tbody tr');
+
+        if (count($expected) !== count($rows)) {
+            throw new ExpectationException(
+                sprintf('Expected %d rows but found %d in "%s"', count($expected), count($rows), $selector),
+                $this->minkContext->getSession()->getDriver(),
+            );
+        }
+
+        foreach ($expected as $index => $expectedText) {
+            $actualText = $rows[$index]->getText();
+            if (!str_contains($actualText, $expectedText)) {
+                throw new ExpectationException(
+                    sprintf('Row %d of "%s" should contain "%s" but contains "%s"', $index + 1, $selector, $expectedText, $actualText),
+                    $this->minkContext->getSession()->getDriver(),
+                );
+            }
+        }
+    }
+
     #[Then('the checksum of the response content should be :md5')]
     public function checksumOfTheResponseContentShouldBe(string $expectedChecksum): void
     {

--- a/tests/behat/features/Admin/Events/Interviews.feature
+++ b/tests/behat/features/Admin/Events/Interviews.feature
@@ -5,6 +5,7 @@ Feature: Administration - Évènements - Interviews
     And I follow "afup-main-menu-item--admin_event_interview_list"
     Then the ".content h2" element should contain "Interviews"
     And I follow "Configurer"
+    Then I should see "La liste ci-dessous correspond aux catégories déjà existantes sur WordPress"
     When I select "1" from "interview_config[interviewsWordpressCategoryId]"
     And I fill in "interview_config[interviewsIntro]" with "Les super interviews"
     And I fill in "interview_config[interviewsCtaText]" with "Le bouton"
@@ -50,6 +51,33 @@ Feature: Administration - Évènements - Interviews
     And I press "Enregistrer"
     Then I should see "L'interview a été enregistrée"
     And the ".content table" element should contain "Adrien GALLOU, Geoffrey BACHELET"
+
+  @reloadDbWithTestData
+  Scenario: La liste des interviews est triée par date de publication (la plus ancienne en premier)
+    And I follow "afup-main-menu-item--admin_event_interview_list"
+    And I follow "Nouvelle interview"
+    And I fill in "interview[datePublication]" with "2026-06-01T10:00:00"
+    When I select "Geoffrey BACHELET" from "interview[speakers][]"
+    And I fill in "interview[questions][0][question]" with "Question récente"
+    And I fill in "interview[questions][0][reponse]" with "Réponse récente"
+    And I press "Enregistrer"
+    Then I should see "L'interview a été enregistrée"
+
+    Given I follow "afup-main-menu-item--admin_event_interview_list"
+    And I follow "Nouvelle interview"
+    And I fill in "interview[datePublication]" with "2026-05-01T10:00:00"
+    When I select "Adrien GALLOU" from "interview[speakers][]"
+    And I fill in "interview[questions][0][question]" with "Question ancienne"
+    And I fill in "interview[questions][0][reponse]" with "Réponse ancienne"
+    And I press "Enregistrer"
+    Then I should see "L'interview a été enregistrée"
+
+    Given I follow "afup-main-menu-item--admin_event_interview_list"
+    Then the rows of table ".content table" should be in the following order:
+      """
+      Adrien GALLOU
+      Geoffrey BACHELET
+      """
 
   @reloadDbWithTestData
   Scenario: Acces refusé pour un membre simple


### PR DESCRIPTION
## Description

Améliore l'ajout d'interviews dans le back-office (issue #2333) sur la base de retours faits sur la fonctionnalité de publication des interviews.

## Changements

- Trie la liste des interviews par date de publication (la plus ancienne en premier) au lieu de trier par nom de speaker.
- Clarifie le wording du champ « Catégorie » de la configuration WordPress : le menu déroulant liste les catégories déjà existantes sur WordPress, il faut donc en créer une si elle n'y figure pas.
- Ajoute un scénario Behat vérifiant l'ordre d'affichage de la liste et une assertion sur le nouveau texte d'aide.

## Comment tester

1. Se rendre dans le back-office sur la liste des interviews d'un événement (`/admin/event/interviews?id=<id>`).
2. Vérifier que les interviews sont ordonnées par date de publication, la plus ancienne en premier.
3. Ouvrir la configuration des interviews d'un événement et vérifier le texte d'aide du menu déroulant de catégorie.

## Notes

Sans objet.