### PR TITLE
Ajout de la possibilité d'avoir une image de couverture pour un article

### DIFF
--- a/db/migrations/20260820120000_add_image_to_articles.php
+++ b/db/migrations/20260820120000_add_image_to_articles.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class AddImageToArticles extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this
+            ->table('afup_site_article')
+            ->addColumn('image', 'string', [
+                'limit' => 255,
+                'null' => true,
+                'default' => null,
+                'after' => 'contenu',
+            ])
+            ->save()
+        ;
+    }
+}

--- a/sources/AppBundle/Controller/Admin/Site/Article/AddArticleAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/Article/AddArticleAction.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Site\Article;
 
 use AppBundle\AuditLog\Audit;
+use AppBundle\Site\ArticleImageStorage;
 use AppBundle\Site\Entity\Article;
 use AppBundle\Site\Entity\Repository\ArticleRepository;
 use AppBundle\Site\Form\ArticleType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\String\Slugger\AsciiSlugger;
@@ -18,6 +20,7 @@ final class AddArticleAction extends AbstractController
     public function __construct(
         private readonly ArticleRepository $articleRepository,
         private readonly Audit $audit,
+        private readonly ArticleImageStorage $articleImageStorage,
     ) {}
 
     public function __invoke(Request $request): Response
@@ -32,6 +35,11 @@ final class AddArticleAction extends AbstractController
                 $article->raccourci = (new AsciiSlugger())->slug($article->titre)->lower()->toString();
             }
 
+            $uploadedImage = $form->get('image')->getData();
+            if ($uploadedImage instanceof UploadedFile) {
+                $article->image = $this->articleImageStorage->store($uploadedImage, $article);
+            }
+
             $this->articleRepository->save($article);
             $this->audit->log('Ajout de l\'article ' . $article->titre);
             $this->addFlash('notice', 'L\'article ' . $article->titre . ' a été ajouté');
@@ -43,6 +51,7 @@ final class AddArticleAction extends AbstractController
             'formTitle' => 'Ajouter un article',
             'submitLabel' => 'Ajouter',
             'article' => $article,
+            'imageUrl' => null,
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Admin/Site/Article/DeleteArticleAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/Article/DeleteArticleAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Site\Article;
 
 use AppBundle\AuditLog\Audit;
+use AppBundle\Site\ArticleImageStorage;
 use AppBundle\Site\Entity\Repository\ArticleRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -17,6 +18,7 @@ class DeleteArticleAction extends AbstractController
         private readonly ArticleRepository $articleRepository,
         private readonly CsrfTokenManagerInterface $csrfTokenManager,
         private readonly Audit $audit,
+        private readonly ArticleImageStorage $articleImageStorage,
     ) {}
 
     public function __invoke(int $id, string $token): RedirectResponse
@@ -31,6 +33,7 @@ class DeleteArticleAction extends AbstractController
             throw $this->createNotFoundException();
         }
 
+        $this->articleImageStorage->remove($article);
         $this->articleRepository->delete($article);
         $this->audit->log('Suppression de l\'article ' . $article->titre);
         $this->addFlash('notice', 'L\'article ' . $article->titre . ' a été supprimé');

--- a/sources/AppBundle/Controller/Admin/Site/Article/EditArticleAction.php
+++ b/sources/AppBundle/Controller/Admin/Site/Article/EditArticleAction.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace AppBundle\Controller\Admin\Site\Article;
 
 use AppBundle\AuditLog\Audit;
+use AppBundle\Site\ArticleImageStorage;
 use AppBundle\Site\Entity\Repository\ArticleRepository;
 use AppBundle\Site\Form\ArticleType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -16,6 +18,7 @@ final class EditArticleAction extends AbstractController
     public function __construct(
         private readonly ArticleRepository $articleRepository,
         private readonly Audit $audit,
+        private readonly ArticleImageStorage $articleImageStorage,
     ) {}
 
     public function __invoke(int $id, Request $request): Response
@@ -25,9 +28,17 @@ final class EditArticleAction extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $form = $this->createForm(ArticleType::class, $article, ['is_new' => false]);
+        $form = $this->createForm(ArticleType::class, $article);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            $uploadedImage = $form->get('image')->getData();
+            if ($uploadedImage instanceof UploadedFile) {
+                $article->image = $this->articleImageStorage->store($uploadedImage, $article);
+            } elseif ($article->image && $form->get('supprimerImage')->getData() === true) {
+                $this->articleImageStorage->remove($article);
+                $article->image = null;
+            }
+
             $this->articleRepository->save($article);
             $this->audit->log('Modification de l\'article ' . $article->titre);
             $this->addFlash('notice', 'L\'article ' . $article->titre . ' a été modifié');
