### PR TITLE
Trésorerie : prérequis base de données à la migration Doctrine

### DIFF
--- a/db/migrations/20260816000000_make_transaction_payment_type_nullable.php
+++ b/db/migrations/20260816000000_make_transaction_payment_type_nullable.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class MakeTransactionPaymentTypeNullable extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->table('compta')
+            ->changeColumn('idmode_regl', 'integer', [
+                'limit' => 5,
+                'null' => true,
+                'default' => null,
+            ])
+            ->update();
+
+        $this->execute('UPDATE compta SET idmode_regl = NULL WHERE idmode_regl = 0');
+    }
+
+    public function down(): void
+    {
+        $this->execute('UPDATE compta SET idmode_regl = 0 WHERE idmode_regl IS NULL');
+
+        $this->table('compta')
+            ->changeColumn('idmode_regl', 'integer', [
+                'limit' => 5,
+                'null' => false,
+                'default' => 0,
+            ])
+            ->update();
+    }
+}

--- a/db/seeds/ComptaCompte.php
+++ b/db/seeds/ComptaCompte.php
@@ -27,6 +27,14 @@ class ComptaCompte extends AbstractSeed
                 'nom_compte' => 'Paypal',
                 'archived_at' => new DateTime('last year')->format('Y-m-d H:i:s'),
             ],
+            [
+                'id' => 5,
+                'nom_compte' => 'Compte courant CMUT',
+            ],
+            [
+                'id' => 6,
+                'nom_compte' => 'Livret CMUT',
+            ],
         ];
 
         $table = $this->table('compta_compte');


### PR DESCRIPTION
> Cette PR est un découpage de #2345 pour l'issue https://github.com/afup/web/issues/2388 

Prérequis de schéma et de fixtures à la migration de la comptabilité vers Doctrine. Aucune modification de code applicatif.

Là où Ting écrivait des identifiants bruts sans vérifier leur existence, Doctrine résout une association vers une entité ou vers `null`. Deux incohérences que Ting masquait deviennent donc bloquantes.

**`compta.idmode_regl`** était `NOT NULL`, avec `0` comme sentinelle « pas de règlement » — une valeur qui ne correspond à aucune ligne de `compta_reglement` (ids 1 à 9). La colonne passe nullable et les `0` deviennent `NULL`, ce que la sentinelle signifiait déjà.

**Le seed des comptes** ne créait que les ids 1 à 4, alors que les importeurs Crédit Mutuel référencent `ComptaCompte::COURANT_CMUT` (5) et `LIVRET_CMUT` (6) depuis longtemps. À l'import, Ting écrivait un `idcompte` pointant dans le vide ; Doctrine y verrait `null`, en violation de `compta.idcompte NOT NULL`. Les deux comptes sont ajoutés aux fixtures.