### PR TITLE
Ajout de coloration syntaxique du code dans les articles

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,3 +1,4 @@
+@import "../../vendor/tempest/highlight/src/Themes/Css/catppuccin-latte.css";
 @import "./fonts.css";
 @import "tailwindcss" source(none);
 @source "../../templates";
@@ -32,5 +33,11 @@
     body {
         /* Désactive les effets (italic, gras, etc) automatiques des polices pour prioriser les version contenues dans les polices */
         font-synthesis: none;
+    }
+
+    /* Pour les balises de code "inline" dans les articles (les blocs de code ont déjà un padding et un arrondi de base) */
+    .prose code {
+        @apply px-2 py-1;
+        @apply rounded-lg;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
     "symfony/yaml": "7.4.*",
     "symfonycasts/tailwind-bundle": "^1.0",
     "tales-from-a-dev/twig-tailwind-extra": "^1.2",
+    "tempest/highlight": "^2.27",
     "tiime/newrelic-bundle": "^1.0",
     "twig/extra-bundle": "^3.24",
     "twig/html-extra": "^3.28",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d83d6ae5ec9fd847a1e5f0b3ec3154d6",
+    "content-hash": "816bcbf0070fbe0b7cb36da1f14116c0",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -11284,6 +11284,65 @@
                 "source": "https://github.com/tales-from-a-dev/twig-tailwind-extra/tree/v1.3.0"
             },
             "time": "2026-08-09T15:21:26+00:00"
+        },
+        {
+            "name": "tempest/highlight",
+            "version": "2.27.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tempestphp/highlight.git",
+                "reference": "7eaf2f4030cc218320672902608b6226bb13a39a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tempestphp/highlight/zipball/7eaf2f4030cc218320672902608b6226bb13a39a",
+                "reference": "7eaf2f4030cc218320672902608b6226bb13a39a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "assertchris/ellison": "^1.0.2",
+                "friendsofphp/php-cs-fixer": "^3.84",
+                "league/commonmark": "^2.4",
+                "phpbench/phpbench": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^12.0",
+                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+            },
+            "suggest": {
+                "assertchris/ellison": "Allows you to analyse sentence complexity",
+                "league/commonmark": "Adds markdown support"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Tempest\\Highlight\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brent Roose",
+                    "email": "brendt@stitcher.io"
+                }
+            ],
+            "description": "Fast, extensible, server-side code highlighting",
+            "support": {
+                "issues": "https://github.com/tempestphp/highlight/issues",
+                "source": "https://github.com/tempestphp/highlight/tree/2.27.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/brendt",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-29T09:11:42+00:00"
         },
         {
             "name": "tiime/newrelic-bundle",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -150,6 +150,11 @@ services:
 
     Twig\Extra\Markdown\MarkdownInterface: '@twig.markdown.default'
 
+    League\CommonMark\Extension\Autolink\AutolinkExtension:
+        tags: [ 'twig.markdown.league_extension' ]
+    Tempest\Highlight\CommonMark\HighlightExtension:
+        tags: [ 'twig.markdown.league_extension' ]
+
     geocoder:
         class: Geocoder\StatefulGeocoder
         arguments: ['@geocoder_provider_google_maps']


### PR DESCRIPTION
Pour écrire des articles techniques un peu plus sympa à lire.

La librairie utilisée fonctionne entièrement en PHP.