### PR TITLE
Nettoyage des classes Tailwind redondantes avec les valeurs par défaut

### DIFF
--- a/templates/admin/association/membership/register.html.twig
+++ b/templates/admin/association/membership/register.html.twig
@@ -5,7 +5,7 @@
 
 {% block content %}
     <div class="container mx-auto flex flex-col items-center px-4 my-5 gap-4">
-        <h1 class="font-titre font-normal text-5xl text-afup-800 text-center">{{ "Formulaire d'inscription à l'AFUP"|trans }}</h1>
+        <h1 class="font-titre text-5xl text-afup-800 text-center">{{ "Formulaire d'inscription à l'AFUP"|trans }}</h1>
 
         {{ form_start(form, {attr: {class: 'self-stretch'}}) }}
 
@@ -46,8 +46,8 @@
 
 
             <div class="flex flex-col-reverse sm:flex-row items-center justify-between gap-4 border-t-2 border-neutre-300 pt-5">
-                <p class="font-sans font-normal text-sm text-neutre-700">{{ 'Vous avez un compte ?'|trans }} <a href="{{ path('app_login') }}" class="text-afup-500 underline hover:no-underline">{{ 'Se connecter'|trans }}</a></p>
-                {{ form_widget(form.userCommonInfo.save, {attr: { "class": "flex flex-row justify-center items-center py-3 px-8 gap-2 bg-ruby-500 rounded-lg font-sans font-semibold text-base text-white text-center"}}) }}
+                <p class="text-sm text-neutre-700">{{ 'Vous avez un compte ?'|trans }} <a href="{{ path('app_login') }}" class="text-afup-500 underline hover:no-underline">{{ 'Se connecter'|trans }}</a></p>
+                {{ form_widget(form.userCommonInfo.save, {attr: { "class": "flex flex-row justify-center items-center py-3 px-8 gap-2 bg-ruby-500 rounded-lg font-semibold text-white text-center"}}) }}
             </div>
 
         </twig:Card>