@@ -39,6 +50,7 @@ final class EditArticleAction extends AbstractController
             'article' => $article,
             'formTitle' => 'Modifier un article',
             'submitLabel' => 'Modifier',
+            'imageUrl' => $this->articleImageStorage->getUrl($article),
         ]);
     }
 }

--- a/sources/AppBundle/Controller/Website/News/DisplayAction.php
+++ b/sources/AppBundle/Controller/Website/News/DisplayAction.php
@@ -6,6 +6,7 @@ namespace AppBundle\Controller\Website\News;
 
 use AppBundle\Event\Model\Event;
 use AppBundle\Event\Model\Repository\EventRepository;
+use AppBundle\Site\ArticleImageStorage;
 use AppBundle\Site\Entity\Article;
 use AppBundle\Site\Entity\Repository\ArticleRepository;
 use AppBundle\Site\Enum\ArticleEtat;
@@ -21,6 +22,7 @@ final class DisplayAction extends AbstractController
         private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly EventRepository $eventRepository,
         private readonly ArticleRepository $articleRepository,
+        private readonly ArticleImageStorage $articleImageStorage,
     ) {}
 
     public function __invoke(string $code): Response
@@ -39,6 +41,7 @@ final class DisplayAction extends AbstractController
             'previous' => $this->articleRepository->findPrevious($article),
             'next' => $this->articleRepository->findNext($article),
             'related_event' => $this->getRelatedEvent($article),
+            'image_url' => $this->articleImageStorage->getUrl($article),
         ]);
     }
 

--- a/sources/AppBundle/Site/ArticleImageStorage.php
+++ b/sources/AppBundle/Site/ArticleImageStorage.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Site;
+
+use AppBundle\Site\Entity\Article;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\String\Slugger\AsciiSlugger;
+
+final readonly class ArticleImageStorage
+{
+    public const string PUBLIC_PATH = '/uploads/articles/';
+
+    private Filesystem $filesystem;
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%/htdocs/uploads/articles')]
+        private string $basePath,
+    ) {
+        $this->filesystem = new Filesystem();
+    }
+
+    public function store(UploadedFile $file, Article $article): string
+    {
+        // On supprime d'abord l'image précédente si elle existe
+        $this->remove($article);
+
+        $this->createDirectory();
+
+        $fileName = $this->generateFileName($file, $article);
+        $file->move($this->basePath, $fileName);
+
+        return $fileName;
+    }
+
+    public function remove(Article $article): void
+    {
+        if ($article->image === null) {
+            return;
+        }
+
+        $this->filesystem->remove($this->basePath . '/' . $article->image);
+    }
+
+    public function getUrl(Article $article): ?string
+    {
+        if ($article->image === null) {
+            return null;
+        }
+
+        if (!$this->filesystem->exists($this->basePath . '/' . $article->image)) {
+            return null;
+        }
+
+        return self::PUBLIC_PATH . $article->image;
+    }
+
+    private function generateFileName(UploadedFile $file, Article $article): string
+    {
+        $slug = (new AsciiSlugger())->slug((string) $article->titre)
+            ->lower()
+            ->truncate(60)
+            ->trim('-')
+            ->toString();
+
+        if ($slug === '') {
+            $slug = 'article';
+        }
+
+        // Pour faire sauter le cache quand l'image est modifiée
+        $randomString = bin2hex(random_bytes(4));
+
+        return sprintf('%s-%s.%s', $slug, $randomString, $file->guessExtension() ?? 'jpg',);
+    }
+
+    private function createDirectory(): void
+    {
+        try {
+            $this->filesystem->mkdir($this->basePath, 0755);
+        } catch (IOException $exception) {
+            throw new FileException('Could not create directory for storage', 0, $exception);
+        }
+    }
+}

--- a/sources/AppBundle/Site/Entity/Article.php
+++ b/sources/AppBundle/Site/Entity/Article.php
@@ -34,6 +34,9 @@ class Article
     #[ORM\Column(type: 'text', nullable: true)]
     public ?string $contenu = null;
 
+    #[ORM\Column(length: 255, nullable: true)]
+    public ?string $image = null;
+
     #[ORM\Column(nullable: true, enumType: ArticleTheme::class)]
     public ?ArticleTheme $theme = null;
 

--- a/sources/AppBundle/Site/Form/ArticleType.php
+++ b/sources/AppBundle/Site/Form/ArticleType.php
@@ -5,19 +5,21 @@ declare(strict_types=1);
 namespace AppBundle\Site\Form;
 
 use AppBundle\Event\Model\Repository\EventRepository;
