### PR TITLE
Correction du décalage horaire des horaires de planning côté public

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -4,5 +4,6 @@ twig:
     globals:
         photo_storage: '@AppBundle\CFP\PhotoStorage'
         global_menu_event_label: '%env(AFUP_GLOBAL_MENU_EVENT_LABEL)%'
+        planning_timezone: !php/const AppBundle\Event\Model\Planning::TIMEZONE
     form_themes: ['form_theme.html.twig']
     default_path: "%kernel.project_dir%/templates"

--- a/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
+++ b/sources/AppBundle/Controller/Admin/Event/Session/IndexAction.php
@@ -38,7 +38,6 @@ final class IndexAction extends AbstractController
                 'events' => $this->calendarEvents($sessions),
                 'resources' => $this->calendarResources($event),
             ],
-            'timezone' => Planning::TIMEZONE,
         ]);
     }
 

--- a/sources/AppBundle/Event/Talk/ExportGenerator.php
+++ b/sources/AppBundle/Event/Talk/ExportGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AppBundle\Event\Talk;
 
 use AppBundle\Event\Model\Event;
+use AppBundle\Event\Model\Planning;
 use AppBundle\Event\Model\Repository\TalkRepository;
 use AppBundle\Event\Model\Speaker;
 use AppBundle\Event\Model\Talk;
@@ -56,6 +57,8 @@ class ExportGenerator
 
         $toFile->fputcsv(['Title','Description','Speaker','Date','Time','Type'], escape: '\\');
 
+        $timezone = new \DateTimeZone(Planning::TIMEZONE);
+
         foreach ($talkAggregates as $talkAggregate) {
 
             // Gestion de la description
@@ -72,6 +75,11 @@ class ExportGenerator
             }
             $speakers = implode(',', $speakers);
 
+            // Gestion des horaires : stockés en timestamp, ils sont exportés dans la
+            // timezone de l'événement et non dans celle du serveur.
+            $start = $talkAggregate->planning?->getStart();
+            $start = $start === null ? null : \DateTimeImmutable::createFromInterface($start)->setTimezone($timezone);
+
             // Gestion du type de conférence
             if ($talkAggregate->planning?->getIsKeynote()) {
                 $type = 'Keynote';
@@ -85,8 +93,8 @@ class ExportGenerator
                 $talkAggregate->talk->getTitle(),
                 $abstract,
                 $speakers,
-                $talkAggregate->planning?->getStart()?->format('Y-m-d'),
-                $talkAggregate->planning?->getStart()?->format('H:i'),
+                $start?->format('Y-m-d'),
+                $start?->format('H:i'),
                 $type,
             ], escape: '\\');
         }

--- a/templates/blog/program.html.twig
+++ b/templates/blog/program.html.twig
@@ -31,9 +31,9 @@
             <h4>{{ talk.talk.title|raw }}</h4>
             {% if talk.planning is not null and event.isPlanningDisplayable %}
                 <span class="salle">{{ talk.room.name }}</span>
-                {{ talk.planning.start|date('d/m/Y') }}
+                {{ talk.planning.start|date('d/m/Y', planning_timezone) }}
                 <strong>
-                    {{ talk.planning.start|date('H:i') }}-{{ talk.planning.end|date('H:i') }}
+                    {{ talk.planning.start|date('H:i', planning_timezone) }}-{{ talk.planning.end|date('H:i', planning_timezone) }}
                 </strong>
                 - Niveau : {{ talk.talk.skillTranslationKey|trans }}
                 {% if talk.talk.languageCode %}- {{ talk.talk.languageLabel }}{% endif %}

--- a/templates/blog/talk.html.twig
+++ b/templates/blog/talk.html.twig
@@ -20,8 +20,8 @@
             {% if talks_info.event.isPlanningDisplayable %}
                 <td width="20%" style="vertical-align: middle; text-align: center">
                     {{ talks_info.room.name }}<br />
-                    {{ talks_info.planning.start|date('d/m/Y') }}<br />
-                    {{ talks_info.planning.start|date('H:i') }}-{{ talks_info.planning.end|date('H:i') }}
+                    {{ talks_info.planning.start|date('d/m/Y', planning_timezone) }}<br />
+                    {{ talks_info.planning.start|date('H:i', planning_timezone) }}-{{ talks_info.planning.end|date('H:i', planning_timezone) }}
                 </td>
             {% endif %}
         </tr>