--- a/templates/components/Benefit.html.twig
+++ b/templates/components/Benefit.html.twig
@@ -2,7 +2,7 @@
 {# @block content Le libellé de l'avantage #}
 {%- props tone = 'default' -%}
 {%- set style = html_cva(
-    base: "flex items-start gap-3 font-sans font-normal text-base",
+    base: "flex items-start gap-3 text-base",
     variants: {
         tone: {
             default: 'text-neutre-700',

--- a/templates/components/SectionTitle.html.twig
+++ b/templates/components/SectionTitle.html.twig
@@ -1,6 +1,6 @@
 {# @block content Le libellé de la section #}
 {%- set style = html_cva(
-    base: "font-sans font-semibold text-base text-afup-800 border-b border-neutre-300 pb-2 [&_a]:hover:text-afup-500 [&_span]:font-normal [&_span]:text-sm [&_span]:text-neutre-400",
+    base: "font-semibold text-base text-afup-800 border-b border-neutre-300 pb-2 [&_a]:hover:text-afup-500 [&_span]:font-normal [&_span]:text-sm [&_span]:text-neutre-400",
 ) -%}
 <h2 class="{{ style.apply({}, attributes.render('class'))|tailwind_merge }}" {{ attributes }}>
     {%- block content %}{% endblock -%}

--- a/templates/site/become_member.html.twig
+++ b/templates/site/become_member.html.twig
@@ -20,8 +20,8 @@
        Faute de photo d'illustration en dépôt, le voile bleu nuit est posé seul. #}
     <div class="bg-gradient-to-br from-afup-900 via-afup-800 to-afup-700">
         <div class="container mx-auto px-4 py-12 sm:px-28 sm:py-16 flex flex-col gap-4">
-            <h1 class="font-titre font-normal text-3xl sm:text-4xl leading-tight text-white">Devenir membre de l'AFUP</h1>
-            <p class="font-sans font-normal text-base text-white/90 max-w-3xl">
+            <h1 class="font-titre text-3xl sm:text-4xl leading-tight text-white">Devenir membre de l'AFUP</h1>
+            <p class="text-white/90 max-w-3xl">
                 Adhérer à l'AFUP, c'est rejoindre la communauté PHP francophone et soutenir concrètement
                 les activités que l'association mène tout au long de l'année. Deux formules existent :
                 une adhésion particulier et une adhésion entreprise.
@@ -34,7 +34,7 @@
             <twig:SectionTitle>Pourquoi adhérer ?</twig:SectionTitle>
 
             <div class="relative isolate flex flex-col gap-8 p-8 sm:p-12 bg-gradient-to-br from-afup-700 to-afup-300 rounded-2xl">
-                <h3 class="font-titre font-normal text-2xl sm:text-3xl leading-snug text-white">En adhérant, vous soutenez</h3>
+                <h3 class="font-titre text-2xl sm:text-3xl leading-snug text-white">En adhérant, vous soutenez</h3>
 
                 {# `columns` plutôt qu'une grille : les puces s'écoulent indépendamment, sinon une
                    puce sur plusieurs lignes ferait grandir toute la rangée et casserait le rythme. #}
@@ -56,8 +56,8 @@
                          class="size-24 shrink-0" />
                     <h3 class="font-titre font-bold text-2xl text-afup-800">Particulier</h3>
                     <p class="flex flex-col gap-1">
-                        <span class="font-titre font-normal text-3xl text-afup-800">{{ membership_fee_natural_person }} €</span>
-                        <span class="font-sans font-normal text-sm text-neutre-400">TTC / an / pour une personne</span>
+                        <span class="font-titre text-3xl text-afup-800">{{ membership_fee_natural_person }} €</span>
+                        <span class="text-sm text-neutre-400">TTC / an / pour une personne</span>
                     </p>
                     <ul class="flex flex-col gap-3">
                         <twig:Benefit>Soutien des activités de l'association</twig:Benefit>
@@ -67,7 +67,7 @@
                     </ul>
                     {# `mt-auto` sur la fine print : elle vient se coller au séparateur, juste
                        au-dessus du CTA qu'elle qualifie, et le bouton reste aligné d'une carte à l'autre. #}
-                    <p class="mt-auto font-sans font-normal text-sm text-neutre-400">
+                    <p class="mt-auto text-sm text-neutre-400">
                         L'inscription se fait directement sur la page dédiée. Elle coûte {{ membership_fee_natural_person }} euros TTC pour 12 mois.
                     </p>
                     <div class="border-t-2 border-neutre-300 pt-5">
@@ -80,8 +80,8 @@
                          class="size-24 shrink-0" />
                     <h3 class="font-titre font-bold text-2xl text-afup-800">Entreprise</h3>
                     <p class="flex flex-col gap-1">
-                        <span class="font-titre font-normal text-3xl text-afup-800">{{ membership_fee_legal_entity }} €</span>
-                        <span class="font-sans font-normal text-sm text-neutre-400">HT / an / par tranche de 3 employé(e)s</span>
+                        <span class="font-titre text-3xl text-afup-800">{{ membership_fee_legal_entity }} €</span>
+                        <span class="text-sm text-neutre-400">HT / an / par tranche de 3 employé(e)s</span>
                     </p>
                     <ul class="flex flex-col gap-3">
                         <twig:Benefit>Plus grand soutien des activités de l'association</twig:Benefit>
@@ -89,7 +89,7 @@
                         <twig:Benefit>Possibilité de changer les personnes associées à la cotisation à n'importe quel moment</twig:Benefit>
                         <twig:Benefit>Une page dédiée à votre entreprise dans notre annuaire des sociétés adhérentes sur le site de l'AFUP afin de montrer votre engagement et promouvoir vos offres</twig:Benefit>
                     </ul>
-                    <p class="mt-auto font-sans font-normal text-sm text-neutre-400">
+                    <p class="mt-auto text-sm text-neutre-400">
                         Une préinscription est à réaliser en suivant le lien ci-dessus. L'équipe trésorerie vous recontactera pour finaliser ensuite l'inscription.
                         Le montant de la cotisation est de {{ membership_fee_legal_entity }} euros HT par tranche de 3 employés pour 12 mois.
                     </p>
@@ -106,16 +106,16 @@
 
             <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">Modes de paiement</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">Modes de paiement</h3>
+                    <p class="text-sm text-neutre-700">
                         Le paiement d'une adhésion professionnelle peut se faire soit par carte bancaire, soit par virement.
                         Pour les particuliers, seul le paiement par carte bancaire est disponible.
                     </p>
                 </twig:Card>
 
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">Règlement intérieur et code de conduite</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">Règlement intérieur et code de conduite</h3>
+                    <p class="text-sm text-neutre-700">
                         L'adhésion nécessite l'acceptation pleine et sans réserve du
                         <a href="{{ path('cms_page_display', {code: '21-reglement-interieur'}) }}" class="text-afup-500 underline hover:no-underline">règlement intérieur</a>
                         et du
@@ -124,8 +124,8 @@
                 </twig:Card>
 
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">Une question ?</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">Une question ?</h3>
+                    <p class="text-sm text-neutre-700">
                         Pour toutes questions, notre
                         <a href="{{ path('cms_page_display', {code: '1012-faq'}) }}" title="FAQ" class="text-afup-500 underline hover:no-underline">FAQ</a>
                         est disponible.

--- a/templates/site/company_membership/adhesion_entreprise.html.twig
+++ b/templates/site/company_membership/adhesion_entreprise.html.twig
@@ -5,8 +5,8 @@
 
 {% block content %}
     <div class="container mx-auto flex flex-col items-center px-4 my-5 gap-4">
-        <h1 class="font-titre font-normal text-5xl text-afup-800 text-center">{{ "Adhésion entreprise à l'AFUP"|trans }}</h1>
-        <p class="font-sans font-normal text-base text-neutre-700 text-center max-w-2xl">
+        <h1 class="font-titre text-5xl text-afup-800 text-center">{{ "Adhésion entreprise à l'AFUP"|trans }}</h1>
+        <p class="text-neutre-700 text-center max-w-2xl">
             {{ 'Ce formulaire est réservé aux entreprises. Vous êtes un particulier ou un indépendant ?'|trans }}
             <a href="{{ path('member_membership') }}" class="text-afup-500 underline hover:no-underline">{{ "Retrouvez le formulaire d'adhésion dédié"|trans }}</a>
         </p>
@@ -39,7 +39,7 @@
             </twig:Card:Section>
 
             <twig:Card:Section title="{{ 'Membres rattachés'|trans }}">
-                <p class="font-sans font-normal text-sm text-neutre-700">{{ 'Chaque membre va recevoir une invitation lui permettant de créer son compte, rattaché à votre compte entreprise.'|trans }}</p>
+                <p class="text-sm text-neutre-700">{{ 'Chaque membre va recevoir une invitation lui permettant de créer son compte, rattaché à votre compte entreprise.'|trans }}</p>
                 {{ form_row(form.maxMembers) }}
                 <div id="company_member_invitations" class="flex flex-col divide-y divide-neutre-300" data-prototype="{{ form_widget(form.invitations.vars.prototype)|e('html_attr') }}">
                     {% for invitation in form.invitations %}
@@ -57,41 +57,41 @@
             </twig:Card:Section>
 
             <div class="flex flex-col-reverse sm:flex-row items-center justify-between gap-4 border-t-2 border-neutre-300 pt-5">
-                <p class="font-sans font-normal text-sm text-neutre-700">Si vous rencontrez le moindre problème, n'hésitez pas à contacter l'AFUP par email: bonjour (at) afup.org.</p>
-                {{ form_widget(form.save, {attr: { "class": "flex flex-row justify-center items-center py-3 px-8 gap-2 bg-ruby-500 rounded-lg font-sans font-semibold text-base text-white text-center"}}) }}
+                <p class="text-sm text-neutre-700">Si vous rencontrez le moindre problème, n'hésitez pas à contacter l'AFUP par email: bonjour (at) afup.org.</p>
+                {{ form_widget(form.save, {attr: { "class": "flex flex-row justify-center items-center py-3 px-8 gap-2 bg-ruby-500 rounded-lg font-semibold text-white text-center"}}) }}
             </div>
 
         </twig:Card>
         {{ form_end(form) }}
 
         <div class="w-full flex flex-col gap-5 my-5">
-            <h2 class="font-titre font-normal text-3xl text-afup-800 text-center">{{ 'Questions fréquentes'|trans }}</h2>
+            <h2 class="font-titre text-3xl text-afup-800 text-center">{{ 'Questions fréquentes'|trans }}</h2>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">{{ "Pourquoi adhérer à l'AFUP ?"|trans }}</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">{{ "Pourquoi adhérer à l'AFUP ?"|trans }}</h3>
+                    <p class="text-sm text-neutre-700">
                         {{ "Adhérer à l'AFUP pour une entreprise du monde PHP, c'est soutenir la communauté du langage sur lequel reposent ses outils, assurant une dynamique positive à l'écosystème. C'est également la possibilité pour vos devs de bénéficier des mailing lists réservées aux membres et faire partie d'un réseau de professionnels."|trans }}
                     </p>
                 </twig:Card>
 
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">{{ "Comment régler l'adhésion ?"|trans }}</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">{{ "Comment régler l'adhésion ?"|trans }}</h3>
+                    <p class="text-sm text-neutre-700">
                         {{ "L'adhésion peut être réglée par carte bancaire, virement ou chèque. Seule l'adhésion par carte bancaire permet une adhésion immédiate. Dans le cas des autres modes de paiement, l'adhésion est activée lors de la réception du paiement."|trans }}
                     </p>
                 </twig:Card>
 
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">{{ 'Comment gérer les membres rattachés à mon compte ?'|trans }}</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">{{ 'Comment gérer les membres rattachés à mon compte ?'|trans }}</h3>
+                    <p class="text-sm text-neutre-700">
                         {{ 'Vous devez toujours avoir au moins un membre ayant les droits de gestion sur votre compte. Ce dernier pourra gérer les membres rattachés, effectuer le règlement des adhésions et collecter les factures.'|trans }}
                     </p>
                 </twig:Card>
 
                 <twig:Card class="flex flex-col gap-2">
-                    <h3 class="font-sans font-semibold text-base text-afup-800">{{ 'Comment est faite la reconduction ?'|trans }}</h3>
-                    <p class="font-sans font-normal text-sm text-neutre-700">
+                    <h3 class="font-semibold text-afup-800">{{ 'Comment est faite la reconduction ?'|trans }}</h3>
+                    <p class="text-sm text-neutre-700">
                         {{ "L'adhésion à l'AFUP est réalisée pour un an à partir de l'enregistrement de votre cotisation. Un mois avant l'échéance, nous vous avertirons que votre adhésion arrive à expiration. Vous pourrez alors choisir de régler à nouveau votre adhésion ou la laisser expirer. 15 jours après expiration de votre adhésion, si celle-ci n'a pas été renouvelée, les comptes de vos membres seront désactivés, ils perdront alors tous les avantages de votre adhésion."|trans }}
                     </p>
                 </twig:Card>

--- a/templates/site/meetups/list.html.twig
+++ b/templates/site/meetups/list.html.twig
@@ -23,7 +23,7 @@
 
         <div class="flex flex-col gap-5">
             <h1 class="font-titre text-afup-800 text-2xl sm:text-4xl">Meetups des antennes</h1>
-            <p class="font-sans font-normal text-base text-neutre-700">
+            <p class="text-neutre-700">
                 Retrouvez ici tous les meetups des antennes de l'AFUP.
             </p>
 

--- a/templates/site/newsletter/postsubscribe.html.twig
+++ b/templates/site/newsletter/postsubscribe.html.twig
@@ -13,7 +13,7 @@
                 <twig:ux:icon name="mdi:email-fast-outline" class="size-12" />
             </span>
 
-            <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Merci de votre inscription&nbsp;!</h1>
+            <h1 class="font-titre text-4xl sm:text-5xl text-afup-800">Merci de votre inscription&nbsp;!</h1>
 
             <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
                 Pour qu'elle soit effective,
@@ -29,7 +29,7 @@
                 <twig:ux:icon name="mdi:alert-outline" class="size-12" />
             </span>
 
-            <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Inscription impossible</h1>
+            <h1 class="font-titre text-4xl sm:text-5xl text-afup-800">Inscription impossible</h1>
 
             <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
                 Une erreur est survenue lors de l'enregistrement de votre adresse.

--- a/templates/site/offices.html.twig
+++ b/templates/site/offices.html.twig
@@ -292,30 +292,30 @@
 <div class="container mx-auto px-4 pb-6 sm:px-28 sm:py-10 flex flex-col gap-5">
     <h1 class="font-titre text-afup-800 text-2xl sm:text-4xl">Les antennes</h1>
 
-    <p class="font-sans font-normal text-base text-neutre-700">Une quinzaine d'antennes locales, représentantes de l'AFUP en région, organise rencontres, meetups et apéros PHP
+    <p class="text-neutre-700">Une quinzaine d'antennes locales, représentantes de l'AFUP en région, organise rencontres, meetups et apéros PHP
         tout au long de l'année, tisse des liens au sein de la communauté  de développeuses et de développeurs et fait la promotion du PHP dans les entreprises partout en France.</p>
 </div>
 
 <div class="container mx-auto flex flex-col sm:flex-row items-stretch sm:h-160 px-4 pt-4 sm:p-6 gap-6 bg-white border border-neutre-200 rounded-2xl sm:shadow-[0_0.5rem_0.625rem_-0.375rem_rgba(0,0,0,0.1)]">
     <div class="flex-1 relative isolate flex flex-col items-start py-4 px-4 sm:py-12 sm:px-8 bg-gradient-to-b from-afup-700 to-afup-300 rounded-2xl">
         <div class="flex flex-col items-start gap-8 w-full h-full">
-            <p class="font-sans text-sm text-white py-1.5 px-3 gap-2 bg-white/20 rounded-full">Carte des antennes</p>
+            <p class="text-sm text-white py-1.5 px-3 gap-2 bg-white/20 rounded-full">Carte des antennes</p>
             <div class="flex flex-col items-start gap-1 w-full">
-                <h2 class="font-titre font-normal text-3xl leading-normal text-white">Trouvez votre antenne</h2>
-                <p class="font-sans font-normal text-base text-white">Découvrez les antennes AFUP réparties dans toute la France et au Luxembourg</p>
+                <h2 class="font-titre text-3xl leading-normal text-white">Trouvez votre antenne</h2>
+                <p class="text-white">Découvrez les antennes AFUP réparties dans toute la France et au Luxembourg</p>
             </div>
             <div class="flex flex-col items-start gap-3 w-full mt-auto">
                 <div class="flex flex-col items-start w-full p-4 gap-1 bg-white/10 border border-white/20 rounded-xl">
-                    <h3 class="font-titre font-normal text-3xl leading-9 text-white">15</h3>
-                    <span class="font-sans font-normal text-sm text-white">Antennes</span>
+                    <h3 class="font-titre text-3xl leading-9 text-white">15</h3>
+                    <span class="text-sm text-white">Antennes</span>
                 </div>
                 <div class="flex flex-col items-start w-full p-4 gap-1 bg-white/10 border border-white/20 rounded-xl">
-                    <h3 class="font-titre font-normal text-3xl leading-9 text-white">3000+</h3>
-                    <span class="font-sans font-normal text-sm text-white">Membres</span>
+                    <h3 class="font-titre text-3xl leading-9 text-white">3000+</h3>
+                    <span class="text-sm text-white">Membres</span>
                 </div>
                 <div class="flex flex-col items-start w-full p-4 gap-1 bg-white/10 border border-white/20 rounded-xl">
-                    <h3 class="font-titre font-normal text-3xl leading-9 text-white">50+</h3>
-                    <span class="font-sans font-normal text-sm text-white">Évènement/an</span>
+                    <h3 class="font-titre text-3xl leading-9 text-white">50+</h3>
+                    <span class="text-sm text-white">Évènement/an</span>
                 </div>
             </div>
         </div>
@@ -328,28 +328,28 @@
 <div class="container mx-auto px-4 pb-6 sm:px-28 sm:py-10 flex flex-col gap-5">
 
 
-    <h2 class="font-titre font-normal text-2xl leading-snug text-afup-800">Concrètement que se passe-t-il près de chez moi ?</h2>
+    <h2 class="font-titre text-2xl leading-snug text-afup-800">Concrètement que se passe-t-il près de chez moi ?</h2>
     <h3 class="font-titre font-bold text-lg leading-relaxed text-afup-500">Meetups et apéros PHP</h3>
-    <p class="font-sans font-normal text-base text-neutre-700">L'antenne locale, avec le soutien de l'AFUP, organise des meetups, soirées de conférences gratuites, accueillies dans des
+    <p class="text-neutre-700">L'antenne locale, avec le soutien de l'AFUP, organise des meetups, soirées de conférences gratuites, accueillies dans des
         locaux d'entreprises partenaires. L'audience est conviée à assister à un ou deux talks proposés par des experts du langage, qu'ils soient speakers confirmés ou nouveaux conférenciers qui se lancent en notre compagnie. <strong>Ces soirées sont l'occasion parfaite pour les auditeurs de progresser et se tenir informés des dernières évolutions de PHP. </strong></p>
-    <p class="font-sans font-normal text-base text-neutre-700">Les apéros PHP, organisés dans un bar autour de quelques verres, permettent également à la communauté de se retrouver.</p>
-    <p class="font-sans font-normal text-base text-neutre-700">Enfin, les équipes en charge des antennes sont pleines de ressources et d’imagination, et proposent d’autres formats tout au long de l’année : hackathons, forum ouverts, tables rondes...</p>
+    <p class="text-neutre-700">Les apéros PHP, organisés dans un bar autour de quelques verres, permettent également à la communauté de se retrouver.</p>
+    <p class="text-neutre-700">Enfin, les équipes en charge des antennes sont pleines de ressources et d’imagination, et proposent d’autres formats tout au long de l’année : hackathons, forum ouverts, tables rondes...</p>
     <h3 class="font-titre font-bold text-lg leading-relaxed text-afup-500">Créer du lien avec les entreprises, les écoles et les autres associations web</h3>
-    <p class="font-sans font-normal text-base text-neutre-700">L'antenne locale est l'interlocuteur de prédilection en région pour créer des passerelles avec les écoles, les
+    <p class="text-neutre-700">L'antenne locale est l'interlocuteur de prédilection en région pour créer des passerelles avec les écoles, les
         entreprises PHP et les autres associations web locales. <strong>Grâce à l'antenne locale, la communauté se rencontre, se fédère, et des ponts se créent avec tous les intervenants importants du monde Open Source</strong>.</p>
     <h3 class="font-titre font-bold text-lg leading-relaxed text-afup-500">Participation à l’AFUP Day</h3>
-    <p class="font-sans font-normal text-base text-neutre-700">L’AFUP Day est le grand évènement printanier de l’AFUP : une journée de conférences mono-track organisée le même jour simultanément dans plusieurs antennes AFUP. Quand l'équipe est dynamique et motivée, et que la communauté locale suit, elle peut dès lors soumettre sa candidature pour accueillir l'évènement dans sa ville l’année suivante.</p>
+    <p class="text-neutre-700">L’AFUP Day est le grand évènement printanier de l’AFUP : une journée de conférences mono-track organisée le même jour simultanément dans plusieurs antennes AFUP. Quand l'équipe est dynamique et motivée, et que la communauté locale suit, elle peut dès lors soumettre sa candidature pour accueillir l'évènement dans sa ville l’année suivante.</p>
     
-    <h2 class="font-titre font-normal text-2xl leading-snug text-afup-800">Envie de vous impliquer ?</h2>
-    <p class="font-sans font-normal text-base text-neutre-700">Chaque antenne locale est représentée par une équipe, élue par la communauté locale lors des élections annuelles de juin. Si elle est l'interlocuteur privilégié de l'AFUP pour votre région, elle a cependant besoin de connaître les envies, les besoins de son audience, pour
+    <h2 class="font-titre text-2xl leading-snug text-afup-800">Envie de vous impliquer ?</h2>
+    <p class="text-neutre-700">Chaque antenne locale est représentée par une équipe, élue par la communauté locale lors des élections annuelles de juin. Si elle est l'interlocuteur privilégié de l'AFUP pour votre région, elle a cependant besoin de connaître les envies, les besoins de son audience, pour
         organiser des meetups qui l'intéresseront : pensez à contacter votre antenne pour lui soumettre vos idées.
-    <p class="font-sans font-normal text-base text-neutre-700">L’équipe a peut-être également besoin de soutien : n’hésitez pas à lui proposer votre aide. Si les élections annuelles permettent d’intégrer officiellement une équipe, il est cependant possible de vous manifester auprès d’elle à tout moment de l’année.</p>
-    <p class="font-sans font-normal text-base text-neutre-700"><strong>Envie de vous impliquer autrement ?</strong> Votre entreprise peut peut-être accueillir un
+    <p class="text-neutre-700">L’équipe a peut-être également besoin de soutien : n’hésitez pas à lui proposer votre aide. Si les élections annuelles permettent d’intégrer officiellement une équipe, il est cependant possible de vous manifester auprès d’elle à tout moment de l’année.</p>
+    <p class="text-neutre-700"><strong>Envie de vous impliquer autrement ?</strong> Votre entreprise peut peut-être accueillir un
         meetup dans ses locaux, sponsoriser un apéro PHP, ou vous pouvez peut-être faire jouer vos contacts pour
         inviter un conférencier de qualité !</p>
 
-    <h2 class="font-titre font-normal text-2xl leading-snug text-afup-800">Trouvez l'antenne locale AFUP proche de chez vous !</h2>
-    <p class="font-sans font-normal text-base text-neutre-700">Suivez-la sur <a href="https://twitter.com/afup/lists/antennes-afup/members?lang=fr">Twitter</a>,
+    <h2 class="font-titre text-2xl leading-snug text-afup-800">Trouvez l'antenne locale AFUP proche de chez vous !</h2>
+    <p class="text-neutre-700">Suivez-la sur <a href="https://twitter.com/afup/lists/antennes-afup/members?lang=fr">Twitter</a>,
         contactez-la en MP, ou écrivez à l'AFUP pour être mis en relation avec l'équipe en charge de votre antenne.</p>
     
 </div>
@@ -395,10 +395,10 @@
                     </div>
                     <div class="flex flex-col gap-2">
                         <h3 class="font-titre font-bold text-2xl text-afup-800">{{ antenne.label }}</h3>
-                        <span class="font-sans font-normal text-base text-neutre-700">{{ antenne.administrativeArea }}</span>
+                        <span class="text-neutre-700">{{ antenne.administrativeArea }}</span>
                     </div>
                 </div>
-                <p class="h-4 font-sans font-semibold text-xs uppercase text-neutre-400 mt-6 mb-4">réseaux sociaux</p>
+                <p class="h-4 font-semibold text-xs uppercase text-neutre-400 mt-6 mb-4">réseaux sociaux</p>
                 <div class="flex flex-row flex-wrap items-start content-start gap-2">
                         {% if antenne.socials.blog is not null %}
                             <a class="flex flex-row justify-center items-center w-12 h-10 bg-afup-100 rounded-2xl flex-none grow-0" href="{{ antenne.socials.blog }}">

--- a/templates/site/superapero.html.twig
+++ b/templates/site/superapero.html.twig
@@ -22,11 +22,11 @@
                  class="size-24 sm:size-28 object-contain" />
 
             <div class="flex flex-col items-center gap-4">
-                <h1 class="font-titre font-normal text-3xl sm:text-4xl leading-tight text-white">Super-apéro PHP</h1>
-                <p class="font-sans font-normal text-lg text-white/90">Des apéros PHP le même jour dans toutes les antennes !</p>
+                <h1 class="font-titre text-3xl sm:text-4xl leading-tight text-white">Super-apéro PHP</h1>
+                <p class="text-lg text-white/90">Des apéros PHP le même jour dans toutes les antennes !</p>
             </div>
 
-            <p class="font-sans font-normal text-base text-white/90 max-w-3xl">
+            <p class="text-white/90 max-w-3xl">
                 Bloquez votre soirée du
                 <time datetime="{{ superApero.date|date('Y-m-d') }}" class="font-semibold text-white">{{ superApero.date|format_date(pattern='EEEE d MMMM', locale='fr') }}</time>
                 et rendez-vous dans votre antenne locale pour une soirée de conférences et d'échanges, où toute la
@@ -52,7 +52,7 @@
                         </div>
 
                         {% if meetup.description %}
-                            <div class="prose prose-sm max-w-none font-sans text-neutre-700">{{ meetup.description|raw }}</div>
+                            <div class="prose prose-sm max-w-none text-neutre-700">{{ meetup.description|raw }}</div>
                         {% endif %}
 
                         {# Sans groupe Meetup l'URL d'inscription serait tronquée : on n'affiche

--- a/templates/site/talks/list.html.twig
+++ b/templates/site/talks/list.html.twig
@@ -32,7 +32,7 @@
 
     <div class="container mx-auto px-4 py-6 sm:px-28 sm:py-10 flex flex-col gap-5">
         <h1 class="font-titre text-afup-800 text-2xl sm:text-4xl">{{ title }}</h1>
-        <p class="font-sans font-normal text-base text-neutre-700">
+        <p class="text-neutre-700">
             Retrouvez ici toutes les conférences passées de l'AFUP. Pour s'informer sur nos prochains
             évènements, rendez-vous sur <a href="https://event.afup.org" class="text-afup-500 underline hover:no-underline">event.afup.org</a>.
         </p>
@@ -69,10 +69,10 @@
     </div>
 
     <div class="container mx-auto px-4 py-6 sm:px-28 sm:py-10 flex flex-col gap-5">
-        <h2 class="font-sans font-semibold text-base text-afup-800 border-b border-neutre-300 pb-2">
+        <h2 class="font-semibold text-afup-800 border-b border-neutre-300 pb-2">
             Les vidéos captées par nos antennes
         </h2>
-        <p class="font-sans font-normal text-base text-neutre-700">
+        <p class="text-neutre-700">
             Certaines de nos antennes locales filment les conférences qu'elles organisent : leurs captations
             sont ensuite mises en ligne sur leur chaîne YouTube. Découvrez toutes leurs vidéos et pensez à
             vous abonner pour ne rien manquer de leurs futures publications !
@@ -85,7 +85,7 @@
                         <img src="{{ antenne.logoUrl }}" alt="" class="w-full h-full object-contain p-1.5" />
                     </div>
                     {# min-w-0 : sans lui le titre refuse de se compresser et pousse le bouton hors de la carte #}
-                    <h3 class="font-titre font-bold text-base text-afup-800 grow min-w-0">{{ antenne.label }}</h3>
+                    <h3 class="font-titre font-bold text-afup-800 grow min-w-0">{{ antenne.label }}</h3>
                     <twig:Button variant="secondary" as="a" href="{{ antenne.socials.youtube }}"
                                  class="flex items-center gap-2 shrink-0"
                                  aria-label="Chaîne YouTube de l'antenne {{ antenne.label }}">

--- a/templates/site/talks/show.html.twig
+++ b/templates/site/talks/show.html.twig
@@ -37,11 +37,11 @@
         <div class="bg-afup-900">
             <div class="container mx-auto px-4 py-10 sm:px-28 sm:py-14 flex flex-col gap-8">
                 <div class="flex flex-col gap-2">
-                    <p class="font-sans text-sm text-white/70">
+                    <p class="text-sm text-white/70">
                         <a href="{{ event_url }}" class="underline hover:no-underline">{{ event.title }}</a> · {{ event_date|trim }}
                     </p>
-                    <h1 class="font-titre font-normal text-2xl sm:text-4xl leading-tight text-white">{{ talk.title }}</h1>
-                    <p class="font-sans text-base text-white/90">{{ speakers_label }}</p>
+                    <h1 class="font-titre text-2xl sm:text-4xl leading-tight text-white">{{ talk.title }}</h1>
+                    <p class="text-white/90">{{ speakers_label }}</p>
                 </div>
 
                 <div class="w-full aspect-video rounded-2xl overflow-hidden bg-black">
@@ -58,11 +58,11 @@
         </div>
     {% else %}
         <div class="container mx-auto px-4 py-6 sm:px-28 sm:py-10 flex flex-col gap-2">
-            <p class="font-sans text-sm text-neutre-400">
+            <p class="text-sm text-neutre-400">
                 <a href="{{ event_url }}" class="text-afup-500 underline hover:no-underline">{{ event.title }}</a> · {{ event_date|trim }}
             </p>
-            <h1 class="font-titre font-normal text-2xl sm:text-4xl leading-tight text-afup-800">{{ talk.title }}</h1>
-            <p class="font-sans text-base text-neutre-700">{{ speakers_label }}</p>
+            <h1 class="font-titre text-2xl sm:text-4xl leading-tight text-afup-800">{{ talk.title }}</h1>
+            <p class="text-neutre-700">{{ speakers_label }}</p>
         </div>
     {% endif %}
 
@@ -102,7 +102,7 @@
                                     </a>
                                 {% endif %}
                             </div>
-                            <p class="font-sans font-normal text-base text-neutre-700">{{ speaker.biography }}</p>
+                            <p class="text-neutre-700">{{ speaker.biography }}</p>
                             <a href="{{ url('talks_list', {"fR": { "speakers.label" : [ speaker.label ]}}) }}"
                                class="text-sm text-afup-500 underline hover:no-underline">Voir tous ses talks</a>
                         </div>
@@ -115,7 +115,7 @@
                     <twig:SectionTitle>Commentaires</twig:SectionTitle>
                     {% for comment in comments|filter(comment => comment.comment|length) %}
                         <twig:Card class="flex flex-col gap-3">
-                            <p class="font-sans font-normal text-base text-neutre-700">{{ comment.comment }}</p>
+                            <p class="text-neutre-700">{{ comment.comment }}</p>
                             <div class="flex flex-wrap items-center gap-3 border-t border-neutre-300 pt-3">
                                 <div class="flex items-center gap-0.5" aria-label="Note : {{ comment.rating }} sur 5">
                                     {% for i in 1..5 %}
@@ -123,7 +123,7 @@
                                                       class="size-4 {{ comment.rating >= i ? 'text-afup-300' : 'text-neutre-300' }}" />
                                     {% endfor %}
                                 </div>
-                                <p class="font-sans text-sm text-neutre-400">
+                                <p class="text-sm text-neutre-400">
                                     {{ comment.user_display_name }}, le {{ comment.created_date|date('d/m/Y') }}
                                 </p>
                             </div>
@@ -138,7 +138,7 @@
                     <div class="transcript flex flex-col gap-2 border-l-4 border-afup-300 pl-4">
                         {% for cue in transcript %}
                             <p data-cue-start="{{ cue.start }}"
-                               class="font-sans font-normal text-base text-neutre-700 {% if talk.hasYoutubeId %}cursor-pointer hover:text-afup-500{% endif %}">{{ cue.text }}</p>
+                               class="text-neutre-700 {% if talk.hasYoutubeId %}cursor-pointer hover:text-afup-500{% endif %}">{{ cue.text }}</p>
                         {% endfor %}
                     </div>
                 </section>
@@ -179,18 +179,18 @@
 
                 <twig:Card:Section title="Langue">
                     <ul class="flex flex-col gap-2">
-                        <li class="flex items-center gap-2 font-sans text-sm text-neutre-700">
+                        <li class="flex items-center gap-2 text-sm text-neutre-700">
                             <twig:ux:icon name="mingcute:headphone-fill" class="size-4 shrink-0 text-afup-500" />
                             Audio : {{ talk.getLanguageLabel|lower }}
                         </li>
                         {% if talk.getVideoHasFrSubtitles %}
-                            <li class="flex items-center gap-2 font-sans text-sm text-neutre-700">
+                            <li class="flex items-center gap-2 text-sm text-neutre-700">
                                 <twig:ux:icon name="mingcute:subtitle-fill" class="size-4 shrink-0 text-afup-500" />
                                 Sous-titres : français
                             </li>
                         {% endif %}
                         {% if talk.getVideoHasEnSubtitles %}
-                            <li class="flex items-center gap-2 font-sans text-sm text-neutre-700">
+                            <li class="flex items-center gap-2 text-sm text-neutre-700">
                                 <twig:ux:icon name="mingcute:subtitle-fill" class="size-4 shrink-0 text-afup-500" />
                                 Sous-titres : anglais
                             </li>

--- a/templates/site/techletter/index.html.twig
+++ b/templates/site/techletter/index.html.twig
@@ -10,14 +10,14 @@
     <div class="bg-gradient-to-br from-afup-900 via-afup-800 to-afup-700">
         <div class="container mx-auto px-4 py-12 sm:px-28 sm:py-16 relative isolate grid grid-cols-1 md:grid-cols-2 gap-10 items-center">
             <div class="flex flex-col items-start gap-6">
-                <p class="flex items-center gap-2 font-sans font-normal text-sm text-white py-1.5 px-3 bg-white/20 rounded-full">
+                <p class="flex items-center gap-2 text-sm text-white py-1.5 px-3 bg-white/20 rounded-full">
                     <twig:ux:icon name="mdi:email-fast-outline" class="size-4" />
                     Tous les 15 jours
                 </p>
 
-                <h1 class="font-titre font-normal text-3xl sm:text-4xl leading-tight text-white">Simplifiez votre veille sur PHP.</h1>
+                <h1 class="font-titre text-3xl sm:text-4xl leading-tight text-white">Simplifiez votre veille sur PHP.</h1>
 
-                <p class="font-sans font-normal text-base text-white/90 max-w-xl">
+                <p class="text-white/90 max-w-xl">
                     Tous les 15 jours, recevez les infos à ne pas rater, sélectionnées par les experts de l'AFUP.
                 </p>
 
@@ -38,7 +38,7 @@
 
                 <twig:Card class="flex flex-col gap-3 p-6 sm:p-8">
                     <h3 class="font-titre font-bold text-lg text-afup-800">Le meilleur de PHP, directement par mail</h3>
-                    <p class="font-sans font-normal text-base text-neutre-700">
+                    <p class="text-neutre-700">
                         Une sélection drastique est effectuée en amont, afin de vous permettre d'accéder aux meilleurs articles
                         du moment.<br />Ne perdez plus de temps à aller de lien en lien et concentrez-vous sur votre métier.
                     </p>
@@ -46,7 +46,7 @@
 
                 <twig:Card class="flex flex-col gap-3 p-6 sm:p-8">
                     <h3 class="font-titre font-bold text-lg text-afup-800">Un avantage exclusif pour nos membres</h3>
-                    <p class="font-sans font-normal text-base text-neutre-700">
+                    <p class="text-neutre-700">
                         Seuls les membres AFUP peuvent accéder à ce concentré de veille qui couvre l'essentiel de
                         l'actualité de PHP et des technologies connexes.
                     </p>
@@ -54,7 +54,7 @@
 
                 <twig:Card class="flex flex-col gap-3 p-6 sm:p-8">
                     <h3 class="font-titre font-bold text-lg text-afup-800">Prérequis</h3>
-                    <p class="font-sans font-normal text-base text-neutre-700">
+                    <p class="text-neutre-700">
                         Pour recevoir cette veille il faut être membre à jour de cotisation et cliquer sur le
                         <a href="{{ path('member_techletter') }}" class="text-afup-500 underline hover:no-underline">bouton d'inscription</a>
                         dans l'espace membres.


### PR DESCRIPTION
Suite à la review de #2370, où les trois suggestions portaient toutes sur le même point : les conversions Figma → Tailwind transcrivent littéralement `font-family: Inter`, `font-weight: 400` et `font-size: 16px`, alors que ces valeurs sont déjà celles du `body`.

Le motif était présent sur 12 fichiers déjà mergés, d'où cette PR dédiée plutôt qu'une correction au coup par coup.

## Ce qui est retiré

| Classe | Pourquoi c'est un no-op |
|---|---|
| `font-sans` | `--font-sans: "Inter"` est déjà la police du `body` (`assets/styles/fonts.css`). Vérifié : `font-titre` n'est jamais posée sur un conteneur parent, uniquement sur l'élément lui-même. |
| `font-normal` | Graisse 400 par défaut. Le preflight remet `h1`…`h6` à `font-weight: inherit`, donc même sur un titre la classe ne change rien. Vérifié : aucun conteneur des fichiers touchés n'impose une graisse. |
| `text-base` | 1rem par défaut. Vérifié : aucun conteneur des fichiers touchés n'impose une autre taille. |

## Ce qui est conservé, et pourquoi

Toutes ces occurrences surchargent réellement quelque chose, elles sont laissées en place :

- **`text-base` et `font-semibold` passées à `<twig:Button>`** — le composant a `text-sm font-medium` en base, et `tailwind_merge` donne la priorité aux attributs. Les retirer changerait le rendu des boutons. Idem pour le préfixe du bloc `button_widget` dans le thème de formulaire.
- **`font-normal` sur les libellés du thème de formulaire** (`tailwind.html.twig` lignes 32, 61, 126) — écrase le `font-medium` de `form_label`.
- **`text-base` dans les bases de composants** (`Benefit`, `SectionTitle`, `Card/Subtitle`) — y fixe l'échelle typographique du composant indépendamment du contexte, comme le `text-sm` de `Button`.
- **`text-base sm:text-xl`** sur la page d'accueil — moitié basse d'une paire responsive volontaire (#2374).

## Vérifications

- Diff vérifié ligne à ligne : les 88 lignes modifiées ne diffèrent que par la suppression de ces trois classes, aucune autre modification.
- `bin/console lint:twig templates/` → `[OK] All 328 Twig files contain valid syntax.`
- Aucun changement de rendu attendu.
