### PR TITLE
Refonte visuelle de la page paybox des cotisations

### DIFF
--- a/templates/site/company_membership/paybox_redirect.html.twig
+++ b/templates/site/company_membership/paybox_redirect.html.twig
@@ -1,4 +1,10 @@
-{% extends 'site/base.html.twig' %}
+{% extends 'layouts/site.html.twig' %}
+
+{% block title %}{{ payboxResponse.successful ? 'Paiement confirmé' : 'Paiement non abouti' }} - Cotisation - AFUP{% endblock %}
+
+{% block metas %}
+    <meta name="robots" content="noindex, nofollow">
+{% endblock %}
 
 {% block google_analytics %}
     {% embed 'google_analytics.html.twig' %}
@@ -13,26 +19,49 @@
     {% endembed %}
 {% endblock %}
 
-{% block inner_content %}
-    <div class="col-md-8">
-        <h2>Paiement de votre cotisation</h2>
-        <div>
-            <p>
-                {% if payboxResponse.successful %}
-                    Le paiement de votre cotisation s'est bien passé, merci.
-                {% elseif return_type == 'refused' %}
-                    Votre paiement a été refusé.<br>
-                    Aucun montant n'a &eacute;t&eacute; pr&eacute;lev&eacute;.
-                {% elseif return_type == 'canceled' %}
-                    Votre paiement a &eacute;t&eacute; annul&eacute;.<br>
-                    Aucun montant n'a &eacute;t&eacute; pr&eacute;lev&eacute;.
-                {% elseif return_type == 'error' %}
+{% block content %}
+    <div class="container mx-auto px-4 sm:px-28 py-16 flex flex-col items-center text-center gap-6">
+        {% if payboxResponse.successful %}
+            <span class="flex items-center justify-center rounded-full bg-afup-100 text-afup-500 p-6">
+                <twig:ux:icon name="mingcute:check-fill" class="size-12" />
+            </span>
+
+            <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Paiement confirmé&nbsp;!</h1>
+
+            <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
+                Le paiement de votre cotisation s'est bien passé, merci.
+            </p>
+        {% else %}
+            <span class="flex items-center justify-center rounded-full bg-erreur-500/10 text-erreur-700 p-6">
+                <twig:ux:icon name="mdi:alert-outline" class="size-12" />
+            </span>
+
+            {# Les trois cas d'échec partagent la même mise en page, seul le libellé change. #}
+            {% if return_type == 'refused' %}
+                <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Paiement refusé</h1>
+                <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
+                    Votre paiement a été refusé. Aucun montant n'a été prélevé.
+                </p>
+            {% elseif return_type == 'canceled' %}
+                <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Paiement annulé</h1>
+                <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
+                    Votre paiement a été annulé. Aucun montant n'a été prélevé.
+                </p>
+            {% else %}
+                <h1 class="font-titre font-normal text-4xl sm:text-5xl text-afup-800">Une erreur est survenue</h1>
+                <p class="text-xl sm:text-2xl max-w-2xl text-neutre-700">
                     Il y a eu une erreur lors de l'enregistrement de votre cotisation.
-                {% endif %}
-            </p>
-            <p>
-                Si vous avez la moindre question, n'hésitez pas à contacter <a href="mailto:bonjour@afup.org">bonjour@afup.org</a>.
-            </p>
-        </div>
+                </p>
+            {% endif %}
+        {% endif %}
+
+        <p class="text-sm text-neutre-400 max-w-xl">
+            Si vous avez la moindre question, n'hésitez pas à nous écrire à
+            <a href="mailto:bonjour@afup.org" class="text-afup-500 underline hover:no-underline">bonjour (at) afup.org</a>.
+        </p>
+
+        <twig:Button as="a" variant="primary" href="{{ path('home') }}" class="px-8 py-3 text-base mt-4">
+            Retour à l'accueil
+        </twig:Button>
     </div>
 {% endblock %}


### PR DESCRIPTION
Le dernier cas n'était pas bien géré.

<table>
<thead>
<tr>
  <th align="left" width="200">Statut Paybox</th>
  <th align="left">Avant</th>
  <th align="left">Après</th>
</tr>
</thead>
<tbody>

<tr>
  <td valign="top"><code>type=success</code><br><code>status=00000</code><br><br>Paiement accepté</td>
  <td valign="top"><img width="1280" height="400" alt="avant-confirme-cropped" src="https://github.com/user-attachments/assets/2a17dfd4-b26b-46a1-aa14-158af728fadd" /></td>
  <td valign="top"><img width="1280" height="800" alt="apres-confirme-cropped" src="https://github.com/user-attachments/assets/48bdf9f6-9d7e-46be-9cd0-5535a1ee169a" /></td>
</tr>

<tr>
  <td valign="top"><code>type=refused</code><br><code>status=00114</code><br><br>Paiement refusé par la banque</td>
  <td valign="top"><img width="1280" height="400" alt="avant-erreur-cropped" src="https://github.com/user-attachments/assets/7667faca-78e1-4666-8e5f-c845ffe8f146" /></td>
  <td valign="top">
<img width="1280" height="800" alt="apres-refuse-cropped" src="https://github.com/user-attachments/assets/36d378c0-359c-495f-8068-b2a540991821" /></td>
</tr>

<tr>
  <td valign="top"><code>type=canceled</code><br><code>status=00114</code><br><br>Paiement abandonné par l'adhérent</td>
  <td valign="top"><img width="1280" height="400" alt="avant-annule-cropped" src="https://github.com/user-attachments/assets/7757863e-681b-4dab-8f7b-9b26dadae064" /></td>
  <td valign="top"><img width="1280" height="800" alt="apres-annule-cropped" src="https://github.com/user-attachments/assets/3c8df7f4-8a68-42d3-84b0-bb861cf415f3" /></td>
</tr>


<tr>
  <td valign="top"><code>type=error</code><br><code>status=00114</code><br><br>Erreur d'enregistrement de la cotisation</td>
  <td valign="top"><img width="1280" height="400" alt="avant-erreur-cropped" src="https://github.com/user-attachments/assets/2ce8f9ab-79e5-4bf9-839f-543948b2a758" /></td>
  <td valign="top"><img width="1280" height="800" alt="apres-erreur-cropped" src="https://github.com/user-attachments/assets/3d297afa-af49-4b38-8c64-9afd235f8d55" /></td>
</tr>

<tr>
  <td valign="top"><code>type=success</code><br><code>status=00114</code><br><br>Segment d'URL en succès, retour Paybox en échec : le legacy n'avait aucune branche pour ce cas et affichait un paragraphe vide.</td>
  <td valign="top"><img width="1280" height="1358" alt="avant-statut-incoherent" src="https://github.com/user-attachments/assets/96808472-c718-4ddb-aa36-14713e2b5b60" /></td>
  <td valign="top"><img width="1280" height="800" alt="apres-statut-incoherent-cropped" src="https://github.com/user-attachments/assets/a35ded14-171f-40df-84e1-2f1da3e32743" /></td>
</tr>

</tbody>
</table>
