### PR TITLE
Réduction de la taille du texte sur mobile

### DIFF
--- a/templates/site/home.html.twig
+++ b/templates/site/home.html.twig
@@ -26,11 +26,11 @@
 {% block content %}
 <div class="home-banner bg-afup-800 bg-cover bg-center">
     <div class="container mx-auto flex flex-col gap-5 p-4 sm:py-15 sm:px-0 text-white">
-        <h1 class="font-titre text-6xl">
+        <h1 class="font-titre text-2xl sm:text-6xl text-wrap">
             AFUP : Association Française<br/>des Utilisateurs de PHP
         </h1>
 
-        <p class="text-xl">
+        <p class="text-base sm:text-xl">
             Apéros, rendez-vous et cycle de conférences, l'AFUP est au cœur de la communauté PHP depuis 2000.<br/>
             L'AFUP vise à favoriser l'échange d'expertises et la diffusion des connaissances auprès de la communauté.
         </p>


### PR DESCRIPTION
Pour éviter que ça déborde du bloc et aussi que ça prenne moins de place verticale.