+use AppBundle\Site\Entity\Article;
 use AppBundle\Site\Entity\Rubrique;
 use AppBundle\Site\Enum\ArticleEtat;
 use AppBundle\Site\Enum\ArticleTheme;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToTimestampTransformer;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\EnumType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\EnumType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints as Assert;
 
 class ArticleType extends AbstractType
@@ -28,6 +30,11 @@ class ArticleType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
+        $article = $builder->getData();
+        if (!$article instanceof Article) {
+            throw new \LogicException();
+        }
+
         $positions = [];
         for ($i = self::POSITIONS_RUBRIQUES; $i >= -(self::POSITIONS_RUBRIQUES); $i--) {
             $positions[$i] = $i;
@@ -79,6 +86,22 @@ class ArticleType extends AbstractType
                     new Assert\Type('string'),
                 ],
             ])
+            ->add('image', FileType::class, [
+                'label' => 'Image de couverture',
+                'required' => false,
+                'mapped' => false,
+                'data_class' => null,
+                'help' => 'JPEG, PNG, WebP ou GIF — 2 Mo maximum',
+                'attr' => [
+                    'accept' => 'image/jpeg,image/png,image/webp,image/gif',
+                ],
+                'constraints' => [
+                    new Assert\Image(
+                        maxSize: '2M',
+                        mimeTypes: ['image/jpeg', 'image/png', 'image/webp', 'image/gif'],
+                    ),
+                ],
+            ])
             ->add('rubrique', EntityType::class, [
                 'required' => true,
                 'label' => 'Rubrique',
@@ -128,12 +151,11 @@ class ArticleType extends AbstractType
                 'constraints' => [
                     new Assert\Type("integer"),
                 ],
-            ])
-        ;
+            ]);
         $builder->get('datePublication')->addModelTransformer(new DateTimeToTimestampTransformer());
 
         $raccourciOption = [
-            'required' => $options['is_new'] === false,
+            'required' => $article->id !== null,
             'label' => 'Raccourci',
             'attr' => [
                 'maxlength' => 255,
@@ -146,19 +168,20 @@ class ArticleType extends AbstractType
             ],
         ];
 
-        if ($options['is_new'] === true) {
+        if ($article->id === null) {
             $raccourciOption['help'] = 'Si ce champ est vide, la valeur sera générée automatiquement';
         } else {
             $raccourciOption['constraints'][] = new Assert\NotBlank();
         }
 
         $builder->add('raccourci', TextType::class, $raccourciOption);
-    }
 
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'is_new' => true,
-        ]);
+        if ($article->image !== null) {
+            $builder->add('supprimerImage', CheckboxType::class, [
+                'label' => 'Supprimer l\'image de couverture',
+                'required' => false,
+                'mapped' => false,
+            ]);
+        }
     }
 }

--- a/templates/admin/site/article_form.html.twig
+++ b/templates/admin/site/article_form.html.twig
@@ -28,6 +28,20 @@
                     {{ form_row(form.titre) }}
                     {{ form_row(form.chapeau) }}
                     {{ form_row(form.contenu) }}
+                    {{ form_row(form.image) }}
+                    <div class="inline fields ui grid">
+                        <div class="three wide column"></div>
+                        <div class="field nine wide column">
+                            <img id="article-image-preview"
+                                 src="{{ imageUrl|default('') }}"
+                                 data-initial-src="{{ imageUrl|default('') }}"
+                                 alt="Image de couverture"
+                                 style="max-width: 320px;{% if imageUrl is null %} display: none;{% endif %}">
+                        </div>
+                    </div>
+                    {% if imageUrl is not null %}
+                        {{ form_row(form.supprimerImage) }}
+                    {% endif %}
                 </div>
             </div>
         </div>
@@ -68,4 +82,37 @@
 
     {{ form_end(form) }}
 
+{% endblock %}
+
+{% block javascript %}
+    {{ parent() }}
+    <script>
+        // Aperçu de l'image de couverture sélectionnée, avant envoi du formulaire.
+        (function () {
+            const input = document.getElementById('{{ form.image.vars.id }}');
+            const preview = document.getElementById('article-image-preview');
+            if (!input || !preview) {
+                return;
+            }
+
+            let objectUrl = null;
+            input.addEventListener('change', function () {
+                if (objectUrl) {
+                    URL.revokeObjectURL(objectUrl);
+                    objectUrl = null;
+                }
+
+                const file = input.files && input.files[0];
+                if (!file) {
+                    preview.src = preview.dataset.initialSrc;
+                    preview.style.display = preview.dataset.initialSrc ? '' : 'none';
+                    return;
+                }
+
+                objectUrl = URL.createObjectURL(file);
+                preview.src = objectUrl;
+                preview.style.display = '';
+            });
+        })();
+    </script>
 {% endblock %}

