### PR TITLE
Correction du décalage horaire du planning en forçant la timezone

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -3128,12 +3128,6 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/sources/AppBundle/Controller/Admin/Event/Session/EditAction.php',
 ];
 $ignoreErrors[] = [
-	'message' => '#^Cannot clone DateTime\\|null\\.$#',
-	'identifier' => 'clone.nonObject',
-	'count' => 2,
-	'path' => __DIR__ . '/sources/AppBundle/Controller/Admin/Event/Session/EditAction.php',
-];
-$ignoreErrors[] = [
 	'message' => '#^Method AppBundle\\\\Controller\\\\Admin\\\\Event\\\\Session\\\\EditAction\\:\\:getForm\\(\\) has parameter \\$roomChoices with no value type specified in iterable type array\\.$#',
 	'identifier' => 'missingType.iterableValue',
 	'count' => 1,

--- a/sources/AppBundle/Controller/Admin/Event/Session/CalendarAjaxAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Session/CalendarAjaxAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AppBundle\Controller\Admin\Event\Session;
 
+use AppBundle\Event\Model\Planning;
 use AppBundle\Event\Model\Repository\PlanningRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,8 +22,12 @@ class CalendarAjaxAction extends AbstractController
         }
         $data = $request->toArray();
 
-        $planning->setStart(new \DateTime($data['start']));
-        $planning->setEnd(new \DateTime($data['end']));
+        // Le calendrier envoie l'heure telle qu'affichée, sans décalage :
+        // c'est donc l'heure locale de l'événement, pas celle du navigateur.
+        $timezone = new \DateTimeZone(Planning::TIMEZONE);
+
+        $planning->setStart(new \DateTime($data['start'], $timezone));
+        $planning->setEnd(new \DateTime($data['end'], $timezone));
         $planning->setRoomId((int) $data['roomId']);
 
         $this->planningRepository->save($planning);

--- a/sources/AppBundle/Controller/Admin/Event/Session/EditAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Session/EditAction.php
@@ -48,8 +48,8 @@ class EditAction extends AbstractController
             $planning = new Planning();
             $planning->setTalkId($talk->getId());
             $planning->setEventId($event->getId());
-            $planning->setStart(clone $event->getDateStart());
-            $planning->setEnd(clone $event->getDateStart());
+            $planning->setStart($this->firstDayOfEvent($event));
+            $planning->setEnd($this->firstDayOfEvent($event));
         }
 
         $form = $this->getForm($planning, $roomChoices);
@@ -95,9 +95,11 @@ class EditAction extends AbstractController
         return $this->createFormBuilder($data)
             ->add('start', DateTimeType::class, [
                 'label' => 'Début',
+                'view_timezone' => Planning::TIMEZONE,
             ])
             ->add('end', DateTimeType::class, [
                 'label' => 'Fin',
+                'view_timezone' => Planning::TIMEZONE,
             ])
             ->add('roomId', ChoiceType::class, [
                 'label' => 'Salle',
@@ -109,6 +111,17 @@ class EditAction extends AbstractController
             ])
             ->getForm();
 
+    }
+
+    /**
+     * Minuit le premier jour de l'événement, dans la timezone où le planning est saisi.
+     */
+    private function firstDayOfEvent(Event $event): \DateTime
+    {
+        return new \DateTime(
+            $event->getDateStart()?->format('Y-m-d') ?? 'today',
+            new \DateTimeZone(Planning::TIMEZONE),
+        );
     }
 
     /**

--- a/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
@@ -6,13 +6,13 @@ namespace AppBundle\Controller\Admin\Event\Session;
 
 use AppBundle\Event\AdminEventSelection;
 use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Planning;
 use AppBundle\Event\Model\Repository\RoomRepository;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Room;
 use AppBundle\Event\Model\Session\CalendarEvent;
 use AppBundle\Event\Model\Session\CalendarResource;
 use AppBundle\Event\Model\TalkAggregate;
-use DateTimeInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -38,6 +38,7 @@ final class IndexAction extends AbstractController
                 'events' => $this->calendarEvents($sessions),
                 'resources' => $this->calendarResources($event),
             ],
+            'timezone' => Planning::TIMEZONE,
         ]);
     }
 
@@ -69,6 +70,8 @@ final class IndexAction extends AbstractController
      */
     private function calendarEvents(array $sessions): array
     {
+        $timezone = new \DateTimeZone(Planning::TIMEZONE);
+
         $events = [];
         foreach ($sessions as $session) {
             if (!$session->planning || !$session->room || !$session->planning->getStart() || !$session->planning->getEnd()) {
@@ -77,12 +80,23 @@ final class IndexAction extends AbstractController
             $events[] = new CalendarEvent(
                 $session->planning->getId(),
                 $session->talk->getTitle(),
-                $session->planning->getStart()->format(DateTimeInterface::ATOM),
-                $session->planning->getEnd()->format(DateTimeInterface::ATOM),
+                $this->formatForCalendar($session->planning->getStart(), $timezone),
+                $this->formatForCalendar($session->planning->getEnd(), $timezone),
                 $session->room->getId(),
             );
         }
 
         return $events;
+    }
+
+    /**
+     * Le calendrier ne gère pas les timezones : il interprète la date reçue telle
+     * qu'elle est écrite. On lui transmet donc l'heure locale de l'événement, sans décalage.
+     */
+    private function formatForCalendar(\DateTimeInterface $date, \DateTimeZone $timezone): string
+    {
+        return \DateTimeImmutable::createFromInterface($date)
+            ->setTimezone($timezone)
+            ->format('Y-m-d\TH:i:s');
     }
 }

