### PR TITLE
Bannière difficulté: lettre ouverte

### DIFF
--- a/templates/layouts/root.html.twig
+++ b/templates/layouts/root.html.twig
@@ -58,8 +58,8 @@
     </div>
 
     <div class="bg-ruby-400 text-white text-center p-1 text-lg font-bold">
-        L'AFUP est en difficulté,
-        <a href="/news/1256-des-nouvelles-situation-afup-mai2026" tabindex="-1" class="underline cursor-pointer">découvrez comment aider l'association</a>.
+        L'écosystème est en difficulté,
+        <a href="https://lettreouverte.afup.org" tabindex="-1" class="underline cursor-pointer">consultez la lettre ouverte</a>.
     </div>
 
     {% block root %}{% endblock %}

--- a/templates/site/base.html.twig
+++ b/templates/site/base.html.twig
@@ -23,7 +23,7 @@
 
     <div style="background-color: #ed0678;color: white;text-align: center;padding: 3px 0;font-size: 1.2em;font-weight: bold;">
         L'écosystème est en difficulté,
-        <a href="https://lettreouverte.afup.org" tabindex="-1" class="underline cursor-pointer">consultez la lettre ouverte</a>.
+        <a href="https://lettreouverte.afup.org" tabindex="-1" style="color: white;">consultez la lettre ouverte</a>.
     </div>
 
     <header>

--- a/templates/site/base.html.twig
+++ b/templates/site/base.html.twig
@@ -22,8 +22,8 @@
     {% autoescape false %}
 
     <div style="background-color: #ed0678;color: white;text-align: center;padding: 3px 0;font-size: 1.2em;font-weight: bold;">
-        L'AFUP est en difficulté,
-        <a href="/news/1256-des-nouvelles-situation-afup-mai2026" tabindex="-1" style="color: white;">découvrez comment aider l'association</a>.
+        L'écosystème est en difficulté,
+        <a href="https://lettreouverte.afup.org" tabindex="-1" class="underline cursor-pointer">consultez la lettre ouverte</a>.
     </div>
 
     <header>


### PR DESCRIPTION
Lors de la publication de la lettre ouverte le 8 septembre on prévoit de basculer la bannière actuellement en oeuvre sur afup.org par une version qui renvoie vers la lettre ouverte.

On mergera donc le 08/09 au matin.