### PR TITLE
Infos speakers: affichage du besoin de défraiement voyage

### DIFF
--- a/templates/admin/event/speakers_management.html.twig
+++ b/templates/admin/event/speakers_management.html.twig
@@ -17,6 +17,7 @@
                 <th data-tf-filter-type="select" class="center aligned">Nuit d'hotel entre les deux jours ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Nuit d'hotel après l'évènement ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Pas de nuit d'hotel ?</th>
+                <th data-tf-filter-type="select" class="center aligned">Défraiement voyage nécessaire ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Sponsors ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Justificatifs envoyés ?</th>
                 <th data-tf-filter-type="select" class="center aligned">Microphone</th>
@@ -121,6 +122,15 @@
                     {% endif %}
                     </span>
                 </td>
+                <td class="center aligned">
+                    <span class="ui label">
+                    {% if speaker.speaker.travelRefundNeeded %}
+                        oui
+                    {% else %}
+                        non
+                    {% endif %}
+                    </span>
+                </td>
                 <td  class="center aligned">
                     {% if not speaker.speaker.travelRefundSponsored and not speaker.speaker.hasHostingSponsor %}
                         <span class="ui label">non</span>
@@ -166,7 +176,7 @@
                 </td>
             </tr>
             {% else %}
-            <tr><td colspan="13" style="text-align: center;">
+            <tr><td colspan="15" style="text-align: center;">
                     <div class="ui icon header">
                         <i class="meh outline icon"></i>
                         Aucune information. {% if event == null %}Essayez de changez d'évènement !{% endif %}

--- a/tests/behat/features/Admin/AdminInfosSpeakers.feature
+++ b/tests/behat/features/Admin/AdminInfosSpeakers.feature
@@ -12,6 +12,7 @@ Feature: Administration - Partie Infos Speakers
     And I follow "afup-main-menu-item--admin_event_speakers_management"
     Then the ".content h2" element should contain "Infos speakers"
     And the ".content table" element should contain "Geoffrey BACHELET"
+    And the ".content table" element should contain "Défraiement voyage nécessaire ?"
     When I follow the button of tooltip "Voir sa page"
     Then I should see "Ma page speaker : forum"
     And I should see "Nous vous hébergeons"


### PR DESCRIPTION
## Contexte

Depuis la PR #1882, un speaker peut cocher deux cases dans la section « Nous vous défrayons » de sa page :

| Case | Champ |
|------|-------|
| « Je n'en n'ai pas besoin » | `Speaker::isTravelRefundNeeded()` (inversé) |
| « Mon transport est sponsorisé » | `Speaker::isTravelRefundSponsored()` |

La page BO **Infos speakers** affichait déjà la seconde (badge `travel` dans la colonne « Sponsors ? »), mais pas la première. Un organisateur ne pouvait donc pas savoir quels speakers ne demandent aucun défraiement.

## Modifications

Ajout d'une colonne **« Défraiement voyage nécessaire ? »** (oui / non, filtrable) dans `templates/admin/event/speakers_management.html.twig`, placée avant la colonne « Sponsors ? » pour regrouper les informations de défraiement.

La donnée était déjà disponible de bout en bout — aucune migration ni changement de modèle :

- `SpeakerRepository::getScheduledSpeakersByEvent()` sélectionne déjà `speaker.travel_refund_needed`
- le mapping hydrator `travel_refund_needed` → `travelRefundNeeded` existe déjà
- `travel_refund_needed` est `boolean NOT NULL DEFAULT true`, donc la propriété PHP est un `bool` non-nullable : pas d'état `N/A` à gérer, contrairement aux autres colonnes booléennes du tableau

### Choix de libellé

Reprendre littéralement « Je n'en n'ai pas besoin » aurait donné une colonne où « oui » signifie « ne veut pas être remboursé » : double négation, source d'erreur de lecture. Le libellé est donc formulé positivement.

### Correction annexe

Le `colspan` de la ligne « Aucune information » passe de `13` à `15`. Il était déjà faux avant ce changement : le tableau compte 15 colonnes réelles (14 nommées + la colonne d'actions), et la colonne « Microphone » ajoutée par #2204 avait porté la valeur à `13` sans rattraper le décalage existant.

## Tests

Assertion ajoutée sur l'en-tête de colonne dans `tests/behat/features/Admin/AdminInfosSpeakers.feature`, scénario « Liste des speakers liés à un évènement ».

```bash
make test-functional
```

À noter : les fixtures ne renseignent pas `travel_refund_needed`, les speakers de seed prennent donc la valeur par défaut (`oui`). Pour vérifier le cas `non` en local, cocher la case sur la page speaker ou `UPDATE afup_conferenciers SET travel_refund_needed = 0 WHERE conferencier_id = 1;`.

## Screenshots

<img width="1261" height="324" alt="image" src="https://github.com/user-attachments/assets/b8d47fa2-14dd-4af3-865d-6dcb3963c462" />

Closes #1974