--- a/templates/event/session/index.html.twig
+++ b/templates/event/session/index.html.twig
@@ -116,8 +116,8 @@
                             <br/>
 
                             {% if session.planning %}
-                                <em>{{ session.planning.start|date("d/m/Y", timezone) }}</em> /
-                                {{ session.planning.start|date("H:i", timezone) }} - {{ session.planning.end|date("H:i", timezone) }} / {{ session.room ? session.room.name }}
+                                <em>{{ session.planning.start|date("d/m/Y", planning_timezone) }}</em> /
+                                {{ session.planning.start|date("H:i", planning_timezone) }} - {{ session.planning.end|date("H:i", planning_timezone) }} / {{ session.room ? session.room.name }}
                             {% else %}
                                 <span class="ui yellow label">non planifié</span>
                             {% endif %}

--- a/templates/event/speaker/page.html.twig
+++ b/templates/event/speaker/page.html.twig
@@ -87,7 +87,7 @@
                     <i>
                         {% if talk_info.planning %}
                             {% if talk_info.room %}({{ talk_info.room.name }}){% endif %}
-                            ({{ talk_info.planning.start|format_datetime('full', 'short') }})
+                            ({{ talk_info.planning.start|format_datetime('full', 'short', timezone=planning_timezone) }})
                         {% else %}
                             (salle et dates de passage à venir)
                         {% endif %}


### PR DESCRIPTION
Dans la foulée de #2354, la page programme affichait toujours les horaires en UTC en production (exemple : `/blog/forumphp2026/program`).

## Cause

Le filtre `date` de Twig (et `format_datetime`) ne se contente pas de formater : il **convertit** la date vers la timezone par défaut de Twig, c'est-à-dire `date_default_timezone_get()`, en ignorant la timezone portée par l'objet `DateTime`. Les horaires de planning étant stockés en timestamp, ils s'affichaient donc en UTC en production, où PHP tourne en UTC — invisible en local, le conteneur de dev étant en `Europe/Paris`.

Reproduit avec le Twig du projet, PHP en UTC :

```
entité hydratée : 2026-10-22T09:30:00+02:00
sans timezone   => 07:30      ← page programme en prod
avec timezone   => 09:30
```

Corriger la timezone à l'hydratation de `Planning` n'aurait rien changé à l'affichage : Twig la réécrit. Il faut la passer au filtre, comme le fait déjà le back-office depuis #2354.

## Correctif

`Planning::TIMEZONE` est exposée à Twig via un global `planning_timezone`, utilisé partout où un horaire de planning est affiché :

| Fichier | Correction |
|---|---|
| `config/packages/twig.yaml` | global `planning_timezone` depuis `Planning::TIMEZONE` |
| `templates/blog/program.html.twig` | page programme (bug signalé) |
| `templates/blog/talk.html.twig` | widget talk, même donnée, même bug |
| `templates/event/speaker/page.html.twig` | `format_datetime` de l'espace conférencier |
| `templates/event/session/index.html.twig` | bascule sur le global |
| `Controller/Admin/Event/Session/IndexAction.php` | variable `timezone` de rendu devenue redondante |
| `Event/Talk/ExportGenerator.php` | export CSV joind.in, qui formatait aussi en timezone serveur |

Pour l'export, la conversion passe par `DateTimeImmutable::createFromInterface()` afin de ne pas muter l'entité — même forme que `formatForCalendar()` dans le back-office.

## Vérifications

- Sémantique du filtre confirmée avant/après sur `date` et `format_datetime`, avec le Twig du projet et PHP en UTC.
- Conversion de l'export vérifiée sur un timestamp hydraté comme le fait Ting (`07:30` → `09:30`, entité non mutée).
- Expressions Twig modifiées parsées sans erreur ; `php -l` sur le fichier PHP modifié.
- `!php/const` bien résolu pour les fichiers `config/packages` (`Yaml::PARSE_CONSTANT` dans `YamlFileLoader::loadFile`).

⚠️ Les conteneurs n'étaient pas démarrés côté dev : cs-fixer, PHPStan et Behat n'ont pas été exécutés localement, la CI reste à valider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LZbMGRyWSL66qwp1551MXd