--- a/templates/site/news/display.html.twig
+++ b/templates/site/news/display.html.twig
@@ -1,7 +1,7 @@
 {% extends 'layouts/site.html.twig' %}
 
 {% block metas %}
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="{{ image_url ? 'summary_large_image' : 'summary' }}">
     <meta name="twitter:title" content="AFUP - {{ article.titre }}">
     <meta name="twitter:description" content="{{ article.resumeTexte }}">
     <meta name="twitter:domain" content="afup.org">
@@ -10,6 +10,10 @@
     <meta property="og:url" content="{{ url('news_display', {code: article.slug }) }}" />
     <meta property="og:description" content="{{ article.resumeTexte }}" />
     <meta property="og:site_name" content="AFUP" />
+    {% if image_url %}
+        <meta name="twitter:image" content="{{ absolute_url(asset(image_url)) }}" />
+        <meta property="og:image" content="{{ absolute_url(asset(image_url)) }}" />
+    {% endif %}
 {% endblock %}
 
 {% block title %}{{ article.titre }} - AFUP{% endblock %}
@@ -62,6 +66,12 @@
                 </header>
 
                 <main class="pt-5">
+                    {% if image_url %}
+                        <figure class="mb-8">
+                            <img src="{{ asset(image_url) }}" alt="Illustration de l'article {{ article.titre }}" class="w-full rounded-lg" loading="lazy" />
+                        </figure>
+                    {% endif %}
+
                     {% if article.chapeau %}
                         <div class="prose max-w-none border-l-8 border-afup-300 bg-afup-100 px-3 py-2 sm:text-justify rounded-lg">
                             {{ article.chapeau|markdown_to_html }}

--- a/tests/behat/features/Admin/Site/AdminSiteArticles.feature
+++ b/tests/behat/features/Admin/Site/AdminSiteArticles.feature
@@ -144,3 +144,57 @@ Feature: Administration - Partie Site
     # vérification de l'article sur le site publique
     When I go to "/news/17-mon-super-123-article"
     Then I should see "Mon super 123 article !"
+
+  @reloadDbWithTestData
+  Scenario: Ajout puis suppression de l'image de couverture d'un article
+    Given I am logged in as admin and on the Administration
+    And I follow "Articles"
+    Then I should see "Liste des articles"
+
+    # ajout d'un article avec une image de couverture
+    When I follow "Ajouter"
+    Then I should see "Ajouter un article"
+    And I fill in "article[titre]" with "Un article illustré"
+    And I fill in "article[contenu]" with "Le contenu de l'article illustré"
+    And I fill in "article[raccourci]" with "url-article-illustre"
+    And I select "Actualités" from "article[rubrique]"
+    And I select "9" from "article[position]"
+    And I select "En ligne" from "article[etat]"
+    And I attach the file "avatar1.png" to "article[image]"
+    And I press "Ajouter"
+    Then I should see "Liste des articles"
+
+    # l'image est affichée sur la page publique
+    When I go to "/news/17-url-article-illustre"
+    Then I should see "Un article illustré"
+    And I should see a "article main figure img" element
+
+    # l'image existante est affichée dans le formulaire d'administration
+    When I follow "Administration"
+    And I follow "Articles"
+    Then I follow "modifier_17"
+    And I should see "Modifier un article"
+    And I should see "Supprimer l'image de couverture"
+    And I should see a "#article-image-preview" element
+
+    # Modifier l'article sans changer l'image la conserve
+    And I press "Modifier"
+    Then I should see "Liste des articles"
+    Then I follow "modifier_17"
+    And I should see "Modifier un article"
+    And I should see "Supprimer l'image de couverture"
+    And I should see a "#article-image-preview" element
+
+    # suppression de l'image de couverture
+    When I check "article[supprimerImage]"
+    And I press "Modifier"
+    Then I should see "Liste des articles"
+    When I follow "Articles"
+    And I follow "modifier_17"
+    And I should see "Modifier un article"
+    Then I should not see "Supprimer l'image de couverture"
+    And I should not see a "#article_supprimerImage" element
+
+    # l'image n'est plus affichée sur la page publique
+    When I go to "/news/17-url-article-illustre"
+    Then I should not see a "article main figure img" element


### PR DESCRIPTION
Cela fait suite à une discussion avec Amélie où elle m'a dit que la feature lui servirait.

## Dans le formulaire de l'admin
<img width="818" height="302" alt="image" src="https://github.com/user-attachments/assets/769e5554-6838-42a3-ad3a-cd8ac892d0d4" />

## Rendu en front
<img width="996" height="925" alt="image" src="https://github.com/user-attachments/assets/2eab5003-5800-48a3-a4ae-a68785679c69" />
