### PR TITLE
Activation du téléchargement automatique des icônes

### DIFF
--- a/config/packages/ux_icons.yaml
+++ b/config/packages/ux_icons.yaml
@@ -1,0 +1,4 @@
+when@dev:
+    ux_icons:
+        iconify:
+            auto_lock: true


### PR DESCRIPTION
Par défaut, les icônes sont téléchargées à la volée par Symfony si elles ne sont présentes en local, même en prod. Les récupérer en local évite cette dépendance et ces appels http. On évite aussi d'avoir des icônes qui peuvent changer avec le temps.

https://symfony.com/bundles/ux-icons/current/index.html#imported-icons