--- a/sources/AppBundle/Event/Model/Planning.php
+++ b/sources/AppBundle/Event/Model/Planning.php
@@ -11,6 +11,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Planning implements NotifyPropertyInterface
 {
     use NotifyProperty;
+
+    /**
+     * Les horaires sont stockés en base sous forme de timestamp, donc absolus.
+     * Les événements de l'AFUP se déroulant en France, ils sont saisis et affichés
+     * dans cette timezone, quelle que soit celle du serveur ou du navigateur.
+     */
+    public const string TIMEZONE = 'Europe/Paris';
+
     private ?int $id = null;
 
     #[Assert\NotBlank]

--- a/templates/event/session/index.html.twig
+++ b/templates/event/session/index.html.twig
@@ -10,6 +10,7 @@
 
             EventCalendar.create(document.getElementById('ec'), {
                 view: 'resourceTimeGridDay',
+                timeZone: 'Europe/Paris',
                 slotDuration: '00:05',
                 slotMinTime: '09:00',
                 slotMaxTime: '19:00',

--- a/templates/event/session/index.html.twig
+++ b/templates/event/session/index.html.twig
@@ -27,14 +27,23 @@
         const $el = $('#status');
         $el.hide();
 
+        // Le calendrier travaille sans timezone : on renvoie l'heure telle qu'elle est
+        // affichée, sans la convertir en UTC comme le ferait JSON.stringify sur une Date.
+        function toLocalDateTime(date) {
+            const pad = (value) => String(value).padStart(2, '0');
+
+            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+                + `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+        }
+
         async function updateEvent(info) {
 
             const url = `/admin/event/sessions/${info.event.id}.json`;
             const response = await fetch(url, {
               method: "POST",
               body: JSON.stringify({
-                start: info.event.start,
-                end: info.event.end,
+                start: toLocalDateTime(info.event.start),
+                end: toLocalDateTime(info.event.end),
                 roomId: info.event.resourceIds[0],
               }),
             });
@@ -106,8 +115,8 @@
                             <br/>
 
                             {% if session.planning %}
-                                <em>{{ session.planning.start|date("d/m/Y") }}</em> /
-                                {{ session.planning.start|date("H:i") }} - {{ session.planning.end|date("H:i") }} / {{ session.room ? session.room.name }}
+                                <em>{{ session.planning.start|date("d/m/Y", timezone) }}</em> /
+                                {{ session.planning.start|date("H:i", timezone) }} - {{ session.planning.end|date("H:i", timezone) }} / {{ session.room ? session.room.name }}
                             {% else %}
                                 <span class="ui yellow label">non planifié</span>
                             {% endif %}

--- a/templates/event/session/index.html.twig
+++ b/templates/event/session/index.html.twig
@@ -27,13 +27,14 @@
         const $el = $('#status');
         $el.hide();
 
-        // Le calendrier travaille sans timezone : on renvoie l'heure telle qu'elle est
-        // affichée, sans la convertir en UTC comme le ferait JSON.stringify sur une Date.
+        // event-calendar 4.7.1 construit ses Date en UTC (Date.UTC(...)) à partir des
+        // chiffres affichés sur la grille : il faut donc relire ces chiffres via les
+        // getters UTC, pas les getters locaux qui dépendent de la timezone du navigateur.
         function toLocalDateTime(date) {
             const pad = (value) => String(value).padStart(2, '0');
 
-            return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
-                + `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+            return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`
+                + `T${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
         }
 
         async function updateEvent(info) {

--- a/templates/event/session/index.html.twig
+++ b/templates/event/session/index.html.twig
@@ -10,7 +10,6 @@
 
             EventCalendar.create(document.getElementById('ec'), {
                 view: 'resourceTimeGridDay',
-                timeZone: 'Europe/Paris',
                 slotDuration: '00:05',
                 slotMinTime: '09:00',
                 slotMaxTime: '19:00',


### PR DESCRIPTION
Par défaut le widget utilise la timezone de la personne qui fait les modification (cf. [slack](https://afup.slack.com/archives/C03L64VE9/p1787251212884459))