### PR TITLE
Correction incohérence entre Produits et Devis

### DIFF
--- a/sources/AppBundle/Accounting/Model/InvoicingDetail.php
+++ b/sources/AppBundle/Accounting/Model/InvoicingDetail.php
@@ -16,7 +16,7 @@ class InvoicingDetail implements NotifyPropertyInterface
     private ?int $invoicingId = null;
 
     #[Assert\NotBlank]
-    #[Assert\Length(max: 20)]
+    #[Assert\Length(max: 50)]
     private ?string $reference = null;
 
     #[Assert\NotBlank]


### PR DESCRIPTION
L'entité des produits autorisait une référence jusqu'à [50 caractères](https://github.com/afup/web/blob/master/sources/AppBundle/Accounting/Entity/Produit.php#L19-L20) mais la référence des devis était limitée à 20 alors que le [formulaire](https://github.com/afup/web/blob/master/sources/AppBundle/Accounting/Form/InvoicingRowType.php#L22-L28) autorise 50.